### PR TITLE
修改文檔錯誤-關於 Guard Relay 架設的錯誤描述

### DIFF
--- a/docs/en/setup-tor-relay.md
+++ b/docs/en/setup-tor-relay.md
@@ -63,9 +63,9 @@ Pluggable Transports：
 
 - To further evade censorship, Bridges often use Pluggable Transports, which are protocols that alter the characteristics of Tor traffic to make it appear like regular HTTPS traffic or other types. These technologies include Obfs4, meek, [Snowflake](https://snowflake.torproject.org/){target="_blank"}, and others, which can obfuscate Tor traffic, making detection and blocking more challenging.
 
-## How to Setup a Middle/Guard Relay
+## How to Setup a Middle Relay
 
-Setting up a Middle Relay or Guard Relay requires some technical knowledge and basic installation and configuration. It is recommended to use Debian or Ubuntu operating systems for installation, and the following examples will use Debian/Ubuntu as well.
+Setting up a Middle Relay requires some technical knowledge and basic installation and configuration. It is recommended to use Debian or Ubuntu operating systems for installation, and the following examples will use Debian/Ubuntu as well.
 
 !!! info "Other Operating Systems"
 
@@ -73,7 +73,7 @@ Setting up a Middle Relay or Guard Relay requires some technical knowledge and b
 
 !!! warning "Considerations Before Setting Up!"
 
-    The following tutorial only uses Guard Relays and Middle Relays as examples. If you wish to set up more advanced nodes, please consider the following questions and assess the risks you can undertake:
+    The following tutorial only uses Middle Relays as examples. If you wish to set up more advanced nodes, please consider the following questions and assess the risks you can undertake:
 
     - Do you want to run a Tor exit or non-exit (bridge/guard/middle) relay?
     - If you want to run an exit relay: Which ports do you want to allow in your exit policy? (More ports usually means potentially more abuse complaints.)
@@ -210,3 +210,7 @@ nyx -s /run/tor-instances/{instance-name}/control
 ??? question "How do I upgrade my Tor Relay software?"
 
     Keeping the Tor software updated is essential for security patches and new features. On most Linux systems, you can update Tor via the package manager. Windows and macOS users should regularly check the Tor website for updates.
+
+??? question "How can I become a Guard Relay?"
+
+    Guard Relays are automatically selected by the Tor network; users cannot manually configure this. If your node runs stably and has sufficient bandwidth, it may be chosen as a Guard Relay.

--- a/docs/zh-CN/setup-tor-relay.md
+++ b/docs/zh-CN/setup-tor-relay.md
@@ -31,9 +31,9 @@ icon: simple/torproject
     - 您希望允许多少带宽、每月流量用于 Tor 流量？
     - 服务器是否允许 IPv6 地址？
 
-## 如何建立 Middle/Guard Relay
+## 如何建立 Middle Relay
 
-建立一个 Middle Relay 或 Guard Relay 需要一些技术知识和基本的安装与设置。建议使用 Debian 或 Ubuntu 操作系统来进行安装，以下范例也将采用 Debian/Ubuntu 系统进行操作。
+建立一个 Middle Relay 需要一些技术知识和基本的安装与设置。建议使用 Debian 或 Ubuntu 操作系统来进行安装，以下范例也将采用 Debian/Ubuntu 系统进行操作。
 
 !!! info "其他操作系统"
 
@@ -165,3 +165,7 @@ nyx -s /run/tor-instances/{instance-name}/control
 ??? question "如何升级我的 Tor Relay 软件？"
 
     保持 Tor 软件更新非常重要，以获得最新的安全更新和功能。在大多数 Linux 系统上，可以通过包管理器来更新 Tor。Windows 和 macOS 用户应定期检查 Tor 官网上的更新。
+
+??? question "如何成为 Guard Relay？"
+
+    Guard Relay 由 Tor 网络自动选定，用户无法手动配置。如果节点稳定运行且具备足够的带宽，就有可能被选为 Guard Relay。

--- a/docs/zh-TW/setup-tor-relay.md
+++ b/docs/zh-TW/setup-tor-relay.md
@@ -24,16 +24,16 @@ icon: simple/torproject
 
     以下的教學僅使用入口節點與中間節點作為範例，如果您想要進階的節點建立操作，請思考以下問題並評估可承擔的風險：
 
-    - 您想要建立一個 Tor 出口節點還是非出口（橋接、入口、中間）節點？
+    - 您想要建立一個 Tor 出口節點還是非出口（橋接、中間）節點？
     - 如果您想建立一個出口節點：您要在出口政策中允許哪些連線埠？更多的連線埠通常代表可能會有更多的濫用或違法投訴。
     - 您希望使用哪個外部 TCP 連線埠來接受 Tor 連接？`ORPort` 設定：如果您的伺服器上沒有其他服務佔用此連線埠，我們建議使用 443 連線埠。推薦使用 `ORPort 443`，是因為這通常是公共 Wi-Fi 網絡中少數幾個開放的端口之一。連線埠 9001 也是另一個常用的 `ORPort`。
     - 您將使用哪個電子郵件作為節點的聯絡訊息 `ContactInfo` 欄位？這個資訊將會公開。
     - 您希望允許多少頻寬、每月流量用於 Tor 流量？
     - 伺服器是否允許 IPv6 地址？
 
-## 如何建立 Middle/Guard Relay
+## 如何建立 Middle Relay
 
-建立一個 Middle Relay 或 Guard Relay 需要一些技術知識和基本的安裝與設定。建議使用 Debian 或 Ubuntu 作業系統來安裝，以下範例也將使用 Debian/Ubuntu 操作。
+建立一個 Middle Relay 需要一些技術知識和基本的安裝與設定。建議使用 Debian 或 Ubuntu 作業系統來安裝，以下範例也將使用 Debian/Ubuntu 操作。
 
 !!! info "其他作業系統"
 
@@ -166,3 +166,7 @@ nyx -s /run/tor-instances/{instance-name}/control
 ??? question "如何升級我的 Tor Relay 軟體？"
 
     保持 Tor 軟體更新非常重要，以獲得最新的安全更新和功能。大多數 Linux 系統上，可以通過套件管理器來更新 Tor。Windows 和 macOS 使用者應定期檢查 Tor 官網上的更新。
+
+??? question "如何成為 Guard Relay？"
+
+    Guard Relay 由 Tor 網路自動選定，使用者無法手動配置。若節點穩定運行且具備足夠頻寬，便有可能被選為 Guard Relay。


### PR DESCRIPTION
關於文檔中的 Tor Relay 有點小錯誤，用戶無法自行配置成為 Guard Relay，而是由 Tor 網路自動選擇長期穩定上線且頻寬足夠的節點成為 Tor Relay，可以參考下面兩篇文章
https://www.reddit.com/r/TOR/comments/2r5sel/what_is_a_guard_relay_and_how_do_i_become_one/
https://forum.torproject.org/t/how-to-get-guard-flag/10796