### PR TITLE
fix(docs): 修掉窄螢幕的橫向溢出，並拉高置頂公告的連結對比

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -363,3 +363,56 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   font-weight: 700;
   line-height: 1.3;
 }
+
+/* ==========================================================================
+   語言切換選單：窄螢幕改成靠右展開，修掉整頁的橫向溢出
+   Material 預設用 left: 50% 搭配 translate3d(-50%, 0.3rem, 0)，把
+   .md-select__inner 置中掛在按鈕下方。三個語言標籤的中文字面讓選單有 177px
+   寬，窄螢幕時按鈕又貼近視窗右緣，選單會往右頂出約 14px。收合時 max-height
+   是 0 看不見，可是版面寬度已經被撐開，整頁能往右滑，露出置頂公告與 header
+   底色蓋不到的白色空白。
+   實測 959px 以下每個寬度都會發生，960px 起按鈕離右緣夠遠沒有這個問題，所以
+   只在 Material 的 59.984375em 斷點以下覆寫，桌面維持原本的置中展開。
+   靠右展開同時讓選單完整留在畫面內，窄螢幕原本會被視窗右緣切掉一截。
+   ========================================================================== */
+
+@media screen and (max-width: 59.984375em) {
+  .md-select__inner {
+    left: auto;
+    right: 0;
+    transform: translate3d(0, 0.3rem, 0);
+  }
+
+  .md-select:focus-within .md-select__inner,
+  .md-select:hover .md-select__inner {
+    transform: translate3d(0, 0, 0);
+  }
+
+  /* 指向按鈕的小箭頭一併改成靠右定位。按鈕寬 2.4rem，中心距選單右緣 1.2rem，
+     箭頭本身寬 0.4rem，所以右側留 1rem */
+  .md-select__inner::after {
+    left: auto;
+    margin-left: 0;
+    right: 1rem;
+  }
+}
+
+/* ==========================================================================
+   置頂公告的連結色
+   .md-banner 在兩種主題都是深底，淺色主題疊合後是 rgb(33, 33, 33)，深色主題是
+   rgb(23, 25, 31)。可是裡面的連結沿用 Material 的 --md-typeset-a-color，也就是
+   主色 #006d99，深藍配黑底在淺色主題只有 2.79:1，遠低於 WCAG AA 要求的 4.5:1，
+   字幾乎融進黑底看不出來是連結。
+   改用品牌 cyan-300，淺色主題 7.83:1、深色主題 8.54:1，兩邊都達 AAA。這也是本檔
+   既有的深底用色，見 --guide-basics-d 與 slate 的 sess-tag 覆寫。
+   hover 與 focus 再亮一階到 cyan-200，維持狀態變化看得出來。
+   ========================================================================== */
+
+.md-banner__inner a {
+  color: var(--brand-cyan-300);
+}
+
+.md-banner__inner a:focus,
+.md-banner__inner a:hover {
+  color: var(--brand-cyan-200);
+}

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -361,3 +361,56 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   font-weight: 700;
   line-height: 1.3;
 }
+
+/* ==========================================================================
+   語言切換選單：窄螢幕改成靠右展開，修掉整頁的橫向溢出
+   Material 預設用 left: 50% 搭配 translate3d(-50%, 0.3rem, 0)，把
+   .md-select__inner 置中掛在按鈕下方。三個語言標籤的中文字面讓選單有 177px
+   寬，窄螢幕時按鈕又貼近視窗右緣，選單會往右頂出約 14px。收合時 max-height
+   是 0 看不見，可是版面寬度已經被撐開，整頁能往右滑，露出置頂公告與 header
+   底色蓋不到的白色空白。
+   實測 959px 以下每個寬度都會發生，960px 起按鈕離右緣夠遠沒有這個問題，所以
+   只在 Material 的 59.984375em 斷點以下覆寫，桌面維持原本的置中展開。
+   靠右展開同時讓選單完整留在畫面內，窄螢幕原本會被視窗右緣切掉一截。
+   ========================================================================== */
+
+@media screen and (max-width: 59.984375em) {
+  .md-select__inner {
+    left: auto;
+    right: 0;
+    transform: translate3d(0, 0.3rem, 0);
+  }
+
+  .md-select:focus-within .md-select__inner,
+  .md-select:hover .md-select__inner {
+    transform: translate3d(0, 0, 0);
+  }
+
+  /* 指向按鈕的小箭頭一併改成靠右定位。按鈕寬 2.4rem，中心距選單右緣 1.2rem，
+     箭頭本身寬 0.4rem，所以右側留 1rem */
+  .md-select__inner::after {
+    left: auto;
+    margin-left: 0;
+    right: 1rem;
+  }
+}
+
+/* ==========================================================================
+   置頂公告的連結色
+   .md-banner 在兩種主題都是深底，淺色主題疊合後是 rgb(33, 33, 33)，深色主題是
+   rgb(23, 25, 31)。可是裡面的連結沿用 Material 的 --md-typeset-a-color，也就是
+   主色 #006d99，深藍配黑底在淺色主題只有 2.79:1，遠低於 WCAG AA 要求的 4.5:1，
+   字幾乎融進黑底看不出來是連結。
+   改用品牌 cyan-300，淺色主題 7.83:1、深色主題 8.54:1，兩邊都達 AAA。這也是本檔
+   既有的深底用色，見 --guide-basics-d 與 slate 的 sess-tag 覆寫。
+   hover 與 focus 再亮一階到 cyan-200，維持狀態變化看得出來。
+   ========================================================================== */
+
+.md-banner__inner a {
+  color: var(--brand-cyan-300);
+}
+
+.md-banner__inner a:focus,
+.md-banner__inner a:hover {
+  color: var(--brand-cyan-200);
+}

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -362,3 +362,56 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   font-weight: 700;
   line-height: 1.3;
 }
+
+/* ==========================================================================
+   語言切換選單：窄螢幕改成靠右展開，修掉整頁的橫向溢出
+   Material 預設用 left: 50% 搭配 translate3d(-50%, 0.3rem, 0)，把
+   .md-select__inner 置中掛在按鈕下方。三個語言標籤的中文字面讓選單有 177px
+   寬，窄螢幕時按鈕又貼近視窗右緣，選單會往右頂出約 14px。收合時 max-height
+   是 0 看不見，可是版面寬度已經被撐開，整頁能往右滑，露出置頂公告與 header
+   底色蓋不到的白色空白。
+   實測 959px 以下每個寬度都會發生，960px 起按鈕離右緣夠遠沒有這個問題，所以
+   只在 Material 的 59.984375em 斷點以下覆寫，桌面維持原本的置中展開。
+   靠右展開同時讓選單完整留在畫面內，窄螢幕原本會被視窗右緣切掉一截。
+   ========================================================================== */
+
+@media screen and (max-width: 59.984375em) {
+  .md-select__inner {
+    left: auto;
+    right: 0;
+    transform: translate3d(0, 0.3rem, 0);
+  }
+
+  .md-select:focus-within .md-select__inner,
+  .md-select:hover .md-select__inner {
+    transform: translate3d(0, 0, 0);
+  }
+
+  /* 指向按鈕的小箭頭一併改成靠右定位。按鈕寬 2.4rem，中心距選單右緣 1.2rem，
+     箭頭本身寬 0.4rem，所以右側留 1rem */
+  .md-select__inner::after {
+    left: auto;
+    margin-left: 0;
+    right: 1rem;
+  }
+}
+
+/* ==========================================================================
+   置頂公告的連結色
+   .md-banner 在兩種主題都是深底，淺色主題疊合後是 rgb(33, 33, 33)，深色主題是
+   rgb(23, 25, 31)。可是裡面的連結沿用 Material 的 --md-typeset-a-color，也就是
+   主色 #006d99，深藍配黑底在淺色主題只有 2.79:1，遠低於 WCAG AA 要求的 4.5:1，
+   字幾乎融進黑底看不出來是連結。
+   改用品牌 cyan-300，淺色主題 7.83:1、深色主題 8.54:1，兩邊都達 AAA。這也是本檔
+   既有的深底用色，見 --guide-basics-d 與 slate 的 sess-tag 覆寫。
+   hover 與 focus 再亮一階到 cyan-200，維持狀態變化看得出來。
+   ========================================================================== */
+
+.md-banner__inner a {
+  color: var(--brand-cyan-300);
+}
+
+.md-banner__inner a:focus,
+.md-banner__inner a:hover {
+  color: var(--brand-cyan-200);
+}


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

修兩件窄螢幕上的版面問題，都在三語的 `stylesheets/extra.css`：

1. 整頁在 959px 以下可以往右滑約 14px，露出置頂公告與 header 底色蓋不到的白色空白
2. 置頂公告裡的連結在淺色主題只有 2.79:1 對比，幾乎融進黑底

相關 Issue / Related issue：無

## 問題一：橫向溢出，元凶是語言切換選單

回報是「上方有全站公告，右邊會突然跑出一段空白」。實際量下來，**公告不是原因**。把公告整個隱藏，`documentElement.scrollWidth` 仍然是 404（視窗 390）。逐一隱藏候選元素後定位到 `.md-select`，也就是 header 裡的語言切換選單。

Material 的規則是：

```css
.md-select__inner {
  left: 50%;
  position: absolute;
  max-height: 0;
  transform: translate3d(-50%, .3rem, 0);
}
```

選單置中掛在按鈕下方。三個語言標籤（`臺灣正體（zh-TW）`、`簡體中文（zh-CN）`、`English (en-US)`）的中文字面讓選單有 177px 寬，窄螢幕時按鈕又貼近視窗右緣，選單就往右頂出約 14px。

收合時 `max-height` 是 0，所以看不見，可是那個盒子的寬度已經把版面撐開，整頁因此能往右滑。公告的黑底與 header 的藍底都是視窗寬，滑過去就蓋不到，露出白邊。

實測各寬度（headless Chrome，量 `documentElement.scrollWidth`）：

| 視窗寬 | scrollWidth | 溢出 |
|---|---|---|
| 320 | 333 | 13 |
| 390 | 404 | 14 |
| 768 | 781 | 13 |
| 959 | 972 | 13 |
| 960 | 960 | 0 |
| 1600 | 1600 | 0 |

斷點正好落在 960px（`60em`），也就是 header 換成桌面排版、按鈕離右緣夠遠的那一刻。首頁、內頁、blog、en、zh-cn 都是同樣的 14px，全站一致。

### 改動

只在 Material 自己的 `59.984375em` 斷點以下，把選單改成靠按鈕右緣展開，桌面維持原本置中：

```css
@media screen and (max-width: 59.984375em) {
  .md-select__inner {
    left: auto;
    right: 0;
    transform: translate3d(0, 0.3rem, 0);
  }
  .md-select:focus-within .md-select__inner,
  .md-select:hover .md-select__inner {
    transform: translate3d(0, 0, 0);
  }
  .md-select__inner::after {
    left: auto;
    margin-left: 0;
    right: 1rem;
  }
}
```

指向按鈕的小箭頭一併改成靠右。按鈕寬 2.4rem，中心距選單右緣 1.2rem，箭頭本身寬 0.4rem，所以右側留 1rem。

順帶解掉一個原本就存在的問題：窄螢幕上這個選單展開後本來會被視窗右緣切掉一截，靠右展開之後完整留在畫面內。

### 評估過但沒有採用的做法

- **`.md-header__inner { overflow-x: clip }`**：`scrollWidth` 會回到 390，可是選單展開時被裁掉，語言切換變成看不完整
- **`html, body { overflow-x: clip }`**：同樣把選單裁掉，而且是全站層級的遮蓋，會蓋掉未來其他真正的溢出，讓問題更難被發現

## 問題二：公告連結對比不足

`.md-banner` 兩種主題都是深底（淺色疊合後 `rgb(33, 33, 33)`，深色 `rgb(23, 25, 31)`），可是連結沿用 Material 的 `--md-typeset-a-color`，也就是本站主色 `#006d99`。深藍配黑底，淺色主題只有 **2.79:1**，遠低於 WCAG AA 要求的 4.5:1。

改用既有的品牌 token `--brand-cyan-300`：

| | 修正前 | 修正後 |
|---|---|---|
| 淺色主題 | 2.79:1 | **7.82:1** |
| 深色主題 | 6.47:1 | **8.54:1** |

兩邊都達 AAA。這也是本檔既有的深底用色（見 `--guide-basics-d` 與 slate 的 sess-tag 覆寫），沒有新增色票。hover 與 focus 再亮一階到 `--brand-cyan-200`，狀態變化維持看得出來。

## 驗證 / Verification

用 headless Chrome 加 DevTools Protocol 實測，不是目視推測：

- **溢出**：本地建置 zh-TW 後量 320、360、390、414、480、600、768、900、959、960、1024、1220、1600 共 13 個寬度，修正後全部 `scrollWidth == clientWidth`，溢出 0
- **選單位置**：390 寬強制 `:hover` 展開，選單由 `[225..403]`（超出視窗 13px）變成 `[161..338]`，右緣切齊按鈕，完整在視窗內，展開高度 108px 正常
- **對比**：讀 computed style 的實際色值，把帶 alpha 的底色疊合後依 WCAG 公式計算，數字如上表
- **建置**：`mkdocs build` exit 0

三語的 `extra.css` 是各自獨立的檔案，三份都套用同一段，已用 `diff` 確認新增片段完全一致。

## 附帶發現（不在本 PR）/ Noted, not fixed

深色主題下，公告裡 `TR-510` 那顆 code chip 的底色對公告底只有 1.25:1，幾乎看不出 chip 的邊界。chip 內的文字本身是 7.27:1，讀得到，所以不影響可讀性，只是視覺上少了區隔。要不要調整取決於設計取向，留給後續決定。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFosDifjwskLuhUzQ1pgr
