### PR TITLE
ci: 把還在 Node 20 的兩個 action 升上去，清掉 runner 的 deprecation 警告

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -91,7 +91,7 @@ jobs:
       # 依 variant 分開存，最後再留一層不分 variant 的 fallback：鏡像的是第三方外部
       # 資產，兩個變體抓到的內容其實一樣，新增的 onion 格不必從零開始重抓一輪。
       - name: Cache privacy plugin external assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: docs/.cache/plugin/privacy
           key: mkdocs-privacy-${{ matrix.variant }}-${{ github.sha }}

--- a/.github/workflows/games-checks.yml
+++ b/.github/workflows/games-checks.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

把兩個還停在 Node 20 runtime 的 action 升上去，清掉 runner 每次跑都會出現的 deprecation 警告。

相關 Issue / Related issue：無

## 問題 / The problem

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v4
```

清點 repo 裡五個在用的 action，只有兩個還停在 node20：

| Action | 位置 | 改前 | 改後 |
|---|---|---|---|
| `actions/cache` | `build_docs.yml` | v4（node20） | **v6**（node24） |
| `actions/setup-node` | `games-checks.yml` | v4（node20） | **v7**（node24） |
| `actions/checkout` | 五支都有 | v6（node24） | 不動 |
| `actions/setup-python` | 四支 | v6（node24） | 不動 |
| `astral-sh/setup-uv` | 三支 | v8.1.0（node24） | 不動 |

`setup-node@v4` 那支雖然不在回報的訊息裡，可是同樣是 node20，會在 games-checks 出一樣的警告，一起處理免得再回來一次。

## 破壞性變更的確認 / Breaking changes, checked

兩支的 major 版差得不少，所以逐版讀了 release notes，沒有直接跳最新了事。

**`actions/cache` v4 → v6：介面沒有變**

- v5.0.0 只做 node24 runtime 升級
- v6.0.0 是 ESM 遷移與相依更新，都屬內部改動

這個步驟只用到 `path`、`key`、`restore-keys` 三個輸入，三者跨版本都沒動過，行為不變。v5 起要求 runner 至少 `2.327.1`，本專案跑 GitHub 託管的 `ubuntu-24.04`，已經滿足；這條限制只對 self-hosted runner 有意義。

**`actions/setup-node` v4 → v7：有破壞性變更，但打不到這裡**

- v5.0.0：`package.json` 內有 `packageManager` 欄位時**自動開啟快取**
- v6.0.0：把自動快取限縮到只剩 npm
- v7.0.0：ESM 遷移，新增 `cache-primary-key` 與 `cache-matched-key` 輸出

前兩項的前提都是 `package.json`。本 repo 一個都沒有（`git ls-files | grep -c package.json` 回 0），games-checks 的四支檢查是直接 `node tools/check_*.mjs`，沒有相依安裝步驟，所以自動快取不會被觸發。該步驟也只帶 `node-version: "22"` 一個輸入，v7 照樣支援。

## 驗證 / Verification

- 五支 workflow 全部用 `yaml.safe_load` 解析通過
- 逐一抓各 action 對應 tag 的 `action.yml`，確認 `runs.using` 都是 `node24`：`cache@v6`、`checkout@v6`、`setup-node@v7`、`setup-python@v6`、`setup-uv@v8.1.0`
- 確認 repo 內沒有任何 `package.json`，`setup-node` 的自動快取變更在這裡是 no-op

`games-checks` 只在改到互動區檔案的 PR 上觸發，本 PR 沒動那些路徑，所以那支不會在這裡跑到。合併後第一次推 `docs` 時可以順便看 BuildDocs 的警告有沒有消失。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFosDifjwskLuhUzQ1pgr
