### PR TITLE
docs(community): pin 教學的 macOS 安裝改用 kubo，補上 brew services 指令

### DIFF
--- a/docs/en/community/pin-ipfs-mirror.md
+++ b/docs/en/community/pin-ipfs-mirror.md
@@ -51,8 +51,10 @@ For pinning to fetch the content, your machine needs a continuously running IPFS
     Install [kubo](https://docs.ipfs.tech/install/command-line/){target="_blank"}, IPFS's official command-line implementation. On macOS you can use Homebrew:
 
     ```bash
-    brew install ipfs
+    brew install kubo
     ```
+
+    The Homebrew formula was renamed from `ipfs` to `kubo`. The old name still installs it, but the service commands below need the `kubo` name. Both Intel and Apple Silicon are supported.
 
     On Linux, download the kubo build for your architecture from the [official guide](https://docs.ipfs.tech/install/command-line/){target="_blank"}. Then initialize and start the daemon:
 
@@ -61,7 +63,13 @@ For pinning to fetch the content, your machine needs a continuously running IPFS
     ipfs daemon
     ```
 
-    To keep the daemon running long-term, use a systemd user service on Linux, or `brew services` / launchd on macOS. For a quick test, running `ipfs daemon` in the background is fine.
+    To keep the daemon running long-term, use a systemd user service on Linux. On macOS the Homebrew formula ships a service definition, so a single command keeps it resident and starts it at login:
+
+    ```bash
+    brew services start kubo
+    ```
+
+    For a quick test, running `ipfs daemon` in the background is fine.
 
 === "Windows"
 
@@ -187,7 +195,7 @@ You can also open it on your local gateway and check it renders: `http://127.0.0
 ## Maintenance and notes
 
 - **It keeps up automatically.** When the site changes its CID, the next scheduled run pins the new version and drops the old one. You do nothing.
-- **Disk use stays flat.** After unpinning the old version the script runs a garbage collection, so only the latest version takes space. The site is a plain static site and isn't large.
+- **Disk use stays flat.** After unpinning the old version the script runs a garbage collection, so only the latest version takes space. A full mirror is about 220 MB (measured August 2026).
 - **It won't lose the copy you have.** The script pins the new version successfully before dropping the old one, and keeps your existing copy if resolving or downloading fails.
 - **To stop helping:** unpin the current version and remove the schedule. It doesn't affect any other node.
 - **Privacy and risk:** what you pin is public documentation, so there's no privacy concern. Offering IPFS pinning carries different legal risk across jurisdictions, so weigh that for where you operate.

--- a/docs/zh-CN/community/pin-ipfs-mirror.md
+++ b/docs/zh-CN/community/pin-ipfs-mirror.md
@@ -51,8 +51,10 @@ pin 要能抓齐内容，本机就得有一个持续运作的 IPFS daemon。下�
     安装 [kubo](https://docs.ipfs.tech/install/command-line/){target="_blank"}（IPFS 官方的命令行版本）。macOS 可以用 Homebrew：
 
     ```bash
-    brew install ipfs
+    brew install kubo
     ```
+
+    Homebrew 的包名已从 `ipfs` 改为 `kubo`，旧名还是装得起来，但后面设定服务要用 `kubo` 这个名字。Intel 与 Apple Silicon 都支持。
 
     Linux 依 [官方说明](https://docs.ipfs.tech/install/command-line/){target="_blank"} 下载对应架构的 kubo。装好后初始化并启动 daemon：
 
@@ -61,7 +63,13 @@ pin 要能抓齐内容，本机就得有一个持续运作的 IPFS daemon。下�
     ipfs daemon
     ```
 
-    要让 daemon 长时间常驻，Linux 建议做成 systemd user service，macOS 可以用 `brew services` 或 launchd。临时测试时，直接让 `ipfs daemon` 在后台执行也可以。
+    要让 daemon 长时间常驻，Linux 建议做成 systemd user service。macOS 用 Homebrew 安装的话，包本身附了服务定义，一行就会常驻并在登录时自动启动：
+
+    ```bash
+    brew services start kubo
+    ```
+
+    临时测试时，直接让 `ipfs daemon` 在后台执行也可以。
 
 === "Windows"
 
@@ -187,7 +195,7 @@ ipfs pin ls --type=recursive | grep "${CID#/ipfs/}"
 ## 维护与注意事项
 
 - **会自动跟上新版**：文件站换 CID 后，下一次定时任务就会 pin 新版、放掉旧版，你不用做任何事。
-- **硬盘不会一直变大**：脚本 unpin 旧版后会执行一次垃圾回收，只留最新版本占空间。文件站是纯静态网站，体积不大。
+- **硬盘不会一直变大**：脚本 unpin 旧版后会执行一次垃圾回收，只留最新版本占空间。一份完整镜像约 220 MB（2026 年 8 月实测）。
 - **不会弄丢你手上的版本**：脚本先确认新版 pin 成功才放掉旧版，解析或下载失败时会保留现有副本。
 - **想停止帮忙**：unpin 目前版本、把定时任务移除即可，不影响其他节点。
 - **隐私与风险**：你 pin 的是公开文件，没有隐私顾虑。提供 IPFS pin 在不同司法管辖下的风险不同，相关限制见 [去中心化网站发布](../advanced/dweb-ipfs-onion.md) 的「已知限制与风险」。

--- a/docs/zh-TW/community/pin-ipfs-mirror.md
+++ b/docs/zh-TW/community/pin-ipfs-mirror.md
@@ -51,8 +51,10 @@ pin 要能抓齊內容，本機就得有一個持續運作的 IPFS daemon。下�
     安裝 [kubo](https://docs.ipfs.tech/install/command-line/){target="_blank"}（IPFS 官方的命令列版本）。macOS 可以用 Homebrew：
 
     ```bash
-    brew install ipfs
+    brew install kubo
     ```
+
+    Homebrew 的套件名已從 `ipfs` 改為 `kubo`，舊名還是裝得起來，但後面設定服務要用 `kubo` 這個名字。Intel 與 Apple Silicon 都支援。
 
     Linux 依 [官方說明](https://docs.ipfs.tech/install/command-line/){target="_blank"} 下載對應架構的 kubo。裝好後初始化並啟動 daemon：
 
@@ -61,7 +63,13 @@ pin 要能抓齊內容，本機就得有一個持續運作的 IPFS daemon。下�
     ipfs daemon
     ```
 
-    要讓 daemon 長時間常駐，Linux 建議做成 systemd user service，macOS 可以用 `brew services` 或 launchd。臨時測試時，直接讓 `ipfs daemon` 在背景執行也可以。
+    要讓 daemon 長時間常駐，Linux 建議做成 systemd user service。macOS 用 Homebrew 安裝的話，套件本身附了服務定義，一行就會常駐並在登入時自動啟動：
+
+    ```bash
+    brew services start kubo
+    ```
+
+    臨時測試時，直接讓 `ipfs daemon` 在背景執行也可以。
 
 === "Windows"
 
@@ -187,7 +195,7 @@ ipfs pin ls --type=recursive | grep "${CID#/ipfs/}"
 ## 維護與注意事項
 
 - **會自動跟上新版**：文件站換 CID 後，下一次排程就會 pin 新版、放掉舊版，你不用做任何事。
-- **磁碟不會一直長大**：腳本 unpin 舊版後會執行一次垃圾回收，只留最新版本佔空間。文件站是純靜態網站，體積不大。
+- **磁碟不會一直長大**：腳本 unpin 舊版後會執行一次垃圾回收，只留最新版本佔空間。一份完整鏡像約 220 MB（2026 年 8 月實測）。
 - **不會弄丟你手上的版本**：腳本先確認新版 pin 成功才放掉舊版，解析或下載失敗時會保留現有複本。
 - **想停止幫忙**：unpin 目前版本、把排程移除即可，不影響其他節點。
 - **隱私與風險**：你 pin 的是公開文件，沒有隱私顧慮。提供 IPFS pin 在不同司法管轄下的風險不同，相關限制見 [去中心化網站發布](../advanced/dweb-ipfs-onion.md) 的「已知限制與風險」。


### PR DESCRIPTION
## 問題

[幫忙 pin 文件站的 IPFS 鏡像](https://anoni.net/docs/community/pin-ipfs-mirror/) 的 macOS 安裝說明有兩處對不上現況。

**一、Homebrew formula 已改名。** 現在正名是 `kubo`，`ipfs` 留在 `oldnames` 裡仍可安裝。問題出在 `brew services` 認的是實際 formula 名，讀者照舊文執行 `brew install ipfs`，接著想用 `brew services` 常駐時會對不上名字。

**二、常駐指令沒給。** 舊文只寫「macOS 可以用 `brew services` 或 launchd」，沒有指令。實際上 formula 本身已定義 service：

```json
"service": { "run": ["$HOMEBREW_PREFIX/opt/kubo/bin/ipfs", "daemon"], "run_type": "immediate" }
```

`brew services start kubo` 一行就會常駐並在登入時自動啟動，讀者不需要自己寫 launchd plist。

## 改動

三語系（zh-TW、zh-CN、en）同步，都在同一個 `=== "Linux / macOS"` 分頁與〈維護與注意事項〉。

| 項目 | 改前 | 改後 |
|---|---|---|
| 安裝指令 | `brew install ipfs` | `brew install kubo` |
| 改名說明 | 無 | 補一句新舊名關係，並提醒服務名要用 `kubo` |
| 硬體支援 | 無 | 補 Intel 與 Apple Silicon 都支援 |
| 常駐做法 | 「可以用 `brew services` 或 launchd」 | 給出 `brew services start kubo` 程式碼區塊 |
| 鏡像體積 | 「文件站是純靜態網站，體積不大」 | 「一份完整鏡像約 220 MB（2026 年 8 月實測）」 |

最後一項不在原本回報範圍內，是這次實測順手量到的。想維持原範圍的話單獨拿掉那三行即可。

## 實測

改之前先照文件跑過一次完整流程，確認腳本本身沒問題。

- 環境：本機 kubo 0.39.0，`ipfs daemon` 前景啟動
- `anoni-pin.sh` exit 0，IPNS 解析到 `bafybeib4drdhi7rrgfmfm7z3s76ruatzvh57tdqj2lpt4yw374i66txqj4`
- `ipfs pin ls --type=recursive` 確認該 CID 在清單內，狀態檔 `~/.anoni-pin/last_cid` 已寫入
- 本機 gateway 讀首頁 HTTP 200
- `ipfs dag stat` 實測 217 MB / 3080 blocks，220 MB 由此而來

`brew services start kubo` 這條沒有 macOS 機器可實測，依據是 Homebrew formula API 回的 service 定義與 IPFS 官方安裝說明。合併前若有 Mac 在手，值得再跑一次確認。

## 驗證

- `docs_style_lint.py` 0 error、0 warn，447 檔
- 三語系 `mkdocs build -s` 皆 exit 0
- 建置後 HTML 確認舊字串 `brew install ipfs` 已消失，`kubo` 出現 11 次

## 來源

- [Homebrew formula API：kubo 0.43.0](https://formulae.brew.sh/api/formula/kubo.json)（`oldnames: ["ipfs"]`，含 service 定義）
- [IPFS 官方命令列安裝說明](https://docs.ipfs.tech/install/command-line/)（`brew install ipfs`、Intel 與 Apple Silicon 皆支援）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QcvMAqJzchH6dwrMayLQt
