### PR TITLE
docs(community): 個人隱私指引研究專題的進度與索引補回實際狀態（雙語系）

### DIFF
--- a/docs/zh-CN/community/privacy-guide.md
+++ b/docs/zh-CN/community/privacy-guide.md
@@ -6,7 +6,7 @@ icon: material/shield-lock-outline
 
 # :material-shield-lock-outline: 个人隐私指引研究专题
 
-个人隐私指引是匿名网络社群 anoni.net 2026 的三大主题之一，跟「Tor Relay 校园建立」、「匿名支付」并列为今年的重点推进项目。这页是研究专题的对外入口，整理研究目标、相关文章索引、目前进度，以及如何加入社群讨论。
+个人隐私指引是匿名网络社群 anoni.net 2026 的三大主题之一，跟 [Tor Relay 校园建立](./relay-on-campus.md)、[匿名支付](./payments-research.md) 并列为今年的重点推进项目。这页是研究专题的对外入口，整理研究目标、相关文章索引、目前进度，以及如何加入社群讨论。年度整体规划与季度节奏见 [2026 年度路线图](./roadmap-2026.md)。
 
 ## 为什么把个人隐私指引独立成一个主题
 
@@ -18,7 +18,7 @@ icon: material/shield-lock-outline
 
 - **三级威胁模型框架**：把日常使用、敏感工作、高风险情境三种等级的对应工具与步骤整理成参考表
 - **概念到实作的桥**：在威胁模型与工具操作之间补上判断流程（什么时候该升级、什么时候不必过度防护）
-- **常见误区整理**：VPN ≠ 匿名、HTTPS ≠ 安全、私密模式 ≠ 隐私、去中心化 ≠ 匿名等高频误解的拆解
+- **常见误区整理**：VPN ≠ 匿名、HTTPS ≠ 安全、私密模式 ≠ 隐私、去中心化 ≠ 匿名等高频误解的拆解。VPN 与去中心化两项已有专篇（[VPN 的风险与选择](../tools/vpn-guide.md)、[常被误认为匿名的网络](../advanced/mistaken-for-anonymity.md)），HTTPS 与私密模式待补
 - **场景指引落地**：给记者、社运参与者、家暴幸存者、LGBTQ+ 等具体角色的实作流程
 - **跨主题串接**：把个资、金流、连线层三个面向（见 [网络自由为什么重要](../basics/internet-freedom.md)）整合进个人隐私的整体规划
 - **教材化**：把研究产出整理成可用于工作坊、小聚的教材，方便对外推广
@@ -28,16 +28,16 @@ icon: material/shield-lock-outline
 社群依「[指南](../guides/index.md)」的分层结构，把隐私主题分散到不同层次：
 
 - 概念：[匿名、隐私、假名、机密性的差别](../basics/anonymity-vs-privacy.md)、[威胁模型如何建立](../basics/threat-model.md)、[Metadata 是什么](../basics/metadata.md)、[社群平台怎么收集你的数据](../basics/platform-tracking.md)、[监控现在做得到什么](../basics/surveillance-capability.md)、[怎么维持多个网络身分](../basics/multiple-identities.md)
-- 工具：[什么是 Tor](../tools/what-is-tor.md)、[什么是 Tails](../tools/what-is-tails.md)、[Tor Browser 进阶设定](../tools/tor-browser-advanced.md)、[匿名操作系统比较](../tools/tails-vs-whonix-vs-qubes.md)、[消息工具比较](../tools/messaging-comparison.md)、[密码管理器入门](../tools/password-manager.md)、[用 AI 工作时怎么避免数据外泄](../tools/ai-privacy.md)
-- 场景：[一般人平常该做到什么](../scenarios/everyday-baseline.md)、[记者保护消息来源](../scenarios/journalist.md)、[社运行动者的数位准备](../scenarios/activist.md)、[家暴幸存者的数位准备](../scenarios/domestic-violence.md)、[LGBTQ+ 与性少数的匿名社交](../scenarios/lgbtq.md)
-- 进阶：[端对端加密如何运作](../advanced/e2ee.md)、[常被误认为匿名的网络](../advanced/mistaken-for-anonymity.md)
+- 工具：[什么是匿名网络](../tools/what-is-anonymity-network.md)、[什么是 Tor](../tools/what-is-tor.md)、[什么是 Tails](../tools/what-is-tails.md)、[Tor Browser 进阶设定](../tools/tor-browser-advanced.md)、[Tor Snowflake 桥接点](../tools/tor-snowflake.md)、[匿名操作系统比较](../tools/tails-vs-whonix-vs-qubes.md)、[GrapheneOS 行动作业系统](../tools/grapheneos.md)、[消息工具比较](../tools/messaging-comparison.md)、[OnionShare 匿名传输](../tools/onionshare.md)、[什么是 CryptPad](../tools/what-is-cryptpad.md)、[密码管理器入门](../tools/password-manager.md)、[Asian Diceware 密语字典](../tools/asian-diceware.md)、[VPN 的风险与选择](../tools/vpn-guide.md)、[加密 DNS 怎么选](../tools/encrypted-dns.md)、[用 AI 工作时怎么避免数据外泄](../tools/ai-privacy.md)
+- 场景：[一般人平常该做到什么](../scenarios/everyday-baseline.md)、[记者保护消息来源](../scenarios/journalist.md)、[社运行动者的数位准备](../scenarios/activist.md)、[家暴幸存者的数位准备](../scenarios/domestic-violence.md)、[LGBTQ+ 与性少数的匿名社交](../scenarios/lgbtq.md)、[选举观察员的自保](../scenarios/election-observer.md)、[在中国大陆的公开平台传播信息](../scenarios/mainland-speech.md)、[出差与研讨会的数位准备](../scenarios/asia-travel.md)、[出国前用 AI 生成目的地概况](../scenarios/travel-ai-briefing.md)
+- 进阶：[端对端加密如何运作](../advanced/e2ee.md)、[常被误认为匿名的网络](../advanced/mistaken-for-anonymity.md)、[后量子密码概观](../advanced/post-quantum.md)、[去中心化网站发布](../advanced/dweb-ipfs-onion.md)
 - 在地：[台湾个资法 2025 修法](../taiwan/pdpa-2025.md)、[揭弊者保护法的技术观察](../taiwan/whistleblower-law.md)
 
 以上文章初稿多已上线，仍会依季度节奏持续校订与补充。
 
 ## 已完成的事
 
-- **概念层五篇上线**：[网络自由为什么重要](../basics/internet-freedom.md)、[匿名/隐私/假名/机密性的差别](../basics/anonymity-vs-privacy.md)、[威胁模型如何建立](../basics/threat-model.md)、[Metadata 是什么](../basics/metadata.md)、[为什么匿名支付重要](../basics/payments-anonymity.md)
+- **概念层八篇上线**：[网络自由为什么重要](../basics/internet-freedom.md)、[匿名/隐私/假名/机密性的差别](../basics/anonymity-vs-privacy.md)、[威胁模型如何建立](../basics/threat-model.md)、[Metadata 是什么](../basics/metadata.md)、[为什么匿名支付重要](../basics/payments-anonymity.md)、[社群平台怎么收集你的数据](../basics/platform-tracking.md)、[监控现在做得到什么](../basics/surveillance-capability.md)、[怎么维持多个网络身分](../basics/multiple-identities.md)
 - **三大面向框架**：在 [网络自由为什么重要](../basics/internet-freedom.md) 确立「连线层 / 个资与身份 / 金流」三面向，作为个人隐私指引的整体骨架
 - **在地法规参考**：[个资法 2025](../taiwan/pdpa-2025.md)、[揭弊者保护法](../taiwan/whistleblower-law.md) 两篇完整上线
 - **写作规范与分类**：sitemap 7 大分类落地，[指南](../guides/index.md) 入口页建立，阅读路径明确化
@@ -45,6 +45,7 @@ icon: material/shield-lock-outline
 ## 进行中与待完成
 
 - 工具层、场景层、进阶层各篇初稿已上线，持续依读者反馈校订与补充
+- 常见误区补完：HTTPS ≠ 安全、私密模式 ≠ 隐私两项尚未有专篇
 - **三级隐私指引合集**（本主题的核心交付物，预计 Q3 整合上述各层内容）
 - 工作坊教材：把研究产出转成可用于工作坊、小聚的讲义
 - 翻译候选报告（候选清单见下方）

--- a/docs/zh-TW/community/privacy-guide.md
+++ b/docs/zh-TW/community/privacy-guide.md
@@ -6,7 +6,7 @@ icon: material/shield-lock-outline
 
 # :material-shield-lock-outline: 個人隱私指引研究專題
 
-個人隱私指引是匿名網路社群 anoni.net 2026 的三大主題之一，跟「Tor Relay 校園建立」、「匿名支付」並列為今年的重點推進項目。這頁是研究專題的對外入口，整理研究目標、相關文章索引、目前進度，以及如何加入社群討論。
+個人隱私指引是匿名網路社群 anoni.net 2026 的三大主題之一，跟 [Tor Relay 校園建立](./relay-on-campus.md)、[匿名支付](./payments-research.md) 並列為今年的重點推進項目。這頁是研究專題的對外入口，整理研究目標、相關文章索引、目前進度，以及如何加入社群討論。年度整體規劃與季度節奏見 [2026 年度路線圖](./roadmap-2026.md)。
 
 ## 為什麼把個人隱私指引獨立成一個主題
 
@@ -18,7 +18,7 @@ icon: material/shield-lock-outline
 
 - **三級威脅模型框架**：把日常使用、敏感工作、高風險情境三種等級的對應工具與步驟整理成參考表
 - **概念到實作的橋**：在威脅模型與工具操作之間補上判斷流程（什麼時候該升級、什麼時候不必過度防護）
-- **常見誤區整理**：VPN ≠ 匿名、HTTPS ≠ 安全、私密模式 ≠ 隱私、去中心化 ≠ 匿名等高頻誤解的拆解
+- **常見誤區整理**：VPN ≠ 匿名、HTTPS ≠ 安全、私密模式 ≠ 隱私、去中心化 ≠ 匿名等高頻誤解的拆解。VPN 與去中心化兩項已有專篇（[VPN 的風險與選擇](../tools/vpn-guide.md)、[常被誤認為匿名的網路](../advanced/mistaken-for-anonymity.md)），HTTPS 與私密模式待補
 - **場景指引落地**：給記者、社運參與者、家暴倖存者、LGBTQ+ 等具體角色的實作流程
 - **跨主題串接**：把個資、金流、連線層三個面向（見 [網路自由為什麼重要](../basics/internet-freedom.md)）整合進個人隱私的整體規劃
 - **教材化**：把研究產出整理成可用於工作坊、小聚的教材，方便對外推廣
@@ -28,16 +28,16 @@ icon: material/shield-lock-outline
 社群依「[指南](../guides/index.md)」的分層結構，把隱私主題分散到不同層次：
 
 - 概念：[匿名、隱私、假名、機密性的差別](../basics/anonymity-vs-privacy.md)、[威脅模型如何建立](../basics/threat-model.md)、[Metadata 是什麼](../basics/metadata.md)、[社群平台怎麼收集你的資料](../basics/platform-tracking.md)、[監控現在做得到什麼](../basics/surveillance-capability.md)、[怎麼維持多個網路身分](../basics/multiple-identities.md)
-- 工具：[什麼是 Tor](../tools/what-is-tor.md)、[什麼是 Tails](../tools/what-is-tails.md)、[Tor Browser 進階設定](../tools/tor-browser-advanced.md)、[匿名作業系統比較](../tools/tails-vs-whonix-vs-qubes.md)、[訊息工具比較](../tools/messaging-comparison.md)、[密碼管理器入門](../tools/password-manager.md)、[用 AI 工作時怎麼避免資料外洩](../tools/ai-privacy.md)
-- 場景：[一般人平常該做到什麼](../scenarios/everyday-baseline.md)、[記者保護消息來源](../scenarios/journalist.md)、[社運行動者的數位準備](../scenarios/activist.md)、[家暴倖存者的數位準備](../scenarios/domestic-violence.md)、[LGBTQ+ 與性少數的匿名社交](../scenarios/lgbtq.md)
-- 進階：[端對端加密如何運作](../advanced/e2ee.md)、[常被誤認為匿名的網路](../advanced/mistaken-for-anonymity.md)
+- 工具：[什麼是匿名網路](../tools/what-is-anonymity-network.md)、[什麼是 Tor](../tools/what-is-tor.md)、[什麼是 Tails](../tools/what-is-tails.md)、[Tor Browser 進階設定](../tools/tor-browser-advanced.md)、[Tor Snowflake 橋接點](../tools/tor-snowflake.md)、[匿名作業系統比較](../tools/tails-vs-whonix-vs-qubes.md)、[GrapheneOS 行動作業系統](../tools/grapheneos.md)、[訊息工具比較](../tools/messaging-comparison.md)、[OnionShare 匿名傳輸](../tools/onionshare.md)、[什麼是 CryptPad](../tools/what-is-cryptpad.md)、[密碼管理器入門](../tools/password-manager.md)、[Asian Diceware 密語字典](../tools/asian-diceware.md)、[VPN 的風險與選擇](../tools/vpn-guide.md)、[加密 DNS 怎麼選](../tools/encrypted-dns.md)、[用 AI 工作時怎麼避免資料外洩](../tools/ai-privacy.md)
+- 場景：[一般人平常該做到什麼](../scenarios/everyday-baseline.md)、[記者保護消息來源](../scenarios/journalist.md)、[社運行動者的數位準備](../scenarios/activist.md)、[家暴倖存者的數位準備](../scenarios/domestic-violence.md)、[LGBTQ+ 與性少數的匿名社交](../scenarios/lgbtq.md)、[選舉觀察員的自保](../scenarios/election-observer.md)、[在中國大陸的公開平台傳播資訊](../scenarios/mainland-speech.md)、[出差與研討會的數位準備](../scenarios/asia-travel.md)、[出國前用 AI 產生目的地概況](../scenarios/travel-ai-briefing.md)
+- 進階：[端對端加密如何運作](../advanced/e2ee.md)、[常被誤認為匿名的網路](../advanced/mistaken-for-anonymity.md)、[後量子密碼概觀](../advanced/post-quantum.md)、[去中心化網站發布](../advanced/dweb-ipfs-onion.md)
 - 在地：[台灣個資法 2025 修法](../taiwan/pdpa-2025.md)、[揭弊者保護法的技術觀察](../taiwan/whistleblower-law.md)
 
 以上文章初稿多已上線，仍會依季度節奏持續校訂與補充。
 
 ## 已完成的事
 
-- **概念層五篇上線**：[網路自由為什麼重要](../basics/internet-freedom.md)、[匿名/隱私/假名/機密性的差別](../basics/anonymity-vs-privacy.md)、[威脅模型如何建立](../basics/threat-model.md)、[Metadata 是什麼](../basics/metadata.md)、[為什麼匿名支付重要](../basics/payments-anonymity.md)
+- **概念層八篇上線**：[網路自由為什麼重要](../basics/internet-freedom.md)、[匿名/隱私/假名/機密性的差別](../basics/anonymity-vs-privacy.md)、[威脅模型如何建立](../basics/threat-model.md)、[Metadata 是什麼](../basics/metadata.md)、[為什麼匿名支付重要](../basics/payments-anonymity.md)、[社群平台怎麼收集你的資料](../basics/platform-tracking.md)、[監控現在做得到什麼](../basics/surveillance-capability.md)、[怎麼維持多個網路身分](../basics/multiple-identities.md)
 - **三大面向框架**：在 [網路自由為什麼重要](../basics/internet-freedom.md) 確立「連線層 / 個資與身分 / 金流」三面向，作為個人隱私指引的整體骨架
 - **在地法規參考**：[個資法 2025](../taiwan/pdpa-2025.md)、[揭弊者保護法](../taiwan/whistleblower-law.md) 兩篇完整上線
 - **寫作規範與分類**：sitemap 7 大分類落地，[指南](../guides/index.md) 入口頁建立，閱讀路徑明確化
@@ -45,6 +45,7 @@ icon: material/shield-lock-outline
 ## 進行中與待完成
 
 - 工具層、場景層、進階層各篇初稿已上線，持續依讀者回饋校訂與補充
+- 常見誤區補完：HTTPS ≠ 安全、私密模式 ≠ 隱私兩項尚未有專篇
 - **三級隱私指引合集**（本主題的核心交付物，預計 Q3 整合上述各層內容）
 - 工作坊教材：把研究產出轉成可用於工作坊、小聚的講義
 - 翻譯候選報告（候選清單見下方）


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

把 `community/privacy-guide.md` 的進度描述與文章索引補回實際狀態，zh-TW 與 zh-CN 兩版同步。

相關 Issue / Related issue：無

## 為什麼要改

這頁 8/6 更新時補了「相關文章」的索引，可是下方的進度段落沒跟著改，變成同一頁自己講不同的話。同時各層索引也累積落後了一段時間。

## 四項改動

### 1. 同一頁內自相矛盾

「相關文章」的概念層已經列了八篇，含 8/4 上線的 `platform-tracking`、`multiple-identities` 與 8/6 的 `surveillance-capability`。下方「已完成的事」卻還寫「**概念層五篇上線**」並只列原本那五篇。改成八篇並補齊清單。

### 2. 索引補上 14 篇本主題文章

| 層 | 實際篇數 | 改前列出 | 改後列出 |
|---|---|---|---|
| 概念 | 8 | 8 | 8 |
| 工具 | 18 | 7 | **15** |
| 場景 | 10 | 5 | **9** |
| 進階 | 5 | 2 | **4** |
| 在地 | 6 | 2 | 2 |

補進來的：

- **工具**：`what-is-anonymity-network`、`tor-snowflake`、`grapheneos`、`onionshare`、`what-is-cryptpad`、`asian-diceware`、`vpn-guide`、`encrypted-dns`
- **場景**：`election-observer`、`mainland-speech`、`asia-travel`、`travel-ai-briefing`
- **進階**：`post-quantum`、`dweb-ipfs-onion`

沒收錄的 9 篇是刻意的，它們分屬另外兩個主題：`crypto-privacy-spectrum`、`vasp-2026`、`zk-identity-payments`、`nonprofit-anonymous-donation` 屬匿名支付，OONI 四篇與 `tor-relay-watcher` 屬 OONI 與 Tor Relay。

### 3. 常見誤區的實際進度沒反映

「2026 研究目標」的「常見誤區整理」列了四項，讀起來像整條還沒動工。實際盤點：

| 誤區 | 現況 |
|---|---|
| VPN ≠ 匿名 | `tools/vpn-guide.md` 已有整篇，含「VPN 到底改變了什麼」「VPN 還是 Tor」，先前沒被連到 |
| 去中心化 ≠ 匿名 | `advanced/mistaken-for-anonymity.md` 已完整涵蓋 IPFS、Yggdrasil、DN42、I2P |
| 私密模式 ≠ 隱私 | 散在 `everyday-baseline`、`platform-tracking`、`multiple-identities`，沒有專篇 |
| HTTPS ≠ 安全 | 全站搜尋只有這頁自己提到，尚未動工 |

補上前兩項的連結，並註明後兩項待補。同時在「進行中與待完成」加一條，讓缺口有可追蹤的出口。

### 4. 姊妹主題頁單向連結

`payments-research.md` 的開場句已經把「個人隱私指引」「Tor Relay 校園建立」都做成連結，這頁的同結構開場句卻是純文字。補上 `relay-on-campus.md` 與 `payments-research.md`，並在句末指向 `roadmap-2026.md`。

## 驗證 / Verification

- 兩語系各 43 條站內連結，逐條 `realpath` 確認指向存在的檔案，0 條損壞
- 兩版連結目標逐一比對完全平行，唯一差異是 Tor 支援站的 `zh-TW` 對 `zh-CN` 語系碼
- `python3 tools/docs_style_lint.py` 掃兩個檔案，0 error、0 warn
- 五個外部延伸閱讀連結另外確認過，全部回 200

## 沒有處理的部分

審閱時另外找到兩項，牽涉判斷所以留給討論，沒有動：

- **Q3 交付物的時程**：「三級隱私指引合集（預計 Q3 整合）」目前全站沒有任何雛形，Q3 剩不到七週。另外 `roadmap-2026.md` 還停在「最後更新：2026-06（Q2 進行中）」，且把場景層列為「Q3 待開始」，可是場景層 10 篇都上線了，兩頁的進度描述對不上。
- **英文版缺頁**：`en/community/` 有 14 頁，沒有 `privacy-guide.md`。`payments-research` 與 `relay-on-campus` 同樣沒有英文版，三大主題的對外入口在英文版整組缺席。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFosDifjwskLuhUzQ1pgr
