### PR TITLE
feat(docs): 置頂公告改為 8/13 行動網路降速演練的 OONI 測量號召（三語）

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# 活動公告：COSCUP 2026 結束（2026/8/9）後移除，屆時另開 PR #}
+{# 活動公告：8/13 降速演練結束後移除，屆時另開 PR #}
 {% block announce %}
-  COSCUP 2026 匿名網路社群議程軌 8/08、8/09 在臺灣科技大學 <code>TR-510</code> 開講，免報名，當天到場即可參與。<a href="{{ 'activity/coscup-2026/' | url }}">看兩天完整議程</a>。現場網路壅塞時不好查資料，建議先<a href="{{ 'help/' | url }}#趁有網路時把文件站裝成離線-App">把文件站裝成離線 App</a>，收訊不好也能翻議程表。
+  8/13（四）14:30 到 15:00，北部七縣市的行動網路會降速 30 分鐘，官方公布的目標是把下載速率壓到 <code>256KB</code>，還沒有人量過。<a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">一起用 OONI Probe 測三家電信</a>，在 14:35 到 14:55 之間執行一次「效能」測試即可。降速期間查資料會很慢，建議先<a href="{{ 'help/' | url }}#趁有網路時把文件站裝成離線-App">把文件站裝成離線 App</a>。
 {% endblock %}
 
 {% block site_meta %}

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# 活动公告：COSCUP 2026 结束（2026/8/9）后移除，届时另开 PR #}
+{# 活动公告：8/13 降速演练结束后移除，届时另开 PR #}
 {% block announce %}
-  COSCUP 2026 匿名网络社群议程轨 8/08、8/09 在台湾科技大学 <code>TR-510</code> 开讲，免报名，当天到场即可参与。<a href="{{ 'activity/coscup-2026/' | url }}">看两天完整议程</a>。现场网络壅塞时不好查资料，建议先<a href="{{ 'help/' | url }}#趁有网络时把文档站装成离线-App">把文档站装成离线 App</a>，信号不好也能翻议程表。
+  8/13（四）14:30 到 15:00，台湾北部七县市的移动网络会降速 30 分钟，官方公布的目标是把下载速率压到 <code>256KB</code>，还没有人测过。<a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">一起用 OONI Probe 测三家电信</a>，在 14:35 到 14:55 之间运行一次「性能」测试即可。降速期间查资料会很慢，建议先<a href="{{ 'help/' | url }}#趁有网络时把文档站装成离线-App">把文档站装成离线 App</a>。
 {% endblock %}
 
 {% block site_meta %}

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# Event notice: remove after COSCUP 2026 ends (2026-08-09), via a follow-up PR #}
+{# Event notice: remove after the 13 August throttling drill, via a follow-up PR #}
 {% block announce %}
-  Our Anonymity Networks Community track at COSCUP 2026 runs on 8 and 9 August at NTUST in Taipei, room <code>TR-510</code>. Entry is free and no registration is needed. <a href="{{ 'activity/coscup-2026/' | url }}">See the two-day schedule</a>, and <a href="{{ 'offline-install/' | url }}">install this site for offline use</a> so you can still read the schedule when the venue network is congested.
+  On Thursday 13 August, 14:30–15:00 Taipei time (06:30–07:00 UTC), mobile networks across seven counties in northern Taiwan will be throttled for 30 minutes. The official target is <code>256KB</code> and nobody has measured it yet. <a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">Help measure all three carriers with OONI Probe</a>: one run of the Performance tests between 14:35 and 14:55 is enough. Reading anything will be slow during the throttle, so <a href="{{ 'offline-install/' | url }}">install this site for offline use</a> first.
 {% endblock %}
 
 {% block site_meta %}


### PR DESCRIPTION
COSCUP 2026 已於 8/09 結束，置頂公告換成 8/13 降速演練的 OONI 測量號召。離線 App 的引導保留，降速期間查資料會很慢，比 COSCUP 現場網路壅塞更需要它。

## 公告內容

**zh-TW**

> 8/13（四）14:30 到 15:00，北部七縣市的行動網路會降速 30 分鐘，官方公布的目標是把下載速率壓到 `256KB`，還沒有人量過。[一起用 OONI Probe 測三家電信](https://anoni.net/docs/blog/2026/08/ooni-mobile-throttle-drill/)，在 14:35 到 14:55 之間執行一次「效能」測試即可。降速期間查資料會很慢，建議先[把文件站裝成離線 App](https://anoni.net/docs/help/#趁有網路時把文件站裝成離線-App)。

**zh-CN** 同結構，連到 help 頁的離線 App 章節。

**en** 連到 `offline-install/`，其餘結構相同。

## 設計取捨

- 主軸用官方公布的 `256KB` 與「還沒有人量過」，跟文章與 SNS 草稿（#219）同一套框架
- 行動門檻只寫一項：14:35 到 14:55 之間執行一次「效能」測試。三個時間點的完整版留在文章裡，公告列不塞
- 離線 App 的理由從「現場網路壅塞」改成「降速期間查資料會很慢」，情境更貼合
- 註解的移除時機改為 8/13 演練結束之後

## 驗證

三語系都用 `run_*.sh` 的環境變數建置。`mkdocs_en.yml` 與 `mkdocs_cn.yml` 的 `docs_dir` 與 `custom_dir` 預設值都落回 zh-TW，直接跑 `mkdocs build -f mkdocs_en.yml` 會建到錯的來源，需要帶 `DOCS_DIR` 與 `OVERRIDES`。

- 公告列在首頁、部落格文章頁、深層文件頁（`community/i18n/`）三個深度都檢查過，文章連結與離線 App 錨點全部解析正確
- en 版確認吃到 `overrides_en`，內容是英文並連到 `offline-install/`
- 三語系建置皆無新增警告

## 相關

- 文章：#218（已合併並上線）
- SNS 草稿：#219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFosDifjwskLuhUzQ1pgr
