### PR TITLE
chore(docs): 移除 8/13 降速演練的置頂公告（三語）

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{# 活動公告：8/13 降速演練結束後移除，屆時另開 PR #}
-{% block announce %}
-  8/13（四）14:30 到 15:00，北部七縣市的行動網路會降速 30 分鐘，時間、地點與業者都預先公開，是難得能留下紀錄的半小時，官方公布的下載速率上限是 <code>256KB</code>。<a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">一起用 OONI Probe 測三家電信</a>，在 14:35 到 14:55 之間執行一次「效能」測試即可。降速期間查資料會很慢，建議先<a href="{{ 'help/' | url }}#趁有網路時把文件站裝成離線-App">把文件站裝成離線 App</a>。
-{% endblock %}
-
 {% block site_meta %}
   {% if page.meta and page.meta.og and page.meta.og.enabled %}
     {% set page_title = page.meta.get("title", page.title) %}

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{# 活动公告：8/13 降速演练结束后移除，届时另开 PR #}
-{% block announce %}
-  8/13（四）14:30 到 15:00，台湾北部七县市的移动网络会降速 30 分钟，时间、地点与运营商都预先公开，是难得能留下记录的半小时，官方公布的下载速率上限是 <code>256KB</code>。<a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">一起用 OONI Probe 测三家电信</a>，在 14:35 到 14:55 之间运行一次「性能」测试即可。降速期间查资料会很慢，建议先<a href="{{ 'help/' | url }}#趁有网络时把文档站装成离线-App">把文档站装成离线 App</a>。
-{% endblock %}
-
 {% block site_meta %}
   {% if page.meta and page.meta.og and page.meta.og.enabled %}
     {% set page_title = page.meta.get("title", page.title) %}

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{# Event notice: remove after the 13 August throttling drill, via a follow-up PR #}
-{% block announce %}
-  On Thursday 13 August, 14:30–15:00 Taipei time (06:30–07:00 UTC), mobile networks across seven counties in northern Taiwan will be throttled for 30 minutes. The time, the place, and the carriers are all public in advance, making it a rare half hour to get on record, with an officially stated download cap of <code>256KB</code>. <a href="{{ 'blog/2026/08/ooni-mobile-throttle-drill/' | url }}">Help measure all three carriers with OONI Probe</a>: one run of the Performance tests between 14:35 and 14:55 is enough. Reading anything will be slow during the throttle, so <a href="{{ 'offline-install/' | url }}">install this site for offline use</a> first.
-{% endblock %}
-
 {% block site_meta %}
   {% if page.meta and page.meta.og and page.meta.og.enabled %}
     {% set page_title = page.meta.get("title", page.title) %}


### PR DESCRIPTION
降速演練 8/13 15:00 已結束，置頂公告完成任務，把三語系的 `announce` block 連同提醒移除時機的註解一起刪掉。

## 變更

- `docs/overrides/main.html`（zh-TW）
- `docs/overrides_cn/main.html`（zh-CN）
- `docs/overrides_en/main.html`（en）

`base.html` 用 `{% if self.announce() %}` 判斷是否輸出橫幅，覆寫拿掉後這個 block 回傳空字串，整段 `md-banner` 不再 render，只留空的 `data-md-component="announce"` 容器。

## 驗證

三個站各跑一次 `mkdocs build`，輸出目錄裡 `md-banner` 的命中檔案數皆為 0，版面其餘照舊。

## 不在此 PR 的範圍

降速演練文 `blog/2026/08/ooni-mobile-throttle-drill/` 保留不動，觀測紀錄與測量說明照舊留在站上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)