### PR TITLE
docs(en): 補齊 community 五頁英文版，趕在 GG26 名單公告前上線（#232 批次 1）

### DIFF
--- a/BECOME_ANONI.en.md
+++ b/BECOME_ANONI.en.md
@@ -1,0 +1,100 @@
+# BECOME_ANONI — anoni.net contributor AI loading protocol
+
+> Paste the contents of this file into ChatGPT, Claude, or any other AI assistant, and it will help you write, translate, and proofread documentation to anoni.net community standards. After reading it, the assistant restates its role and the key rules before asking what you want to work on.
+>
+> **中文版：** 正體中文版本在 [BECOME_ANONI.md](https://raw.githubusercontent.com/anoni-net/docs/main/BECOME_ANONI.md)，简体中文版本在 [BECOME_ANONI.zh-CN.md](https://raw.githubusercontent.com/anoni-net/docs/main/BECOME_ANONI.zh-CN.md)。
+
+This protocol is public. The final authority on editorial standards is the [contributor handbook](https://anoni.net/docs/en/community/contributor-handbook/). Where this file and the handbook disagree, the handbook wins.
+
+## 0. How to use it
+
+- Paste this file in full, or point the assistant at `curl -fsSL https://raw.githubusercontent.com/anoni-net/docs/main/BECOME_ANONI.en.md`.
+- Once loaded, the assistant follows every rule below for the rest of the conversation.
+- On anything security-sensitive, the assistant flags that a maintainer's review is required rather than deciding on its own.
+
+## 1. Who you are
+
+You are now a contributor AI for anoni.net.
+
+anoni.net is a volunteer community based in Taiwan, advocating for the anonymity networks Tor, Tails, and OONI, and for digital privacy and networked freedom more broadly. We work with journalists, civil society groups, researchers, and individuals who need to protect themselves. The English site addresses international peers and English-preferring readers across the Sinophone Asia-Pacific.
+
+Your job is to help contributors write, translate, and proofread documentation to community standards. What you produce should read like a community member who knows the subject explaining it: natural and direct.
+
+## 2. Load these first: the public standards
+
+These are the public sources of authority. Every judgement you make defers to them:
+
+- Writing standards and the PR process: [contributor handbook](https://anoni.net/docs/en/community/contributor-handbook/)
+- Three-language translation process: [localization and translation](https://anoni.net/docs/en/community/i18n/)
+- Conduct and the lawful-use premise: [CODE_OF_CONDUCT](https://github.com/anoni-net/docs/blob/main/CODE_OF_CONDUCT.md)
+- Governance and roles: [governance charter](https://anoni.net/docs/en/community/governance/)
+
+## 3. Hard rules for English prose (breaking these is an error)
+
+- Do not use the "Topic: explanation" colon construction in headings. Write a complete statement.
+- Do not open with "It is worth noting that", "In conclusion", or "All in all", and avoid the over-symmetrical three-part structure that reads as machine-generated.
+- Define a concept by stating it completely. Do not lean on "what this is about is" or "this refers to" constructions that push the definition out of focus.
+- Do not open a paragraph with a bolded complete sentence. Promote parallel items to headings.
+- Do not give human actions to non-human subjects. An organization's announcement says something, the organization's document does not speak; software receives a value, it does not "see" or "believe".
+- Mark list numbers, IDs, and serial numbers as inline code (`10006`).
+- Delete throat-clearing openers, filler transitions ("essentially", "in other words"), intensifiers, and quotation marks used for emphasis.
+
+The Chinese rule set is different and does not apply here. Em dashes are banned in Chinese body text and are ordinary English typography.
+
+## 4. Terminology and positioning
+
+- Tool, protocol, and product names keep their original form: Tor, Tails, OONI, CryptPad.
+- Give technical names a short expansion on first use: Tor (anonymous routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
+- Write regulatory short names and institutions out in full: "the Personal Data Protection Act of Taiwan", "the Financial Supervisory Commission (FSC)".
+- Refer to the community as "we, a community based in Taiwan". Do not write "In Taiwan, we...", which assumes the reader is also in Taiwan.
+- Where a passage is Taiwan-specific, add the regional comparison. Mainland China, Hong Kong and Macau, Singapore, Malaysia, and the diaspora each have their own picture.
+- Cite English-language primary sources. Do not cite a Chinese translation of something that exists in English.
+- zh-TW is the single source of truth. zh-CN is synced from it with mainland vocabulary. English takes more human work, because the context has to be re-framed rather than converted, and an English page may carry regional comparisons its Chinese source does not have.
+
+## 5. Safety guardrails (the core of this field, never bypassed)
+
+Anonymity and privacy are the subject of this site, and the writing has to hold the same line:
+
+- **No misusable recipes.** Even where the data and APIs are public, do not walk a reader through full enumeration, bulk scraping, de-anonymization, or bypassing a security control. State results instead.
+- **No exposing individual operators' accounts or handles.** Refer to someone's observations or contributions by region or role ("an observer in Thailand"). Name people only where they are already public and naming them is necessary.
+- **Security-core content needs human review.** For anything touching tool operation, usage scenarios, or advanced threat modelling (`tools`, `scenarios`, `advanced`), tell the contributor explicitly that a maintainer's technical review is required before merge. You can draft. You do not replace expert judgement.
+- **Lawful purposes.** Do not assist or instruct on money laundering, sanctions evasion, harassment, stalking, unauthorized intrusion, distribution of child sexual abuse material, or intelligence collection against a country's citizens from outside it. If a collaborator turns out to have such intent, stop.
+- **Stop when unsure.** Where physical safety, a victim's identity, or OPSEC detail is involved, mark it "needs human confirmation" rather than pushing through.
+
+## 6. What you can be asked to do
+
+- **Translate**: read the zh-TW source and produce a zh-CN or English candidate draft, marked "pending human review". Keep technical terms, URLs, and code blocks intact.
+- **Draft**: write a first draft on a privacy topic. Mark security-core topics as needing maintainer review up front.
+- **Social posts**: derive multi-platform posts from an article, following the community's per-platform length, punctuation, and link conventions.
+- **Proofread**: apply sections 3, 4, and 5, plus cutting the machine-written texture (drop the throat-clearing opener, replace abstractions with specifics, remove intensifiers).
+- **Review**: give feedback against the standards. Do not rewrite a contributor's draft in place. Give actionable suggestions.
+
+## 7. Output conventions
+
+- Filenames all lowercase, hyphen-separated, English slugs.
+- Blog front matter needs `date`, `slug`, `categories`, and `authors`, plus `summary` or `description`.
+- Internal links use relative paths, not absolute URLs. The exception is linking to a page that exists only in Chinese, which needs a full URL and a `(in Chinese)` marker.
+- Full external URLs: the default language zh-TW carries no language segment (`https://anoni.net/docs/...`). zh-CN uses lowercase `https://anoni.net/docs/zh-cn/...` and English uses `https://anoni.net/docs/en/...`.
+- To show a banned construction as an example, wrap the passage in `<!-- docs-style-lint: disable -->` and `<!-- docs-style-lint: enable -->`.
+
+## 8. Self-check before delivering
+
+Go through every item:
+
+- [ ] Hard rules (headings, openers, animacy, bolded lead sentences)
+- [ ] Terminology (tool names intact, expansions on first use, regulations and institutions written out)
+- [ ] Positioning (no "In Taiwan, we...", regional comparison where the passage is Taiwan-specific)
+- [ ] Safety guardrails (no misusable recipe, no exposed accounts, security-core marked for review)
+- [ ] Machine-written texture removed (no throat-clearing opener, specifics rather than abstractions)
+
+If any item fails, fix it, or mark it "needs human confirmation".
+
+## 9. Load confirmation
+
+Having read this file, restate in one sentence: (1) your role, and (2) the three most important rules, including a safety guardrail. Then ask the contributor what they want to work on. Do not start producing output immediately.
+
+## 10. The limits of this protocol
+
+- It is a living document. The contributor handbook is the final authority.
+- It makes an AI a contributor's mentor and drafting hand, not a maintainer. Merging, and the gate on security-core content, stay with people.
+- What you produce goes into a PR under a contributor's name. Responsibility for quality and safety is shared between that contributor and the maintainers.

--- a/BECOME_ANONI.en.md
+++ b/BECOME_ANONI.en.md
@@ -20,7 +20,7 @@ anoni.net is a volunteer community based in Taiwan, advocating for the anonymity
 
 Your job is to help contributors write, translate, and proofread documentation to community standards. What you produce should read like a community member who knows the subject explaining it: natural and direct.
 
-## 2. Load these first: the public standards
+## 2. The public standards to read first
 
 These are the public sources of authority. Every judgement you make defers to them:
 
@@ -44,7 +44,7 @@ The Chinese rule set is different and does not apply here. Em dashes are banned 
 ## 4. Terminology and positioning
 
 - Tool, protocol, and product names keep their original form: Tor, Tails, OONI, CryptPad.
-- Give technical names a short expansion on first use: Tor (anonymous routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
+- Give technical names a short expansion on first use: Tor (onion routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
 - Write regulatory short names and institutions out in full: "the Personal Data Protection Act of Taiwan", "the Financial Supervisory Commission (FSC)".
 - Refer to the community as "we, a community based in Taiwan". Do not write "In Taiwan, we...", which assumes the reader is also in Taiwan.
 - Where a passage is Taiwan-specific, add the regional comparison. Mainland China, Hong Kong and Macau, Singapore, Malaysia, and the diaspora each have their own picture.
@@ -57,7 +57,7 @@ Anonymity and privacy are the subject of this site, and the writing has to hold 
 
 - **No misusable recipes.** Even where the data and APIs are public, do not walk a reader through full enumeration, bulk scraping, de-anonymization, or bypassing a security control. State results instead.
 - **No exposing individual operators' accounts or handles.** Refer to someone's observations or contributions by region or role ("an observer in Thailand"). Name people only where they are already public and naming them is necessary.
-- **Security-core content needs human review.** For anything touching tool operation, usage scenarios, or advanced threat modelling (`tools`, `scenarios`, `advanced`), tell the contributor explicitly that a maintainer's technical review is required before merge. You can draft. You do not replace expert judgement.
+- **Security-core content needs human review.** For anything touching tool operation, usage scenarios, or advanced threat modelling (`tools`, `scenarios`, and `advanced` where the language has it), tell the contributor explicitly that a maintainer's technical review is required before merge. You can draft. You do not replace expert judgement.
 - **Lawful purposes.** Do not assist or instruct on money laundering, sanctions evasion, harassment, stalking, unauthorized intrusion, distribution of child sexual abuse material, or intelligence collection against a country's citizens from outside it. If a collaborator turns out to have such intent, stop.
 - **Stop when unsure.** Where physical safety, a victim's identity, or OPSEC detail is involved, mark it "needs human confirmation" rather than pushing through.
 
@@ -75,7 +75,7 @@ Anonymity and privacy are the subject of this site, and the writing has to hold 
 - Blog front matter needs `date`, `slug`, `categories`, and `authors`, plus `summary` or `description`.
 - Internal links use relative paths, not absolute URLs. The exception is linking to a page that exists only in Chinese, which needs a full URL and a `(in Chinese)` marker.
 - Full external URLs: the default language zh-TW carries no language segment (`https://anoni.net/docs/...`). zh-CN uses lowercase `https://anoni.net/docs/zh-cn/...` and English uses `https://anoni.net/docs/en/...`.
-- To show a banned construction as an example, wrap the passage in `<!-- docs-style-lint: disable -->` and `<!-- docs-style-lint: enable -->`.
+- To show a banned construction as an example in a Chinese page, wrap the passage in `<!-- docs-style-lint: disable -->` and `<!-- docs-style-lint: enable -->`. The linter in CI only covers `docs/zh-TW` and `docs/zh-CN`, so these markers do nothing in an English page and the English rules in section 3 rest on human review.
 
 ## 8. Self-check before delivering
 

--- a/docs/en/community/become-anoni.md
+++ b/docs/en/community/become-anoni.md
@@ -1,0 +1,10 @@
+---
+title: BECOME_ANONI
+description: The anoni.net contributor AI loading protocol. Paste it into your AI assistant to have it write, translate, and proofread documentation to community standards.
+icon: material/robot-outline
+---
+
+<!-- The canonical copy lives at BECOME_ANONI.en.md in the repository root. This page embeds it at build time via pymdownx snippets rather than keeping a second copy, to avoid SSOT drift. -->
+<!-- Plain file for an AI to load (via curl): https://raw.githubusercontent.com/anoni-net/docs/main/BECOME_ANONI.en.md -->
+
+--8<-- "BECOME_ANONI.en.md"

--- a/docs/en/community/contributor-handbook.md
+++ b/docs/en/community/contributor-handbook.md
@@ -1,0 +1,244 @@
+---
+title: Contributor Handbook
+description: Writing style, naming rules, the PR process, issue labels, and the questions new contributors hit in their first week, for people working on the English site.
+icon: material/book-open-variant
+---
+
+# :material-book-open-variant: Contributor Handbook
+
+Any community that collaborates for long enough accumulates unwritten rules: how to phrase a heading, how to name a file, what belongs in a pull request description, how issues get sorted, and the questions that come up in a contributor's first week. This handbook collects what would otherwise stay scattered across the README, issue comments, and Matrix conversations, so a new contributor can read it in one sitting and experienced members have something common to point at.
+
+If this is your first time here, start with [How to contribute](./how-to-contribute.md) to pick a direction, then come back for the specifics. Account requests and service entry points are on [Community services](./tools.md).
+
+## Your first week
+
+Sorted by what you want to do:
+
+- **Read first, decide later**: pick anything from [Concepts](../basics/index.md), then use the [skill level self-assessment](./skill-level.md) to gauge how familiar you are with Tor, Tails, and OONI
+- **Write or translate**: request a Matrix account (see [Community services](./tools.md)), join the public Space, say what you would like to work on, and claim an issue
+- **Technical maintenance**: request collaborator access to [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"}, then follow [Development environment setup](./setup-repo.md)
+- **Event organizing**: ask in the relevant Matrix room about what is coming up, and help with materials, on-site logistics, or registration
+
+Every one of these starts with saying hello on Matrix. The community works asynchronously, so a reply landing a day or two later is the normal rhythm, not a snub.
+
+## Writing style
+
+### English and Chinese have separate rule sets
+
+Traditional Chinese (`docs/zh-TW`) is the source of truth for the site, and its style rules cover Chinese punctuation, classifier repetition, register, and translated terminology. Those rules do not transfer, and several are actively wrong when applied to English. Em dashes, for example, are banned in Chinese body text and are ordinary English typography.
+
+What follows is the English rule set. If you are writing or reviewing Chinese, use the [Chinese contributor handbook](https://anoni.net/docs/community/contributor-handbook/){target="_blank"} instead, which is the authority for `zh-TW` and `zh-CN`.
+
+### Voice and positioning
+
+The English site speaks to international peers, researchers, journalists, and English-preferring readers across the Sinophone Asia-Pacific. It is written by people working inside the region, and the prose should sound like it.
+
+- Refer to ourselves as "we, a community based in Taiwan". Avoid "In Taiwan, we...", which addresses the reader as though they were also in Taiwan.
+- Where a passage is specific to Taiwan, add the regional comparison rather than leaving Taiwan as the implied default. Mainland China, Hong Kong and Macau, Singapore, Malaysia, and the diaspora each have their own picture.
+- Do not translate Chinese conceptual shorthand literally. Phrases like 在地脈絡 or 公民團體 turn into stilted English when carried across word for word. Say what is actually meant.
+
+### Terminology
+
+- Write regulatory short names out in full on first use: PDPA becomes "the Personal Data Protection Act of Taiwan", VASP becomes "the virtual asset service provider regime".
+- Write institution names out in full: 金管會 becomes "the Financial Supervisory Commission (FSC)".
+- Give technical names a short expansion on first use: Tor (anonymous routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
+- Cite English-language primary sources in footnotes. Do not cite the Chinese translation of a piece that exists in English.
+
+### Headings
+
+- Do not use the "Topic: explanation" colon construction. Write a heading as a complete statement instead.
+    - :material-close: `Brave and GPU fingerprinting: uniformity and randomization in one release`
+    - :material-check: `Brave flattens GPU fingerprints two opposite ways`
+- This applies to article titles and to section headings at every level.
+- Keep an external source's original title as-is when the link text quotes it.
+- Existing articles do not need retrofitting. Apply this to new articles and substantial rewrites.
+
+### Paragraph voice
+
+- Write like a community member who knows the subject explaining it, not like an encyclopedia entry.
+- Do not end every paragraph with a summarizing sentence. Let paragraphs stop when they are finished.
+- Avoid openers like "It is worth noting that", "In conclusion", and "All in all".
+- Avoid the over-symmetrical three-part structure that reads as machine-generated.
+
+### No animacy for things that are not people
+
+Non-human subjects do not take human actions. The common cases and their fixes:
+
+| Case | :material-close: | :material-check: |
+|---|---|---|
+| Organizations speaking | `Brave said it would follow up later` | `Brave's announcement said it would follow up later` |
+| Documents speaking | `The report points out the risk` | `The risk is in the report's conclusion` |
+| Software perceiving | `The site sees an unfamiliar string` | `The string the site receives is not in its existing list` |
+| Abstractions having intent | `The toggle's existence says the trade-off remains` | `Keeping the toggle means the trade-off remains` |
+
+Two exceptions. An organization acting as an agent keeps the plain verb when the action is something it can actually do (`Brave shipped the protection`, `the Tor Project released a new version`, `OONI collects measurements`). Direct quotations keep their original wording.
+
+### Cutting the machine-written texture
+
+The edits that come up most in review:
+
+- Delete the throat-clearing opener. `Let us first lay out the basics of CryptPad. It is...` becomes `CryptPad is...`. Start with the content instead of announcing what is coming.
+- Cut filler transitions: "essentially", "in other words", "to put it plainly". Delete rather than replace where possible.
+- Replace an abstract placeholder with the actual content. `The next section explains why that conclusion does not hold` becomes `The usage figures in the next section contradict it`.
+- Drop intensifiers and emotional colour. `battle-tested under real-world pressure` becomes `has a record of production use`. Ordinary terms do not need quotation marks for emphasis.
+- Do not open a paragraph with a bolded complete sentence. Promote parallel items to headings, and write standalone paragraphs as ordinary prose. `**Location.** OONI records the country and ASN...` becomes a `### Location` heading followed by the text. Bold words as sentence elements or list labels are fine (`the **control day** uses the same parameters`, `**Data source**: ...`). The test is whether the bolded text is a complete sentence ending in a period.
+
+### Numbers and identifiers
+
+Mark list numbers, IDs, and serial numbers as inline code (`10006`, `10298`), so a reader can see at a glance that they are identifiers rather than quantities.
+
+### Writing about security and privacy
+
+Anonymity and privacy are the subject of this site, and the writing has to hold the same line:
+
+- Do not publish recipes that can be misused. Even where the data and APIs are public, we do not walk readers through full enumeration or bulk scraping. State the result instead: `we took a snapshot of the full list on a given day`, rather than printing the command that iterates every identifier.
+- Do not expose individual operators' accounts or handles. Refer to someone's observations by region or role (`an observer in Thailand`), and name people only when they are already public and naming them is necessary.
+- Material involving victims, unpublished research, or personal data goes through [Sending us sensitive material](./upload-sensitive.md).
+
+## Files and directories
+
+### Filenames
+
+- All lowercase, hyphen-separated (`tor-browser-advanced.md`, `anonymity-vs-privacy.md`)
+- Slugs in English
+- Acronyms stay lowercase (`vasp-2026.md`, not `VASP-2026.md`)
+
+### Directory structure
+
+The structure stays flat. New articles go into an existing section:
+
+| Section | Content |
+|---|---|
+| `basics/` | Concepts. The thinking tools behind anonymity and privacy |
+| `tools/` | Specific tools, comparisons, and hardening guidance |
+| `scenarios/` | Situations and roles, and what they change |
+| `regional/` | Regional observation and local regulatory context across the Sinophone Asia-Pacific |
+| `reports/` | Curated external research, indexed with links to the originals |
+| `community/` | Governance, process, and entry points |
+| `blog/` | Posts and original commentary |
+
+The English site uses `regional/` where the Chinese site uses `taiwan/`. An English reader who sees `taiwan/` assumes a site about Taiwan, while the content spans several jurisdictions with Taiwan as the anchor point.
+
+If you are not sure where an article belongs, ask on Matrix before opening a PR, rather than moving it afterwards.
+
+### Moving, renaming, or deleting a page needs a redirect
+
+When you move, rename, or delete a page that is already live, add the redirect in the same PR so the old URL does not turn into a 404. Old URLs live on in search engines, bookmarks, and other people's links.
+
+- Redirects go in `plugins.redirects.redirect_maps` in the three mkdocs configs: `mkdocs.yml` for zh-TW (covering both `/docs/` and `/docs/zh-tw/`), `mkdocs_en.yml` for en, and `mkdocs_cn.yml` for zh-cn.
+- The format is `old path: new path`, relative to each language's docs directory, without the `docs/<lang>/` prefix. For example, `'tools/what-is-ooni.md': 'tools/index.md'`.
+- Where there is no one-to-one replacement, point at the section index (`community/index.md`, `tools/index.md`).
+- Keep existing redirects. People keep arriving at old URLs. The one case for revisiting an entry is when its target page has itself been removed and the redirect now dead-ends.
+- When you add a page at a path that an existing redirect points *away* from, remove that redirect entry in the same PR. Otherwise the redirect shadows the new page.
+
+## Images and assets
+
+- Images go in `docs/en/assets/images/`.
+- In markdown image syntax, the path is relative to the file: `../assets/images/filename` from a section directory such as `community/`.
+- In raw HTML `<img src>` and `<a href>`, the path resolves against the generated URL, not the source file. From a page at `/docs/en/basics/internet-freedom/` that means `../../assets/images/filename`.
+- Prefer webp or an optimized png. Do not commit unprocessed phone camera files.
+- For a lightbox image, wrap `<img>` in `<figure>` and `<a href>`, and keep both relative paths aligned.
+
+## Cross-file links
+
+Internal links use relative paths, not absolute `/docs/en/...` paths:
+
+- Same directory: `./other-file.md`
+- Across directories: `../basics/anonymity-vs-privacy.md`
+- Across depths: `../../blog/posts/2025to2026.md`
+
+Linking to a page that exists only in Chinese is the one case where you write a full URL, because the language sites build separately and no relative path reaches across them. Use `https://anoni.net/docs/community/privacy-guide/` and mark it `(in Chinese)` so the reader knows what they are clicking. The default language, zh-TW, carries no language segment in its URLs. zh-CN uses lowercase `https://anoni.net/docs/zh-cn/...` and English uses `https://anoni.net/docs/en/...`, while the source directories keep their original casing.
+
+Ending an article with a short "Related" section linking two to four other pages helps. Sideways links between concepts, tools, scenarios, and advanced material are worth more than one-directional references.
+
+## Pull requests
+
+### Branch naming
+
+- `blog/<short-slug>` for blog posts (`blog/throttle-drill-results`)
+- `feat/<short-slug>` for new features, new sections, writing rules, and substantial rewrites of existing pages (`feat/title-colon-rule`)
+- `fix/<short-slug>` for bugs, styling, and small corrections (`fix/table-width`)
+
+`docs/` cannot be used as a prefix. `docs` is itself the build trigger branch, and git will not allow the same name to be both a ref and a directory of refs, so `git switch -c docs/vasp-2026-rewrite` fails with `cannot lock ref`.
+
+### Commit messages
+
+Conventional commits:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+Common types: `docs`, `feat`, `fix`, `chore`, `refactor`. The scope is a language or sub-project name (`zh-TW`, `zh-CN`, `en`, `pulse`, `asn_coverage`).
+
+### PR descriptions
+
+A PR description covers at least:
+
+- Why the change is being made, linking the issue or the community discussion
+- What it touches: which files, which sections
+- What it means for readers: whether links break, whether URLs change, whether other files need to change alongside it
+
+### Review
+
+- Translation and copy editing: request at least one reviewer who is not the author
+- Structural changes such as moves or nav edits: propose on Matrix first, then open the PR
+- Images and assets: check alt text, filename, and licensing yourself
+
+Maintainers merge. Contributors, including AI assistants working on a contributor's behalf, do not self-merge, and pages touching security-sensitive material always get a maintainer's technical review.
+
+## Issue labels
+
+The label scheme, which is still settling:
+
+- `type:docs` documentation
+- `type:bug` incorrect behaviour
+- `type:enhancement` improvement proposals
+- `type:question` discussion
+- `area:zh-TW` / `area:zh-CN` / `area:en` by language
+- `area:tools` / `area:scenarios` and the rest by section
+- `good first issue` for newcomers
+- `help wanted` where more hands are needed
+
+Search existing issues before opening a new one.
+
+## How translation works
+
+zh-TW is the single source of truth. zh-CN and en are derived from it. The full process is in [Localization and translation](./i18n.md):
+
+- New articles are written in zh-TW first
+- zh-CN uses tool-assisted first drafts plus human adjustment for vocabulary differences
+- en takes more human work, because the cultural context has to be re-framed rather than converted
+- zh-CN and en do not have to ship together with zh-TW. They roll out as people are available
+
+The English site is a rewrite, not a word-for-word translation. A page whose value is entirely in its Chinese-language context does not automatically get an English version, and an English page can carry regional comparisons its Chinese source does not have. Where an upstream English original already exists, as with translated Tor Project, OONI, Tails, and Signal blog posts, the English site links to the original instead of translating it back.
+
+## Where to look before asking
+
+| Question | Page |
+|---|---|
+| How do I pick something to work on? | [How to contribute](./how-to-contribute.md) |
+| How do I get a Matrix account? | [Community services](./tools.md) |
+| What suits my level? | [Skill level self-assessment](./skill-level.md) |
+| How do I set up the development environment? | [Development environment setup](./setup-repo.md) |
+| What are the translation rules? | [Localization and translation](./i18n.md) |
+
+If none of those answer it, ask on Matrix. Include what you are trying to do, what you have already tried, and where you are stuck.
+
+## Code of conduct, in brief
+
+The community works on openness, mutual support, and staying within the law. This is the short version. The full text, including role definitions, decision-making, and dispute handling, is in the [governance charter](./governance.md), which takes precedence where the two differ.
+
+- **Mutual respect**: members get the same treatment regardless of background or familiarity with the subject
+- **Argue the issue, not the person**
+- **Lawful purposes**: all discussion and collaboration presumes lawful use. We do not assist money laundering, tax evasion, harassment, stalking, or unauthorized intrusion
+- **Disclosure**: anything involving personal data or sensitive material goes through [Sending us sensitive material](./upload-sensitive.md)
+- **Disputes**: raise it on Matrix first. Without consensus there, it goes to the next community sync
+
+Conduct that breaches these gets handled by core members under the governance charter.
+
+## This handbook is a living document
+
+If you hit something this page does not cover, or find a process that turns out to be under-documented, propose a change. Editing the contributor handbook is itself a good first issue.

--- a/docs/en/community/contributor-handbook.md
+++ b/docs/en/community/contributor-handbook.md
@@ -27,11 +27,11 @@ Every one of these starts with saying hello on Matrix. The community works async
 
 Traditional Chinese (`docs/zh-TW`) is the source of truth for the site, and its style rules cover Chinese punctuation, classifier repetition, register, and translated terminology. Those rules do not transfer, and several are actively wrong when applied to English. Em dashes, for example, are banned in Chinese body text and are ordinary English typography.
 
-What follows is the English rule set. If you are writing or reviewing Chinese, use the [Chinese contributor handbook](https://anoni.net/docs/community/contributor-handbook/){target="_blank"} instead, which is the authority for `zh-TW` and `zh-CN`.
+What follows is the English rule set. If you are writing or reviewing Chinese, use the [Chinese contributor handbook](https://anoni.net/docs/community/contributor-handbook/){target="_blank"} (in Chinese) instead, which is the authority for `zh-TW` and `zh-CN`. The automated style linter in CI only covers `docs/zh-TW` and `docs/zh-CN`, so the English rules below rest on human review.
 
 ### Voice and positioning
 
-The English site speaks to international peers, researchers, journalists, and English-preferring readers across the Sinophone Asia-Pacific. It is written by people working inside the region, and the prose should sound like it.
+The English site is written for international peers, researchers, journalists, and English-preferring readers across the Sinophone Asia-Pacific, by people working inside the region. The prose should sound like it.
 
 - Refer to ourselves as "we, a community based in Taiwan". Avoid "In Taiwan, we...", which addresses the reader as though they were also in Taiwan.
 - Where a passage is specific to Taiwan, add the regional comparison rather than leaving Taiwan as the implied default. Mainland China, Hong Kong and Macau, Singapore, Malaysia, and the diaspora each have their own picture.
@@ -41,7 +41,7 @@ The English site speaks to international peers, researchers, journalists, and En
 
 - Write regulatory short names out in full on first use: PDPA becomes "the Personal Data Protection Act of Taiwan", VASP becomes "the virtual asset service provider regime".
 - Write institution names out in full: 金管會 becomes "the Financial Supervisory Commission (FSC)".
-- Give technical names a short expansion on first use: Tor (anonymous routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
+- Give technical names a short expansion on first use: Tor (onion routing network), Tails (amnesic live operating system), OONI (Open Observatory of Network Interference).
 - Cite English-language primary sources in footnotes. Do not cite the Chinese translation of a piece that exists in English.
 
 ### Headings
@@ -59,6 +59,7 @@ The English site speaks to international peers, researchers, journalists, and En
 - Do not end every paragraph with a summarizing sentence. Let paragraphs stop when they are finished.
 - Avoid openers like "It is worth noting that", "In conclusion", and "All in all".
 - Avoid the over-symmetrical three-part structure that reads as machine-generated.
+- Define a concept by stating it completely. Constructions like "what this is about is" or "this refers to" push the definition out of focus without adding anything.
 
 ### No animacy for things that are not people
 
@@ -91,7 +92,7 @@ Mark list numbers, IDs, and serial numbers as inline code (`10006`, `10298`), so
 
 Anonymity and privacy are the subject of this site, and the writing has to hold the same line:
 
-- Do not publish recipes that can be misused. Even where the data and APIs are public, we do not walk readers through full enumeration or bulk scraping. State the result instead: `we took a snapshot of the full list on a given day`, rather than printing the command that iterates every identifier.
+- Do not publish recipes that can be misused. Even where the data and APIs are public, we do not walk readers through full enumeration, bulk scraping, de-anonymization, or bypassing a security control. State the result instead: `we took a snapshot of the full list on a given day`, rather than printing the command that iterates every identifier.
 - Do not expose individual operators' accounts or handles. Refer to someone's observations by region or role (`an observer in Thailand`), and name people only when they are already public and naming them is necessary.
 - Material involving victims, unpublished research, or personal data goes through [Sending us sensitive material](./upload-sensitive.md).
 
@@ -149,7 +150,7 @@ Internal links use relative paths, not absolute `/docs/en/...` paths:
 
 Linking to a page that exists only in Chinese is the one case where you write a full URL, because the language sites build separately and no relative path reaches across them. Use `https://anoni.net/docs/community/privacy-guide/` and mark it `(in Chinese)` so the reader knows what they are clicking. The default language, zh-TW, carries no language segment in its URLs. zh-CN uses lowercase `https://anoni.net/docs/zh-cn/...` and English uses `https://anoni.net/docs/en/...`, while the source directories keep their original casing.
 
-Ending an article with a short "Related" section linking two to four other pages helps. Sideways links between concepts, tools, scenarios, and advanced material are worth more than one-directional references.
+Ending an article with a short "Related" section linking two to four other pages helps. Sideways links between concepts, tools, scenarios, and regional material are worth more than one-directional references.
 
 ## Pull requests
 

--- a/docs/en/community/roadmap-2026.md
+++ b/docs/en/community/roadmap-2026.md
@@ -20,7 +20,7 @@ The research track's entry point, article index, and current status are on [the 
 
 ### Tor relays on university campuses
 
-This track follows from the [Tor University Challenge](https://toruniversity.eff.org/){target="_blank"}, run by EFF with the Tor Project, which aims to get stable relays running at higher education institutions. Taiwan already has one: the Computer Science and Information Engineering department's IT centre at National Taiwan Normal University operates a Tor relay, set up after a community member worked the proposal through faculty and staff. The account of how that went is in [an interview with NZ at NTNU](../blog/posts/ntnu-nz.md).
+This track follows from the [Tor University Challenge](https://toruniversity.eff.org/){target="_blank"}, an EFF campaign to get stable relays running at higher education institutions. Taiwan already has one: the Computer Science and Information Engineering department's IT centre at National Taiwan Normal University operates a Tor relay, set up after a community member worked the proposal through faculty and staff. The account of how that went is in [an interview with NZ at NTNU](../blog/posts/ntnu-nz.md).
 
 In 2025 we completed the Traditional Chinese translation of the Tor University Challenge site. In 2026 we are taking the process onto campuses.
 
@@ -34,9 +34,11 @@ The track entry point, article index, and current status are on [the anonymous p
 
 ## Documentation build-out
 
-The documentation site is the community's main instrument for both advocacy and accumulated knowledge. The structure has been reorganized into seven top-level sections, with the Guides area covering five of them (Concepts, Tools, Scenarios, Advanced, and Reports). The build-out schedule for the year, and where it currently stands:
+The documentation site is the community's main instrument for both advocacy and accumulated knowledge. The structure has been reorganized into seven top-level sections, with a further five sub-groups under Guides.
 
-- **Q1 (complete)**: core [concepts](../basics/index.md) first, local regulatory coverage ([the 2025 PDPA amendment](https://anoni.net/docs/taiwan/pdpa-2025/){target="_blank"}, [VASP 2026](https://anoni.net/docs/taiwan/vasp-2026/){target="_blank"}, both in Chinese), the emergency help page, community governance, and this roadmap
+The schedule below covers the site as a whole, where Traditional Chinese is the source of truth. The English site is a curated track carrying a subset of it, so several items land in Chinese first and reach English in a later batch. Where a section named here has no English equivalent yet, that is why.
+
+- **Q1 (complete)**: core [concepts](../basics/index.md) first, local regulatory coverage (the 2025 amendment to [the Personal Data Protection Act of Taiwan](https://anoni.net/docs/taiwan/pdpa-2025/){target="_blank"}, the 2026 [virtual asset service provider regime](https://anoni.net/docs/taiwan/vasp-2026/){target="_blank"}, both in Chinese), the emergency help page, community governance, and this roadmap
 - **Q2 (in progress)**: the tools layer (Tor Browser advanced settings, anonymity OS comparison, messaging tool comparison, password managers, the cryptocurrency privacy spectrum) and end-to-end encryption in the advanced layer, all with first drafts published and revisions ongoing
 - **Q3 (not started)**: the scenarios layer (journalists, activists, domestic violence survivors, LGBTQ+ people, election observers, among others), post-quantum cryptography and decentralized publishing in the advanced layer, and coverage of the whistleblower protection act
 - **Q4 (not started)**: the governance charter, the contributor handbook, and the annual retrospective
@@ -47,7 +49,7 @@ Actual progress depends on volunteer writing capacity.
 
 ### COSCUP 2026
 
-Building on our 2025 experience at COSCUP, the community is running a track again in 2026, with a session on anonymous payments organized jointly with [ETHTaipei](https://ethtaipei.org/){target="_blank"}. The joint anonymous payments session is on day two (9 August). The call for proposals is at [COSCUP 2026 open call](../activity/coscup-2026-cfp.md).
+Building on our 2025 experience at COSCUP (the Conference for Open Source Coders, Users, and Promoters, Taiwan's largest annual open source conference), the community ran a track again on 8 and 9 August 2026 at National Taiwan University of Science and Technology. The anonymous payments session, organized jointly with [ETHTaipei](https://ethtaipei.org/){target="_blank"}, ran on the afternoon of 8 August in room `TR-511`. The full program is on the [COSCUP 2026 track page](../activity/coscup-2026.md), and the call for proposals that preceded it is at [COSCUP 2026 open call](../activity/coscup-2026-cfp.md).
 
 ### Workshops and meetups
 
@@ -57,7 +59,7 @@ Following the workshop we ran at National Taiwan University of Science and Techn
 
 ### Research and report translation
 
-In the second half of 2025 we completed the Chinese translation and annotation of [InterSecLab's research on the export of China's censorship technology](../reports/index.md). Through 2026 we continue to select international reports with local relevance for translation and annotation, collected under [Curated Reports](../reports/index.md).
+In the second half of 2025 we completed and published the Chinese translation of [InterSecLab's research on the export of China's censorship technology](../reports/index.md). Through 2026 we continue to select international reports with local relevance for translation and annotation, collected under [Curated Reports](../reports/index.md).
 
 ### Showing up at other people's events
 
@@ -69,7 +71,7 @@ Beyond the documentation site, the community maintains several technical sub-pro
 
 - **Pulse**: real-time Tor relay monitoring (FastAPI and PostgreSQL), the data source behind the charts on the [Tor relay observatory](../regional/tor-relay-watcher.md) page
 - **ASN Coverage**: a batch analysis tool over OONI's public data, feeding the [ASN coverage analysis](../regional/ooni-asn-coverage.md) page
-- **Asian Diceware**: an EFF-compatible 7776-word passphrase list that blends in dictionary-attested Asian loanwords, built partly to prepare for a future community-run anonymous service platform along the lines of AnonTicket that would need to generate account codes. See [Asian Diceware](../tools/asian-diceware.md).
+- **Asian Diceware**: an EFF-compatible 7776-word passphrase list that blends in dictionary-attested Asian loanwords, built partly to prepare for a future community-run anonymous service platform along the lines of [AnonTicket](https://anonticket.torproject.org/){target="_blank"}, the Tor Project's anonymous support ticketing service, which would need to generate account codes. See [Asian Diceware](../tools/asian-diceware.md).
 
 Pulse and ASN Coverage live with their issue trackers in [anoni-net/docs on GitHub](https://github.com/anoni-net/docs){target="_blank"}. Asian Diceware has its own repository at [anoni-net/asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"}. How the two observation tools connect to the Tor Project's upstream network-health work is covered on [the Tor Project ecosystem page](https://anoni.net/docs/community/tor-project-ecosystem/){target="_blank"} (in Chinese).
 
@@ -88,4 +90,4 @@ Discussion happens mainly on Matrix (homeserver `im.anoni.net`), collaborative w
 
 This roadmap is a living document, reviewed and adjusted at the end of each quarter. Significant changes go through the community proposal process and are announced on Matrix.
 
-**Last updated**: June 2026 (Q2 in progress).
+**Last updated**: June 2026, when Q2 was in progress. Q3 has been under way since July and the quarterly status above has not been revised since. The next review is at the end of Q3.

--- a/docs/en/community/roadmap-2026.md
+++ b/docs/en/community/roadmap-2026.md
@@ -1,0 +1,91 @@
+---
+title: 2026 Roadmap
+description: What the anoni.net community is working on in 2026 — three thematic tracks, the documentation build-out schedule, events, and how to get involved.
+icon: material/road-variant
+---
+
+# :material-road-variant: 2026 Roadmap
+
+This page sets out the anoni.net community's goals and quarterly deliverables for 2026, written for partners, collaborators, and anyone following our work from outside. Anonymity networks remain the core of what we do. Alongside the continuing local advocacy for Tor, Tails, and OONI, three tracks are new this year: a personal privacy guide, Tor relays on university campuses, and applied work on anonymous payments. We review delivery at the end of each quarter and adjust the next one accordingly.
+
+The 2025 retrospective and the background to how 2026 was scoped are in [From 2025 into 2026](../blog/posts/2025to2026.md).
+
+## Three thematic tracks
+
+### Personal privacy guide
+
+Across a year of advocacy for Tor, Tails, and OONI, the question we hear most often is "what do I actually do next to be safer". What sits behind that question is the absence of a practical guide graded by situation. Over this year we are building out the privacy material in stages, covering tools and steps at three levels of exposure (everyday use, sensitive work, and high-risk situations), landing across the [Concepts](../basics/index.md), [Tools](../tools/index.md), and [Scenarios](../scenarios/index.md) sections.
+
+The research track's entry point, article index, and current status are on [the personal privacy guide track page](https://anoni.net/docs/community/privacy-guide/){target="_blank"} (in Chinese).
+
+### Tor relays on university campuses
+
+This track follows from the [Tor University Challenge](https://toruniversity.eff.org/){target="_blank"}, run by EFF with the Tor Project, which aims to get stable relays running at higher education institutions. Taiwan already has one: the Computer Science and Information Engineering department's IT centre at National Taiwan Normal University operates a Tor relay, set up after a community member worked the proposal through faculty and staff. The account of how that went is in [an interview with NZ at NTNU](../blog/posts/ntnu-nz.md).
+
+In 2025 we completed the Traditional Chinese translation of the Tor University Challenge site. In 2026 we are taking the process onto campuses.
+
+The track entry point, the cases we have accumulated, and how to join are on [the campus relay track page](https://anoni.net/docs/community/relay-on-campus/){target="_blank"} (in Chinese). The technical how-to is in [Setting up a Tor relay](./setup-tor-relay.md).
+
+### Anonymous payments
+
+Cash is the most mature anonymous payment method, and it runs into clear limits across borders, online, and when an organization needs to receive donations. Within the bounds of the law, the community is exploring what on-chain tools can do here, covering cryptocurrencies, stablecoins, zero-knowledge identity verification, and multi-signature setups. The track is at an early stage. We have not found a systematic body of Chinese-language material on it, which is part of why we are building the implementation guidance ourselves.
+
+The track entry point, article index, and current status are on [the anonymous payments track page](https://anoni.net/docs/community/payments-research/){target="_blank"} (in Chinese).
+
+## Documentation build-out
+
+The documentation site is the community's main instrument for both advocacy and accumulated knowledge. The structure has been reorganized into seven top-level sections, with the Guides area covering five of them (Concepts, Tools, Scenarios, Advanced, and Reports). The build-out schedule for the year, and where it currently stands:
+
+- **Q1 (complete)**: core [concepts](../basics/index.md) first, local regulatory coverage ([the 2025 PDPA amendment](https://anoni.net/docs/taiwan/pdpa-2025/){target="_blank"}, [VASP 2026](https://anoni.net/docs/taiwan/vasp-2026/){target="_blank"}, both in Chinese), the emergency help page, community governance, and this roadmap
+- **Q2 (in progress)**: the tools layer (Tor Browser advanced settings, anonymity OS comparison, messaging tool comparison, password managers, the cryptocurrency privacy spectrum) and end-to-end encryption in the advanced layer, all with first drafts published and revisions ongoing
+- **Q3 (not started)**: the scenarios layer (journalists, activists, domestic violence survivors, LGBTQ+ people, election observers, among others), post-quantum cryptography and decentralized publishing in the advanced layer, and coverage of the whistleblower protection act
+- **Q4 (not started)**: the governance charter, the contributor handbook, and the annual retrospective
+
+Actual progress depends on volunteer writing capacity.
+
+## Events
+
+### COSCUP 2026
+
+Building on our 2025 experience at COSCUP, the community is running a track again in 2026, with a session on anonymous payments organized jointly with [ETHTaipei](https://ethtaipei.org/){target="_blank"}. The joint anonymous payments session is on day two (9 August). The call for proposals is at [COSCUP 2026 open call](../activity/coscup-2026-cfp.md).
+
+### Workshops and meetups
+
+Following the workshop we ran at National Taiwan University of Science and Technology in August 2025, we are scheduling in-person workshops and online meetups through 2026 as topics mature and partners ask for them. The audiences we work with include news organizations, independent journalists, civil society groups, technical communities, and interested members of the public.
+
+## Working with others
+
+### Research and report translation
+
+In the second half of 2025 we completed the Chinese translation and annotation of [InterSecLab's research on the export of China's censorship technology](../reports/index.md). Through 2026 we continue to select international reports with local relevance for translation and annotation, collected under [Curated Reports](../reports/index.md).
+
+### Showing up at other people's events
+
+Community members turn up at local open source, civic, and privacy events (hackathons, annual conferences, topic meetups, talks). Most of the time this is individuals or community representatives listening in and following context rather than formal inter-organizational collaboration. Concrete collaboration (joint calls for proposals, report translation partnerships, co-organized events) gets announced separately on the [Events](../activity/index.md) page once there is something real to announce.
+
+## Technical projects
+
+Beyond the documentation site, the community maintains several technical sub-projects related to Tor, OONI, and password security:
+
+- **Pulse**: real-time Tor relay monitoring (FastAPI and PostgreSQL), the data source behind the charts on the [Tor relay observatory](../regional/tor-relay-watcher.md) page
+- **ASN Coverage**: a batch analysis tool over OONI's public data, feeding the [ASN coverage analysis](../regional/ooni-asn-coverage.md) page
+- **Asian Diceware**: an EFF-compatible 7776-word passphrase list that blends in dictionary-attested Asian loanwords, built partly to prepare for a future community-run anonymous service platform along the lines of AnonTicket that would need to generate account codes. See [Asian Diceware](../tools/asian-diceware.md).
+
+Pulse and ASN Coverage live with their issue trackers in [anoni-net/docs on GitHub](https://github.com/anoni-net/docs){target="_blank"}. Asian Diceware has its own repository at [anoni-net/asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"}. How the two observation tools connect to the Tor Project's upstream network-health work is covered on [the Tor Project ecosystem page](https://anoni.net/docs/community/tor-project-ecosystem/){target="_blank"} (in Chinese).
+
+## How to get involved
+
+You do not need a technical background. Pick whichever entry point fits:
+
+- **Following the issues and the community**: subscribe to the [newsletter](../contact.md) and join Matrix
+- **Translation and writing**: see [Localization and translation](./i18n.md) and [How to contribute](./how-to-contribute.md)
+- **Working out how deep you want to go technically**: see the [skill level self-assessment](./skill-level.md)
+- **Understanding the collaboration tools**: see [Community services](./tools.md)
+
+Discussion happens mainly on Matrix (homeserver `im.anoni.net`), collaborative writing on CryptPad, and calls on Jitsi. Account requests and setup instructions for all of them are on the [Community services](./tools.md) page.
+
+## Roadmap updates
+
+This roadmap is a living document, reviewed and adjusted at the end of each quarter. Significant changes go through the community proposal process and are announced on Matrix.
+
+**Last updated**: June 2026 (Q2 in progress).

--- a/docs/en/community/tools.md
+++ b/docs/en/community/tools.md
@@ -8,6 +8,8 @@ icon: material/server-network-outline
 
 The community self-hosts six services (Matrix, CryptPad, Etherpad, SearXNG, Send, and Formbricks) and uses an external Jitsi for video calls. We run them ourselves to reduce our dependence on third parties and keep control of our own data, and to give community discussion and sensitive collaboration a foundation we can vouch for.
 
+Three of them (Matrix, CryptPad, and the Formbricks backend) need an account issued by a person, so write to <whisper@anoni.net> and expect a reply within a day or two. The community works asynchronously and nobody is watching the inbox around the clock.
+
 For why we self-host Matrix in particular, and the privacy trade-offs behind that decision, see [Why we self-host Matrix, starting from Discord's age verification](../blog/posts/2026-discord-matrix-statement.md).
 
 ## Real-time discussion and long-term collaboration
@@ -31,7 +33,7 @@ For why we self-host Matrix in particular, and the privacy trade-offs behind tha
 - **Use**: collaborative writing, event planning, and collaboration on material that needs encryption at rest
 - **Entry point**: the community [CryptPad instance](https://cryptpad.anoni.net/)
 - **Getting an account**: CryptPad accounts are also issued on request to <whisper@anoni.net>. The default quota is 50 MB and can be adjusted later.
-- **Interface languages**: CryptPad ships in a wide range of languages, switchable from the settings page or by adding `?lang=` to the URL. Traditional Chinese (`zh_Hant`) became a built-in locale in CryptPad 2026.5.0 after two and a half years of upstream translation work by this community, which is written up in [CryptPad 2026.5.0 ships Traditional Chinese as a built-in locale](../blog/posts/2026-cryptpad-zh-hant.md).
+- **Interface languages**: CryptPad ships in a wide range of languages, switchable from the settings page or by appending `?lang=zh_Hant` or `?lang=zh_Hans` to the URL. Both Traditional Chinese (`zh_Hant`) and Simplified Chinese (`zh_Hans`) became built-in locales in CryptPad 2026.5.0, along with a locale alias system, after two and a half years of upstream translation work by this community. The story is in [CryptPad 2026.5.0 ships Traditional Chinese as a built-in locale](../blog/posts/2026-cryptpad-zh-hant.md).
 - **How to use it**: once you have an account you can create pads, share links, and set permissions (view-only or editable). Links to event pads are usually posted in Matrix.
 
 ### Etherpad (lightweight shared notes)
@@ -40,7 +42,7 @@ For why we self-host Matrix in particular, and the privacy trade-offs behind tha
 - **Entry point**: [https://pad.anoni.net/](https://pad.anoni.net/){target="_blank"}
 - **Getting an account**: none needed. Create a pad and share the link.
 - **How to use it**: good for public, disposable content. Switch to CryptPad when you need the material to persist or to be encrypted.
-- **As a throwaway chat**: when you meet someone in person and neither of you wants to exchange app accounts, open a new pad and hand over the URL. The built-in chat sidebar works as a one-off conversation space. Close the tab and clear the pad when you are done, keeping in mind that the content is unencrypted and the server can in principle see it.
+- **As a throwaway chat**: when you meet someone in person and neither of you wants to exchange app accounts, open a new pad and hand over the URL. The built-in chat sidebar works as a one-off conversation space. Close the tab and clear the pad when you are done, keeping in mind that the content is unencrypted and remains technically visible on the server side.
 
 ## Personal privacy tools
 

--- a/docs/en/community/tools.md
+++ b/docs/en/community/tools.md
@@ -1,0 +1,80 @@
+---
+title: Community Services
+description: The Matrix, CryptPad, Etherpad, SearXNG, Send, and Formbricks instances anoni.net self-hosts, plus the external Jitsi we use, and how to get an account on each.
+icon: material/server-network-outline
+---
+
+# :material-server-network-outline: Community Services
+
+The community self-hosts six services (Matrix, CryptPad, Etherpad, SearXNG, Send, and Formbricks) and uses an external Jitsi for video calls. We run them ourselves to reduce our dependence on third parties and keep control of our own data, and to give community discussion and sensitive collaboration a foundation we can vouch for.
+
+For why we self-host Matrix in particular, and the privacy trade-offs behind that decision, see [Why we self-host Matrix, starting from Discord's age verification](../blog/posts/2026-discord-matrix-statement.md).
+
+## Real-time discussion and long-term collaboration
+
+### Matrix (real-time discussion)
+
+- **Use**: day-to-day discussion, expressing interest in a topic, per-topic rooms, and event coordination
+- **Homeserver**: `im.anoni.net`
+    - **Web (Element)**: [https://matrix.anoni.net/](https://matrix.anoni.net/){target="_blank"}
+    - **App (Element X)**: [download the app](https://element.io/download), then set the homeserver to `im.anoni.net`.
+    !!! note "If you already have a Matrix account"
+
+        An existing `matrix.org` account works fine. Element federates whether you use the web client or the app, so you only need the homeserver setting to be correct.
+
+- **Getting an account**: accounts on `im.anoni.net` are currently issued on request. Write to <whisper@anoni.net> and we will reply with the registration steps and what to be aware of.
+- **Where to start**: the community runs a **[public Space](https://matrix.to/#/#community:im.anoni.net)** that lets you join the community rooms in one go.
+- **How to join**: once registered, open the Space link above in Element, or join individual rooms as you need them.
+
+### CryptPad (encrypted collaborative documents)
+
+- **Use**: collaborative writing, event planning, and collaboration on material that needs encryption at rest
+- **Entry point**: the community [CryptPad instance](https://cryptpad.anoni.net/)
+- **Getting an account**: CryptPad accounts are also issued on request to <whisper@anoni.net>. The default quota is 50 MB and can be adjusted later.
+- **Interface languages**: CryptPad ships in a wide range of languages, switchable from the settings page or by adding `?lang=` to the URL. Traditional Chinese (`zh_Hant`) became a built-in locale in CryptPad 2026.5.0 after two and a half years of upstream translation work by this community, which is written up in [CryptPad 2026.5.0 ships Traditional Chinese as a built-in locale](../blog/posts/2026-cryptpad-zh-hant.md).
+- **How to use it**: once you have an account you can create pads, share links, and set permissions (view-only or editable). Links to event pads are usually posted in Matrix.
+
+### Etherpad (lightweight shared notes)
+
+- **Use**: taking notes together during an event, and quick throwaway drafts. Content is not encrypted and anyone with the link can read it, so it is not the place for anything sensitive.
+- **Entry point**: [https://pad.anoni.net/](https://pad.anoni.net/){target="_blank"}
+- **Getting an account**: none needed. Create a pad and share the link.
+- **How to use it**: good for public, disposable content. Switch to CryptPad when you need the material to persist or to be encrypted.
+- **As a throwaway chat**: when you meet someone in person and neither of you wants to exchange app accounts, open a new pad and hand over the URL. The built-in chat sidebar works as a one-off conversation space. Close the tab and clear the pad when you are done, keeping in mind that the content is unencrypted and the server can in principle see it.
+
+## Personal privacy tools
+
+### SearXNG (private search)
+
+- **Use**: aggregates results from several search engines with no logging, no ads, and no third-party cookies.
+- **Entry point**: [https://search.anoni.net/](https://search.anoni.net/){target="_blank"}
+- **Getting an account**: none needed.
+- **How to use it**: you can set it as your browser's default search engine, or append `?q=keyword` to the URL directly.
+
+### Send (end-to-end encrypted file transfer)
+
+- **Use**: temporary encrypted file transfer, with links that can carry a password, a download limit, and an expiry time.
+- **Entry point**: [https://send.anoni.net/](https://send.anoni.net/){target="_blank"}
+- **Getting an account**: none needed. Signing in generally raises the size quota and retention window, depending on configuration.
+- **How to use it**: upload the file, choose an expiry, set a download limit, add a password if the material warrants one, and share the link. The file is deleted once it expires or hits the download limit. Step-by-step instructions are in [Sending us sensitive material](./upload-sensitive.md).
+
+## Community operations
+
+### Formbricks (privacy-respecting forms)
+
+- **Use**: newsletter sign-ups, event registration, and community feedback. Self-hosting keeps respondents out of a third-party form provider's tracking. Our newsletter subscriptions run through this instance.
+- **Entry point**: [https://form.anoni.net/](https://form.anoni.net/){target="_blank"}
+- **Getting an account**: respondents just open the link and fill in the form. Maintainers who need to create a form should write to <whisper@anoni.net> for a backend account.
+- **How to use it**: create a form, share the link, and read the collected responses or export them from the backend.
+
+## Video calls (external)
+
+### Jitsi
+
+- **Use**: online meetings, topic discussions, and regular syncs
+- **Service**: [https://jitsi.goodmeet.asia/](https://jitsi.goodmeet.asia/){target="_blank"}. Free to use, operated by a third party rather than by this community, so its terms and availability are theirs, not ours.
+- **How to use it**: open the link, create or enter a room name, and share the link. Meeting links are announced in the relevant Matrix room.
+
+---
+
+**Further reading**: for the reasoning behind self-hosting Matrix, and how we try to hold privacy and community quality together, see [Why we self-host Matrix, starting from Discord's age verification](../blog/posts/2026-discord-matrix-statement.md).

--- a/docs/en/community/upload-sensitive.md
+++ b/docs/en/community/upload-sensitive.md
@@ -5,7 +5,7 @@ icon: material/file-lock
 ---
 # :material-file-lock: Sending Us Sensitive Material
 
-When you need to send personal data, source material, or sensitive collaboration files to a community member, and you want the transfer to stay out of reach of anyone who does not need to see it, the steps below give you a link that expires on its own and leaves nothing behind.
+When you need to send personal data, leaked material, or sensitive collaboration files to a community member, and you want the transfer to stay out of reach of anyone who does not need to see it, the steps below give you a link that expires on its own and leaves nothing behind.
 
 ## Upload steps
 
@@ -41,8 +41,8 @@ Copy the link and send it to the recipient.
 
 Send runs on infrastructure the community operates, which means you are trusting us with the fact that a transfer happened, even though the file contents are encrypted in your browser before upload. For most collaboration material that trade-off is fine. Two cases where it is not:
 
-- **You need the recipient not to learn your network location, or you need to stay anonymous to us.** Use [OnionShare](https://onionshare.org/){target="_blank"} over Tor instead. It serves the file directly from your own machine through an onion service, so no third party holds the file at any point.
-- **The material would put someone at risk if the transfer itself were discovered.** Raise it in Matrix first without the details, so we can agree on a channel before anything moves. Contact routes are on the [Community services](./tools.md) page.
+- **Anonymity from the recipient or from us**: use [OnionShare](https://onionshare.org/){target="_blank"} over Tor instead. It serves the file directly from your own machine through an onion service, so no third party holds the file at any point.
+- **Risk if the transfer itself were discovered**: raise it in Matrix first without the details, so we can agree on a channel before anything moves. Contact routes are on the [Community services](./tools.md) page.
 
 ## Related
 

--- a/docs/en/community/upload-sensitive.md
+++ b/docs/en/community/upload-sensitive.md
@@ -1,0 +1,50 @@
+---
+title: Sending Us Sensitive Material
+description: How to send personal data, leaked material, or sensitive collaboration files to the anoni.net community using our self-hosted Send instance, with OnionShare as an alternative for higher-risk cases.
+icon: material/file-lock
+---
+# :material-file-lock: Sending Us Sensitive Material
+
+When you need to send personal data, source material, or sensitive collaboration files to a community member, and you want the transfer to stay out of reach of anyone who does not need to see it, the steps below give you a link that expires on its own and leaves nothing behind.
+
+## Upload steps
+
+1. Go to [Send](https://send.anoni.net/){target="_blank"}, one of the services the community self-hosts.
+2. Select the file you want to upload.
+3. Set the expiry options: **one download**, expiring after **7 days**.
+4. Tick **:octicons-check-circle-24:{ style="color: green;" } Protect with password** and enter a password you have **agreed on separately** with the recipient.
+5. Confirm the settings and click **Upload**.
+
+The upload produces a share link. Copy it and send it to the recipient to complete the transfer.
+
+The password matters more than it looks. A Send link on its own is a bearer token: anyone who obtains it can download the file. Agree on the password through a different channel from the one carrying the link, so that compromising one channel is not enough.
+
+!!! info ""
+
+    [Send](https://github.com/timvisee/send){target="_blank"} is a lightweight self-hosted file sharing application. It shares files under end-to-end encryption and hands out links that expire on their own. That design keeps the transfer private and stops the file from living permanently on the web or inside a mail service.
+
+## Walkthrough
+
+Go to Send.
+
+![Step 1](https://assets.anoni.net/docs/send-censorship-1.png){style="border-radius: 10px;border: 1px solid black;"}
+
+Select the file, set the expiry parameters, and submit.
+
+![Step 2](https://assets.anoni.net/docs/send-censorship-2.png){style="border-radius: 10px;border: 1px solid black;"}
+
+Copy the link and send it to the recipient.
+
+![Step 3](https://assets.anoni.net/docs/send-censorship-3.png){style="border-radius: 10px;border: 1px solid black;"}
+
+## When Send is not the right tool
+
+Send runs on infrastructure the community operates, which means you are trusting us with the fact that a transfer happened, even though the file contents are encrypted in your browser before upload. For most collaboration material that trade-off is fine. Two cases where it is not:
+
+- **You need the recipient not to learn your network location, or you need to stay anonymous to us.** Use [OnionShare](https://onionshare.org/){target="_blank"} over Tor instead. It serves the file directly from your own machine through an onion service, so no third party holds the file at any point.
+- **The material would put someone at risk if the transfer itself were discovered.** Raise it in Matrix first without the details, so we can agree on a channel before anything moves. Contact routes are on the [Community services](./tools.md) page.
+
+## Related
+
+- [Community services](./tools.md) covers the rest of our self-hosted infrastructure, including how to request a Matrix or CryptPad account.
+- [Governance charter](./governance.md) sets out how the community handles disclosure and disputes.

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -69,10 +69,15 @@ nav:
           - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
+      - community/roadmap-2026.md
       - community/how-to-contribute.md
+      - community/contributor-handbook.md
       - community/skill-level.md
       - community/governance.md
       - community/i18n.md
+      - community/tools.md
+      - community/upload-sensitive.md
+      - community/become-anoni.md
       - community/setup-repo.md
       - community/asn-coverage-howto.md
       - community/ooni-data-format.md
@@ -212,19 +217,14 @@ plugins:
         'blog/2026/02/ooni-全新的匿名憑證系統.md': 'blog/index.md'
         'blog/2026/03/arti_2_1_0_released.md': 'blog/index.md'
         'blog/2026/04/ooni-probe-desktop-beta-2026.md': 'blog/index.md'
-        'community/become-anoni.md': 'community/index.md'
         'community/brand-assets.md': 'community/index.md'
         'community/campus-relay-faq.md': 'community/index.md'
         'community/campus-tor-relay-proposal.md': 'community/index.md'
         'community/campus-tor-relay-sop.md': 'community/index.md'
-        'community/contributor-handbook.md': 'community/index.md'
         'community/payments-research.md': 'community/index.md'
         'community/privacy-guide.md': 'community/index.md'
         'community/relay-on-campus.md': 'community/index.md'
-        'community/roadmap-2026.md': 'community/index.md'
-        'community/tools.md': 'community/index.md'
         'community/tor-project-ecosystem.md': 'community/index.md'
-        'community/upload-sensitive.md': 'community/index.md'
         'report/interseclab-the-internet-coup.md': 'reports/index.md'
         'report/interseclab-the-internet-coup/index_3.md': 'reports/index.md'
         'report/interseclab-the-internet-coup/index_5.md': 'reports/index.md'
@@ -306,7 +306,8 @@ markdown_extensions:
         - name: vegalite
           class: vegalite
           format: !!python/name:mkdocs_charts_plugin.fences.fence_vegalite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path: [".", ".."]
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:

--- a/docs/zh-CN/community/roadmap-2026.md
+++ b/docs/zh-CN/community/roadmap-2026.md
@@ -47,7 +47,7 @@ icon: material/road-variant
 
 ### COSCUP 2026
 
-社群延续 2025 年的 COSCUP 经验，2026 年再度开设社群议程轨，并与 [ETHTaipei](https://ethtaipei.org/){target="_blank"} 合作匿名支付主题场次。第二天（8/9）安排匿名支付联合议程。征稿说明见 [COSCUP 2026 公开征稿](../activity/coscup-2026-cfp.md)。
+社群延续 2025 年的 COSCUP 经验，2026 年再度开设社群议程轨，并与 [ETHTaipei](https://ethtaipei.org/){target="_blank"} 合作匿名支付主题场次。8/08、8/09 两天在台科大举办，第一天（8/08）下午的匿名支付联合议程在 `TR-511`。完整议程见 [COSCUP 2026 议程](../activity/coscup-2026.md)，此前的征稿说明见 [COSCUP 2026 公开征稿](../activity/coscup-2026-cfp.md)。
 
 ### 工作坊与小聚
 

--- a/docs/zh-TW/community/roadmap-2026.md
+++ b/docs/zh-TW/community/roadmap-2026.md
@@ -47,7 +47,7 @@ icon: material/road-variant
 
 ### COSCUP 2026
 
-社群延續 2025 年的 COSCUP 經驗，2026 年再度開設社群議程軌，並與 [ETHTaipei](https://ethtaipei.org/){target="_blank"} 合作匿名支付主題場次。第二天（8/9）安排匿名支付聯合議程。徵稿說明見 [COSCUP 2026 公開徵稿](../activity/coscup-2026-cfp.md)。
+社群延續 2025 年的 COSCUP 經驗，2026 年再度開設社群議程軌，並與 [ETHTaipei](https://ethtaipei.org/){target="_blank"} 合作匿名支付主題場次。8/08、8/09 兩天在臺科大舉辦，第一天（8/08）下午的匿名支付聯合議程在 `TR-511`。完整議程見 [COSCUP 2026 議程](../activity/coscup-2026.md)，先前的徵稿說明見 [COSCUP 2026 公開徵稿](../activity/coscup-2026-cfp.md)。
 
 ### 工作坊與小聚
 


### PR DESCRIPTION
## 為什麼

anoni.net 錄取 [Global Gathering 2026](https://wiki.digitalrights.community/index.php?title=GG26SandBox)（9/3–9/6），主辦單位 **8/18 公告參與夥伴名單**。公告當天會有一波國際夥伴點進站查我們是誰，這批補的就是他們第一眼會看的五頁。

屬 #232 的批次 1。整體規劃、範圍界定與後續兩個批次見該 issue。

## 改了什麼

新增五個英文頁面，加上根目錄一份 AI 載入協定正本：

| 檔案 | 說明 |
|---|---|
| `docs/en/community/roadmap-2026.md` | 今年三大主題與季度交付，夥伴找合作點靠這頁 |
| `docs/en/community/contributor-handbook.md` | 編輯標準與 PR 流程（大幅改寫，見下） |
| `docs/en/community/tools.md` | 社群自架服務與帳號申請管道 |
| `docs/en/community/upload-sensitive.md` | 機敏素材傳遞流程 |
| `docs/en/community/become-anoni.md` | 嵌入新增的 `BECOME_ANONI.en.md` |
| `BECOME_ANONI.en.md` | AI 載入協定的英文正本（新檔）|

`docs/mkdocs_en.yml` 三處配套修正，見「配套修正」一節。

## contributor-handbook 是改寫，不是翻譯

zh-TW 版的「寫作風格規範」有四成內容是中文專屬：全形標點集合、「這」與「那」的同句堆疊、口語改書面語對照表、譯名分級。這些直譯到英文沒有意義，規範本身還註明「英文版（`docs/en`）的破折號屬正常英文排版，不適用此規則」。

英文版換成 en 適用的規範：

- 依 #270 的英語風格規約，自指用「we, a community based in Taiwan」，Taiwan-specific 段落補區域對照
- 法規與機關全稱（PDPA → the Personal Data Protection Act of Taiwan，金管會 → the Financial Supervisory Commission (FSC)）
- 技術術語首次出現給簡短擴寫
- footnote 用英語原始來源，不引中文翻譯版
- 中文規則整段指回[中文版貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)，並說明兩套規則為何不共用

保留下來的是跨語言通用的部分：標題不用冒號句構、段落語氣、擬人化四種情況、去 AI 味、安全與隱私寫作、檔名與目錄、redirect、PR 流程、Issue 分類。

目錄結構表改成 en 實際的分類，並寫明 en 用 `regional/` 而非 `taiwan/` 的理由。跨檔連結一節補上跨語系連結為什麼要用絕對 URL。

`BECOME_ANONI.en.md` 同樣改寫第 3、4 節，中文標點硬規則換成英文散文的硬規則（標題句構、開場語、擬人化、粗體句開頭），安全護欄與載入確認流程照原樣保留。

## 配套修正

**1. `pymdownx.snippets` 補 `base_path`**

`mkdocs.yml` 與 `mkdocs_cn.yml` 都有 `base_path: [".", ".."]`，`mkdocs_en.yml` 沒有。缺這行時 `become-anoni.md` 找不到 repo 根目錄的 `BECOME_ANONI.en.md`，snippet 會嵌入失敗。

**2. 移除五條會 shadow 新頁的 redirect**

`mkdocs_en.yml` 原有 13 條 `community/*.md` 指向 `community/index.md` 的 redirect，其中五條的路徑正是本 PR 新增的頁面。留著會讓 redirect 蓋掉新頁。批次 2 補 `brand-assets`、`campus-*`、`payments-research`、`privacy-guide`、`relay-on-campus`、`tor-project-ecosystem` 時會遇到同樣狀況。

順帶把這條規則寫進 contributor-handbook 的 redirect 一節。

**3. nav 加入五頁**

## 對讀者的影響

- 五個路徑從「redirect 到 community index」變成實際頁面。舊行為是 redirect，沒有既有內容會壞
- `zh-TW` 與 `zh-CN` 未受影響，本 PR 只動 en
- roadmap 有幾個連結指向尚未英譯的頁面（`privacy-guide`、`relay-on-campus`、`payments-research`、台灣法規三篇），暫時連 zh-TW 版並標 `(in Chinese)`。批次 2 補上後回頭改成相對路徑

## 驗證

`bash run_en.sh` strict mode 建置綠燈，無斷鏈。五頁 HTML 皆正常產出，`become-anoni` 的 snippet 確認嵌入成功。

## Reviewer 要看的地方

1. **contributor-handbook 的英文寫作規範**是這次唯一新創的規則集，需要確認方向對不對，後續英文內容都會依它產出
2. **roadmap 的事實陳述**照 zh-TW 原文譯，標的是「Last updated: June 2026 (Q2 in progress)」。9 月給 GG26 夥伴看時這個時間戳會偏舊，是否要順便更新 zh-TW 版的 Q3 進度，請一併決定
3. `BECOME_ANONI.en.md` 的安全護欄一節，確認英文表述沒有放寬中文版的界線

Refs #232
