### PR TITLE
fix(zh): 清單外的四項修正，GrapheneOS、個資會、g0v 與工作坊的連結指向

### DIFF
--- a/docs/zh-CN/blog/posts/event-workshop-2025-preparing.md
+++ b/docs/zh-CN/blog/posts/event-workshop-2025-preparing.md
@@ -50,4 +50,4 @@ description: "匿名网络工作坊招募活动筹备人员与培训小助手！
 | 2025/07 | 活动宣传与报名。                     |
 | 2025/08 | 活动日与会后记录与通知。             |
 
-[查看工作坊招募页面说明](../../event-workshop-2025.md){ .md-button .md-button--primary }
+[查看工作坊招募页面说明](../../event-workshop-2025-prepare.md){ .md-button .md-button--primary }

--- a/docs/zh-CN/blog/posts/g0v-hackath65n.md
+++ b/docs/zh-CN/blog/posts/g0v-hackath65n.md
@@ -42,7 +42,7 @@ description: "邀请您于 2025 年 2 月 22 日参加 g0v Hackath65n 零时政�
 
 针对 OONI 观测数据多样性不足的问题，我们要如何随时监控数据的质量呢？是否可以通过某种量化指标或数字来快速掌握状况？要如何将其实施并建立起来呢？在这次活动中，我们将讨论数据流架构、自动化分析等相关问题。最后，我们也需要思考如何吸引更多人参与 OONI 观测数据的收集。
 
-[:material-arrow-right-circle-outline: 了解此项目目前的进度](../../taiwan/ooni-checklist.md){ .md-button target="_blank" }
+[:material-arrow-right-circle-outline: 了解此项目目前的进度](../../taiwan/ooni-asn-coverage.md){ .md-button target="_blank" }
 
 ### 中文化与词汇校阅
 

--- a/docs/zh-CN/blog/posts/updates-202504.md
+++ b/docs/zh-CN/blog/posts/updates-202504.md
@@ -34,6 +34,6 @@ description: "项目当前近况与更新 2025/04"
 
 也希望通过这次的工作坊，与对此议题感兴趣的人一起提升对于 Tor/Tails、OONI 等知识！我们设计了一个技能分级表，后续的培训希望把大家提升到 **Basic Level 3** 的层级！
 
-[了解「匿名网络工作坊」筹备事项！](../../event-workshop-2025.md){ .md-button .md-button--primary }
+[了解「匿名网络工作坊」筹备事项！](../../event-workshop-2025-prepare.md){ .md-button .md-button--primary }
 
 如果你对工作坊筹备与培训小助手感兴趣，欢迎直接回信给我。另外，开放文化基金会的志工招募也已[同步公告](https://volunteer.ocf.tw/blog/)工作坊招募信息。

--- a/docs/zh-CN/help/index.md
+++ b/docs/zh-CN/help/index.md
@@ -184,7 +184,7 @@ icon: material/lifebuoy
 
 1. 截图保留证据（含 URL、发布时间、发布者）
 2. 对该平台提出检举，附上证据与「侵害个人资料」的明确主张
-3. 对特定平台不应的情况下，可向 [iWIN](https://i.win.org.tw/){target="_blank"}（儿少相关）或 [个人资料保护委员会](https://www.pdpc.gov.tw/){target="_blank"} 提出协助申请
+3. 平台不回应时，可向 [iWIN](https://i.win.org.tw/){target="_blank"}（儿少相关）或 [个人资料保护委员会筹备处](https://www.pdpc.gov.tw/){target="_blank"} 提出协助申请。委员会本体还在等组织法三读，目前对外挂牌与受理的是筹备处
 4. 咨询专业律师考虑民事或刑事追诉
 
 ### 同步保护

--- a/docs/zh-CN/tools/grapheneos.md
+++ b/docs/zh-CN/tools/grapheneos.md
@@ -55,9 +55,9 @@ GrapheneOS 的功能可以分成三组：缩减攻击面、减少对 Google 的�
 
 ## 为什么几乎只支援 Pixel
 
-GrapheneOS 对硬件的要求很严格，列在官方 [FAQ](https://grapheneos.org/faq){target="_blank"}：bootloader 要能解锁、刷完客制系统后还能重新锁回（重锁才能完整启用 verified boot）、要有安全晶片提供的 StrongBox keystore 与硬件金钥验证、韧体与作业系统都要 A/B 双槽更新加上防回滚保护、原厂还要给够长的安全更新（GrapheneOS 要求至少 5 年，Pixel 目前提供 7 年）。
+GrapheneOS 对硬件的要求很严格，列在官方 [FAQ](https://grapheneos.org/faq){target="_blank"}：bootloader 要能解锁、刷完客制系统后还能重新锁回（重锁才能完整启用 verified boot）、要有安全晶片提供的 StrongBox keystore 与硬件金钥验证、韧体与作业系统都要 A/B 双槽更新加上防回滚保护、原厂还要给够长的安全更新（GrapheneOS 要求至少 5 年）。Pixel 8 以后的机型是 7 年，仍在支援清单上的 Pixel 6、7 系列是 5 年，两者不同。
 
-目前同时满足这些条件的消费级手机几乎只有 Google Pixel。Pixel 从第 6 代起搭载 Titan M2 安全晶片（第 3 到 5 代是第一代 Titan M），这颗晶片是金钥保护与硬件验证的信任根。
+目前同时满足这些条件的消费级手机几乎只有 Google Pixel。Pixel 从第 6 代到第 10 代搭载 Titan M2 安全晶片，第 11 代换成 Titan M3，第 3 到 5 代是第一代 Titan M。这颗晶片是金钥保护与硬件验证的信任根。
 
 GrapheneOS 目前只能运作于 Google 自家的 Pixel 上，但它要对付的，正是 Google 服务对手机的渗透。Google 对 Pixel 与 Android 的每一个政策调整，都会直接影响 GrapheneOS 的处境，而 Android 17 之后，Google 收紧的力道越来越强。
 
@@ -65,7 +65,7 @@ GrapheneOS 目前只能运作于 Google 自家的 Pixel 上，但它要对付的
 
 2025 年起，Google 连续两步垫高了第三方系统的开发成本。先是在 2025 年 3 月把 Android 开发移进内部分支，只在版本发布时才把原始码推上 AOSP，开发过程不再公开可追（仍是开源，但外部看不到中间的演进）。接着在 2025 年 6 月发布 Android 16 时，不再把 Pixel 的 device tree（描述机型硬件、让系统能驱动它的设定档）放进 AOSP，第三方开发者只能靠反推补回这些资料。
 
-即使如此，GrapheneOS 在 2026 年 6 月 16 日 Android 17 发布当天就完成移植，韧性还在。它同时开始替 Pixel 找替代出路，2026 年 3 月与 Motorola 宣布长期合作，第一次把硬件选项铺到 Pixel 以外（具体机型与时间官方尚未公布）。
+即使如此，GrapheneOS 在 2026 年 6 月 16 日 Android 17 发布当天就完成移植，韧性还在。它同时开始替 Pixel 找替代出路，2026 年 3 月与 Motorola 宣布长期合作，第一次把硬件选项铺到 Pixel 以外。官方说明目标是 2027 年的硬件，因为 2026 年的 Motorola 机型都不符合要求，具体机型仍未公布。
 
 另一条压力来自 attestation（装置认证，由 app 在背景检查你的手机是不是「原厂认可」的状态）。Google 的 Play Integrity 把非官方系统判为不合格，连带让部分银行、企业 app 拒绝在 GrapheneOS 上执行，即使它比原厂更安全。
 
@@ -76,14 +76,14 @@ Google 收紧 AOSP、attestation 锁定非官方系统的完整时间轴与分�
 - **取得管道**：Pixel 在不少地区没有官方销售（中国大陆、台湾、港澳等都买不到行货），多数人透过水货、海外代购或出国时自行购入。买之前先到官方 [FAQ](https://grapheneos.org/faq){target="_blank"} 确认那台是 GrapheneOS 支援的型号，二手机要特别确认 bootloader 没有被锁死（电信商绑约机常锁住 bootloader，一旦锁住就无法解锁刷机）。
 - **app 锁定的实际冲击**：银行、政府、企业验证类 app 越来越常用 attestation 检查装置，GrapheneOS 使用者可能遇到某些 app 拒绝执行。对把手机当主要上网装置的人，转用前要先确认每天必用的 app 有哪些可能受影响、自己能否接受，再决定是否转移。
 - **在中国大陆的情境不同**：Google 服务在中国大陆本就难以使用，degoogle 与 sandboxed Google Play 的意义跟海外不一样，但「装什么系统、装什么 app 由谁决定」的问题一样存在，甚至更尖锐。本地大量 app 同时走自家的装置认证与实名要求，非官方系统一样容易被挡。
-- **侧载限制正在逼近**：Android 17 新增的应用程式侧载「开发者验证」流程，2026 年先在巴西、印尼、新加坡、泰国试行，2027 年扩大。APAC 是第一批试验场，华语地区多数不在首批，但这类政策通常会逐步扩大。
+- **侧载限制正在逼近**：Google 在 2025 年 8 月宣布对侧载应用程式要求「开发者验证」，执行方式是认证装置上的 Play services 元件，涵盖 Android 7 以上，不绑定单一 Android 版本。2026 年 9 月 30 日先在巴西、印尼、新加坡、泰国生效，2027 年推向全球。首批四国有两个在这个区域，华语地区多数不在首批，但这类政策通常会逐步扩大。
 - 取得管道、app 锁定、侧载限制，指向的都是同一件事，谁有权决定你买来的手机上能执行什么系统、能装什么 app。GrapheneOS 让使用者在原厂系统之外仍然有选择。
 
 ## 常见问题
 
 ??? question "我一定要买 Pixel 吗？"
 
-    目前实务上几乎是。只有 Pixel 同时满足 GrapheneOS 要求的可重锁 bootloader、安全晶片、完整 verified boot 与长期更新。2026 年 3 月宣布的 Motorola 合作可能在未来提供 Pixel 以外的选项，但具体机型与上市时间还没公布，现在要用 GrapheneOS 仍要准备一台支援的 Pixel。
+    目前实务上几乎是。只有 Pixel 同时满足 GrapheneOS 要求的可重锁 bootloader、安全晶片、完整 verified boot 与长期更新。2026 年 3 月宣布的 Motorola 合作目标是 2027 年的硬件，具体机型还没公布，现在要用 GrapheneOS 仍要准备一台支援的 Pixel。
 
 ??? question "安装 GrapheneOS 后，还能使用 Google 地图、Gmail 吗？"
 
@@ -99,7 +99,7 @@ Google 收紧 AOSP、attestation 锁定非官方系统的完整时间轴与分�
 
 ??? question "与 LineageOS、CalyxOS、/e/OS 有什么不同？"
 
-    四套的取舍不同。GrapheneOS 是 hardening 最彻底的一套，要求在 Pixel 上重锁 bootloader 以维持完整的安全模型。CalyxOS 走 microG（一套开源的 Google 服务替代实作）加上重锁 bootloader 的实用中间路线。LineageOS 支援的机型最广，但不提供同等的安全强化，而且在很多机型上解锁 bootloader 后就削弱了 Android 预设的安全保护。/e/OS 以延续旧硬件可用为主，漏洞缓解的等级最低。要最高的安全与隐私选 GrapheneOS，要照顾更多旧机型或想更简便，可以看其他几套。
+    四套的取舍不同。GrapheneOS 是 hardening 最彻底的一套，要求在 Pixel 上重锁 bootloader 以维持完整的安全模型。CalyxOS 走 microG（一套开源的 Google 服务替代实作）加上重锁 bootloader 的实用中间路线，选用前值得知道它从 2025 年 8 月起暂停开发、2026 年 7 月恢复，目前重新处于积极维护状态。LineageOS 支援的机型最广，但不提供同等的安全强化，而且在很多机型上解锁 bootloader 后就削弱了 Android 预设的安全保护。/e/OS 以延续旧硬件可用与去 Google 化的预设值为主，没有公布可与其他几套相比的 hardening 说明。要最高的安全与隐私选 GrapheneOS，要照顾更多旧机型或想更简便，可以看其他几套。
 
 ## 接下来
 

--- a/docs/zh-TW/blog/posts/event-workshop-2025-preparing.md
+++ b/docs/zh-TW/blog/posts/event-workshop-2025-preparing.md
@@ -50,4 +50,4 @@ description: "匿名網路工作坊招募活動籌備人員與培訓小幫手！
 | 2025/07 | 活動宣傳與報名。                     |
 | 2025/08 | 活動日與會後紀錄與通知。             |
 
-[查看工作坊招募頁面說明](../../event-workshop-2025.md){ .md-button .md-button--primary }
+[查看工作坊招募頁面說明](../../event-workshop-2025-prepare.md){ .md-button .md-button--primary }

--- a/docs/zh-TW/blog/posts/g0v-hackath65n.md
+++ b/docs/zh-TW/blog/posts/g0v-hackath65n.md
@@ -42,7 +42,7 @@ description: "邀請您於 2025 年 2 月 22 日 g0v Hackath65n 零時政府第 
 
 針對 OONI 觀測資料多樣性不足的問題，我們要如何隨時監控資料的品質呢？是否可以透過某種量化指標或數字來快速掌握狀況？要如何將其實作並建立起來呢？在這次活動，我們將討論資料流架構、自動化分析等相關問題。最後，我們也需要思考如何吸引更多人參與 OONI 觀察資料的蒐集。
 
-[:material-arrow-right-circle-outline: 瞭解此專案目前的進度](../../taiwan/ooni-checklist.md){ .md-button target="_blank" }
+[:material-arrow-right-circle-outline: 瞭解此專案目前的進度](../../taiwan/ooni-asn-coverage.md){ .md-button target="_blank" }
 
 ### 中文化與詞彙校閱
 

--- a/docs/zh-TW/blog/posts/updates-202504.md
+++ b/docs/zh-TW/blog/posts/updates-202504.md
@@ -34,6 +34,6 @@ description: "專案目前近況與更新 2025/04"
 
 也希望可以透過這次的工作坊，讓對相關議題有興趣的夥伴，一起來提升關於 Tor/Tails、OONI 等知識！我們有設計一個技能分級表，後續的培訓希望把大家提升到 **Basic Level 3** 的層級！
 
-[瞭解「匿名網路工作坊」籌備事項！](../../event-workshop-2025.md){ .md-button .md-button--primary }
+[瞭解「匿名網路工作坊」籌備事項！](../../event-workshop-2025-prepare.md){ .md-button .md-button--primary }
 
 如果你對工作坊籌備與培訓小幫手感興趣，歡迎直接回信給我，另外開放文化基金會的志工招募也[同步公告](https://volunteer.ocf.tw/blog/)工作坊招募資訊。

--- a/docs/zh-TW/help/index.md
+++ b/docs/zh-TW/help/index.md
@@ -180,7 +180,7 @@ icon: material/lifebuoy
 
 1. 截圖保留證據（含 URL、發布時間、發布者）
 2. 對該平台提出檢舉，附上證據與「侵害個人資料」的明確主張
-3. 對特定平台不應的情況下，可向 [iWIN](https://i.win.org.tw/){target="_blank"}（兒少相關）或 [個人資料保護委員會](https://www.pdpc.gov.tw/){target="_blank"} 提出協助申請
+3. 平台不回應時，可向 [iWIN](https://i.win.org.tw/){target="_blank"}（兒少相關）或 [個人資料保護委員會籌備處](https://www.pdpc.gov.tw/){target="_blank"} 提出協助申請。委員會本體還在等組織法三讀，目前對外掛牌與受理的是籌備處
 4. 諮詢專業律師考慮民事或刑事追訴
 
 ### 同步保護

--- a/docs/zh-TW/tools/grapheneos.md
+++ b/docs/zh-TW/tools/grapheneos.md
@@ -55,9 +55,9 @@ GrapheneOS 的功能可以分成三組：縮減攻擊面、減少對 Google 的�
 
 ## 為什麼幾乎只支援 Pixel
 
-GrapheneOS 對硬體的要求很嚴格，列在官方 [FAQ](https://grapheneos.org/faq){target="_blank"}：bootloader 要能解鎖、刷完客製系統後還能重新鎖回（重鎖才能完整啟用 verified boot）、要有安全晶片提供的 StrongBox keystore 與硬體金鑰驗證、韌體與作業系統都要 A/B 雙槽更新加上防回滾保護、原廠還要給夠長的安全更新（GrapheneOS 要求至少 5 年，Pixel 目前提供 7 年）。
+GrapheneOS 對硬體的要求很嚴格，列在官方 [FAQ](https://grapheneos.org/faq){target="_blank"}：bootloader 要能解鎖、刷完客製系統後還能重新鎖回（重鎖才能完整啟用 verified boot）、要有安全晶片提供的 StrongBox keystore 與硬體金鑰驗證、韌體與作業系統都要 A/B 雙槽更新加上防回滾保護、原廠還要給夠長的安全更新（GrapheneOS 要求至少 5 年）。Pixel 8 以後的機型是 7 年，仍在支援清單上的 Pixel 6、7 系列是 5 年，兩者不同。
 
-目前同時滿足這些條件的消費級手機幾乎只有 Google Pixel。Pixel 從第 6 代起搭載 Titan M2 安全晶片（第 3 到 5 代是第一代 Titan M），這顆晶片是金鑰保護與硬體驗證的信任根。
+目前同時滿足這些條件的消費級手機幾乎只有 Google Pixel。Pixel 從第 6 代到第 10 代搭載 Titan M2 安全晶片，第 11 代換成 Titan M3，第 3 到 5 代是第一代 Titan M。這顆晶片是金鑰保護與硬體驗證的信任根。
 
 GrapheneOS 目前只能運作於 Google 自家的 Pixel 上，但它要對付的，正是 Google 服務對手機的滲透。Google 對 Pixel 與 Android 的每一個政策調整，都會直接影響 GrapheneOS 的處境，而 Android 17 之後，Google 收緊的力道越來越強。
 
@@ -65,7 +65,7 @@ GrapheneOS 目前只能運作於 Google 自家的 Pixel 上，但它要對付的
 
 2025 年起，Google 連續兩步墊高了第三方系統的開發成本。先是在 2025 年 3 月把 Android 開發移進內部分支，只在版本發布時才把原始碼推上 AOSP，開發過程不再公開可追（仍是開源，但外部看不到中間的演進）。接著在 2025 年 6 月發布 Android 16 時，不再把 Pixel 的 device tree（描述機型硬體、讓系統能驅動它的設定檔）放進 AOSP，第三方開發者只能靠反推補回這些資料。
 
-即使如此，GrapheneOS 在 2026 年 6 月 16 日 Android 17 發布當天就完成移植，韌性還在。它同時開始替 Pixel 找替代出路，2026 年 3 月與 Motorola 宣布長期合作，第一次把硬體選項鋪到 Pixel 以外（具體機型與時間官方尚未公布）。
+即使如此，GrapheneOS 在 2026 年 6 月 16 日 Android 17 發布當天就完成移植，韌性還在。它同時開始替 Pixel 找替代出路，2026 年 3 月與 Motorola 宣布長期合作，第一次把硬體選項鋪到 Pixel 以外。官方說明目標是 2027 年的硬體，因為 2026 年的 Motorola 機型都不符合要求，具體機型仍未公布。
 
 另一條壓力來自 attestation（裝置認證，由 app 在背景檢查你的手機是不是「原廠認可」的狀態）。Google 的 Play Integrity 把非官方系統判為不合格，連帶讓部分銀行、企業 app 拒絕在 GrapheneOS 上執行，即使它比原廠更安全。
 
@@ -75,14 +75,14 @@ Google 收緊 AOSP、attestation 鎖定非官方系統的完整時間軸與分�
 
 - **取得管道**：Pixel 在台灣沒有官方銷售，多數人透過水貨、海外代購或出國時自行購入。買之前先到官方 [FAQ](https://grapheneos.org/faq){target="_blank"} 確認那台是 GrapheneOS 支援的型號，二手機要特別確認 bootloader 沒有被鎖死（電信商綁約機常鎖住 bootloader，一旦鎖住就無法解鎖刷機）。
 - **app 鎖定的實際衝擊**：銀行、政府、企業驗證類 app 越來越常用 attestation 檢查裝置，GrapheneOS 使用者可能遇到某些 app 拒絕執行。對把手機當主要上網裝置的在地使用者，轉用前要先確認每天必用的 app 有哪些可能受影響、自己能否接受，再決定是否轉移。
-- **側載限制正在逼近**：Android 17 新增的應用程式側載「開發者驗證」流程，2026 年先在巴西、印尼、新加坡、泰國試行，2027 年擴大。APAC 是第一批試驗場，台灣雖不在首批，但這類政策通常會逐步擴大到鄰近地區。
+- **側載限制正在逼近**：Google 在 2025 年 8 月宣布對側載應用程式要求「開發者驗證」，執行方式是認證裝置上的 Play services 元件，涵蓋 Android 7 以上，不綁定單一 Android 版本。2026 年 9 月 30 日先在巴西、印尼、新加坡、泰國生效，2027 年推向全球。首批四國有兩個在這個區域，台灣雖不在首批，但這類政策通常會逐步擴大到鄰近地區。
 - 取得管道、app 鎖定、側載限制，指向的都是同一件事，誰有權決定你買來的手機上能執行什麼系統、能裝什麼 app。GrapheneOS 讓使用者在原廠系統之外仍然有選擇。
 
 ## 常見問題
 
 ??? question "我一定要買 Pixel 嗎？"
 
-    目前實務上幾乎是。只有 Pixel 同時滿足 GrapheneOS 要求的可重鎖 bootloader、安全晶片、完整 verified boot 與長期更新。2026 年 3 月宣布的 Motorola 合作可能在未來提供 Pixel 以外的選項，但具體機型與上市時間還沒公布，現在要用 GrapheneOS 仍要準備一台支援的 Pixel。
+    目前實務上幾乎是。只有 Pixel 同時滿足 GrapheneOS 要求的可重鎖 bootloader、安全晶片、完整 verified boot 與長期更新。2026 年 3 月宣布的 Motorola 合作目標是 2027 年的硬體，具體機型還沒公布，現在要用 GrapheneOS 仍要準備一台支援的 Pixel。
 
 ??? question "安裝 GrapheneOS 後，還能使用 Google 地圖、Gmail 嗎？"
 
@@ -98,7 +98,7 @@ Google 收緊 AOSP、attestation 鎖定非官方系統的完整時間軸與分�
 
 ??? question "與 LineageOS、CalyxOS、/e/OS 有什麼不同？"
 
-    四套的取捨不同。GrapheneOS 是 hardening 最徹底的一套，要求在 Pixel 上重鎖 bootloader 以維持完整的安全模型。CalyxOS 走 microG（一套開源的 Google 服務替代實作）加上重鎖 bootloader 的實用中間路線。LineageOS 支援的機型最廣，但不提供同等的安全強化，而且在很多機型上解鎖 bootloader 後就削弱了 Android 預設的安全保護。/e/OS 以延續舊硬體可用為主，漏洞緩解的等級最低。要最高的安全與隱私選 GrapheneOS，要照顧更多舊機型或想更簡便，可以看其他幾套。
+    四套的取捨不同。GrapheneOS 是 hardening 最徹底的一套，要求在 Pixel 上重鎖 bootloader 以維持完整的安全模型。CalyxOS 走 microG（一套開源的 Google 服務替代實作）加上重鎖 bootloader 的實用中間路線，選用前值得知道它從 2025 年 8 月起暫停開發、2026 年 7 月恢復，目前重新處於積極維護狀態。LineageOS 支援的機型最廣，但不提供同等的安全強化，而且在很多機型上解鎖 bootloader 後就削弱了 Android 預設的安全保護。/e/OS 以延續舊硬體可用與去 Google 化的預設值為主，沒有公布可與其他幾套相比的 hardening 說明。要最高的安全與隱私選 GrapheneOS，要照顧更多舊機型或想更簡便，可以看其他幾套。
 
 ## 接下來
 


### PR DESCRIPTION
接 #236 的後續。這六處是英文版品管在 #234 查證出來、zh-TW 原文有同樣問題的錯誤，當時不在 #232 的 zh-TW 清單上所以 #236 沒動。正確資訊與來源出自 #234 的查證，這裡沒有重查。

從 `main` 分出，只動 `docs/zh-TW` 與 `docs/zh-CN`，四個檔。跟 #236 有兩個同名檔案（`help/index.md`），改的行不同，可以各自合併。

## tools/grapheneos.md

| 原本 | 修正後 |
|---|---|
| GrapheneOS 要求至少 5 年，Pixel 目前提供 7 年 | 7 年只適用 Pixel 8 以後，仍在支援清單上的 Pixel 6、7 是 5 年 |
| Pixel 從第 6 代起搭載 Titan M2 | Titan M2 涵蓋第 6 代到 Pixel 10，Pixel 11 換 Titan M3 |
| Motorola 合作「具體機型與時間官方尚未公布」 | 目標是 2027 年硬體，因為 2026 年的 Motorola 機型都不符合要求。常見問題那一則同步改 |
| 側載驗證是「Android 17 新增」、2026 年試行 | 是認證裝置上的 Play services 元件，涵蓋 Android 7 以上，跟 Android 版本無關。2026-09-30 在巴西、印尼、新加坡、泰國生效，2027 年推向全球 |
| CalyxOS 沒提開發中斷 | 補上 2025-08 至 2026-07 曾暫停、之後恢復。要拿它當替代方案的人該知道 |
| /e/OS「漏洞緩解的等級最低」 | 查無現行可靠來源，改成不做排名的描述 |

## help/index.md

個人資料保護委員會目前掛牌的是籌備處，委員會本體還在等組織法三讀。站內 `taiwan/pdpa-2025.md` 已經寫對，只有 help 頁寫成委員會，屬內部矛盾。

順帶修同一行的「對特定平台不應的情況下」，那是漏字。

## 驗證

- zh-TW 與 zh-CN strict build 都 `exit 0`
- `docs_style_lint` 掃 4 個變更檔，0 error 0 warn

Refs #232