### PR TITLE
fix(docs): 修掉英文頁 frontmatter 未加引號的冒號，讓 YAML 能正常解析

### DIFF
--- a/docs/en/community/governance.md
+++ b/docs/en/community/governance.md
@@ -1,6 +1,6 @@
 ---
 title: Governance Charter
-description: How the anoni.net community makes decisions: roles, consensus and voting, dispute resolution, code of conduct, and how the charter itself is amended.
+description: "How the anoni.net community makes decisions: roles, consensus and voting, dispute resolution, code of conduct, and how the charter itself is amended."
 icon: material/gavel
 ---
 

--- a/docs/en/community/setup-repo.md
+++ b/docs/en/community/setup-repo.md
@@ -1,6 +1,6 @@
 ---
 title: Development environment setup
-description: Set up the tools you need to contribute to anoni.net's repositories: a GitHub account, Git, Python 3.12 with uv, and an editor. Then fork anoni-net/docs and open your first pull request.
+description: "Set up the tools you need to contribute to anoni.net's repositories: a GitHub account, Git, Python 3.12 with uv, and an editor. Then fork anoni-net/docs and open your first pull request."
 icon: octicons/mark-github-24
 ---
 # :octicons-mark-github-24: Development environment setup

--- a/docs/en/regional/ooni-asn-coverage.md
+++ b/docs/en/regional/ooni-asn-coverage.md
@@ -1,6 +1,6 @@
 ---
 title: ASN observation data analysis
-description: A coverage audit of OONI measurement data for Taiwan: 78.94% of observations come from just two ASNs and only 7.32% of the country's roughly 437 ASNs appear at all. Explains why ASN diversity limits what censorship measurement can show, and how to run the same audit for your own country.
+description: "A coverage audit of OONI measurement data for Taiwan: 78.94% of observations come from just two ASNs and only 7.32% of the country's roughly 437 ASNs appear at all. Explains why ASN diversity limits what censorship measurement can show, and how to run the same audit for your own country."
 icon: material/access-point-network
 ---
 

--- a/docs/en/scenarios/election-observer.md
+++ b/docs/en/scenarios/election-observer.md
@@ -1,6 +1,6 @@
 ---
 title: Election observer self-protection
-description: An individual operational-security guide for the person doing election observation: device prep, secure reporting, seized-device exposure, harassment, and cross-border accreditation, with Asia-Pacific framing.
+description: "An individual operational-security guide for the person doing election observation: device prep, secure reporting, seized-device exposure, harassment, and cross-border accreditation, with Asia-Pacific framing."
 icon: material/vote-outline
 ---
 


### PR DESCRIPTION
## 摘要

英文頁 `description` 內出現半形冒號加空格（如 `election observation: device prep`）時，YAML 會把它讀成巢狀 mapping，整段 frontmatter 解析失敗（`mapping values are not allowed here`）。結果是 `title`、`description`、`icon` 全部失效，Material 的 social card 與 meta description 也跟著壞掉。

把受影響的四頁 `description` 用雙引號包起來，文字內容一字未動：

- `docs/en/scenarios/election-observer.md`（回報的頁面）
- `docs/en/community/governance.md`
- `docs/en/community/setup-repo.md`
- `docs/en/regional/ooni-asn-coverage.md`

zh-TW 與 zh-CN 版用的是全形「：」，YAML 不會誤判，所以不受影響，本 PR 也未改動。

## 驗證

以 `yaml.safe_load` 掃過 `docs/en/`、`docs/zh-TW/`、`docs/zh-CN/` 共 449 個帶 frontmatter 的 md：修改前 4 個解析失敗，修改後 0 個。

- [ ] 建置後確認四頁的 title/description/icon 與 social card 正常

Made with [Cursor](https://cursor.com)