### PR TITLE
chore(docs): 移除與 /docs/ 重複的 /docs/zh-tw/ 建置

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -101,10 +101,12 @@ jobs:
 
       - name: Install mkdocs-material social dependencies
         run: sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+      # zh-TW 只建一份，就在根路徑。曾經另外跑 run_zh-tw.sh 建一棵 /docs/zh-tw/，
+      # 內容與根路徑逐位元組相同，只為了讓語言選單有對稱的網址。兩棵樹各自
+      # self-canonical 又各自進 sitemap，等於自己製造重複內容。選單改填 /docs/ 之後
+      # 那棵樹沒有存在理由。舊網址由 Cloudflare Redirect Rule 301 導回 /docs/。
       - name: Build Docs (/)
         run: source ./.venv/bin/activate; sh ./run.sh;
-      - name: Build Docs (/zh-tw)
-        run: source ./.venv/bin/activate; sh ./run_zh-tw.sh;
       - name: Build Docs (/zh-cn)
         run: source ./.venv/bin/activate; sh ./run_zh-cn.sh;
       - name: Build Docs (/en)
@@ -112,14 +114,13 @@ jobs:
       - name: Replace OG images
         run: |
           # output 結構已改為依年份 blog/YYYY/MM/
-          for base in ./output ./output/zh-tw ./output/en; do
+          for base in ./output ./output/en; do
             [ -d "$base" ] || continue
             mkdir -p "$base/assets/images/social/blog/2025/02" "$base/assets/images/social/blog/2025/03"
           done
           wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-zh-tw.png -O ./output/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
-          [ -d ./output/zh-tw ] && wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-zh-tw.png -O ./output/zh-tw/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
           [ -d ./output/en ] && wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-en.png -O ./output/en/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
-          for base in ./output ./output/zh-tw ./output/en; do
+          for base in ./output ./output/en; do
             [ -d "$base" ] || continue
             [ -f "$base/blog/assets/images/g0v-hackath65n.webp" ] && cp "$base/blog/assets/images/g0v-hackath65n.webp" "$base/assets/images/social/blog/2025/02/g0v-hackath65n.png"
             [ -f "$base/blog/assets/images/tor-tails-workshop-slide.webp" ] && cp "$base/blog/assets/images/tor-tails-workshop-slide.webp" "$base/assets/images/social/blog/2025/03/rightscon25-tor-tails-ooni-after.png"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,7 @@ source .venv/bin/activate
 mkdocs serve
 
 # 或使用腳本啟動不同語言版本
-sh run.sh          # zh-TW (預設)
-sh run_zh-tw.sh    # zh-TW
+sh run.sh          # zh-TW（預設語系，建在根路徑）
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```
@@ -278,6 +277,7 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 - 寫作風格的單一來源是[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)（原始檔 `docs/zh-TW/community/contributor-handbook.md`）的「寫作風格規範」一節。要新增或修改規則先改那裡
 - 送 PR 前可先跑 `python3 tools/docs_style_lint.py <path>` 自檢，CI 會對變更的中文 Markdown 跑同一支
 - 語系的資料夾與對外 URL 規則不同：`docs/zh-TW/` 對應 `https://anoni.net/docs/`（預設語系不帶語系區段），`docs/zh-CN/` 對應 `/docs/zh-cn/`（URL 小寫），`docs/en/` 對應 `/docs/en/`
+- `/docs/zh-tw/` 是已停用的舊網址，由 Cloudflare Redirect Rule 301 導回 `/docs/`。它曾經是 `run_zh-tw.sh` 建出來的第二棵樹，內容與根路徑完全相同，兩邊各自 self-canonical 又各自進 sitemap，等於自製重複內容。語言選單的 zh-TW 項填 `/docs/` 就夠，不要再加回那份建置
 
 ### 修改 API 時
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,7 @@ mkdocs serve   # 預設 zh-TW
 或使用腳本啟動不同語言版本：
 
 ```bash
-sh run.sh          # zh-TW（預設）
-sh run_zh-tw.sh    # zh-TW
+sh run.sh          # zh-TW（預設語系，建在根路徑）
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```
@@ -104,8 +103,7 @@ mkdocs serve   # Default: zh-TW
 Or use scripts to serve a specific language:
 
 ```bash
-sh run.sh          # zh-TW (default)
-sh run_zh-tw.sh    # zh-TW
+sh run.sh          # zh-TW (default language, built at the site root)
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```

--- a/docs/build_docs_anoni.sh
+++ b/docs/build_docs_anoni.sh
@@ -3,7 +3,6 @@ rm -rf ./output/*
 rm -rf .cache/plugin/privacy
 sh ./run.sh
 sh ./run_en.sh
-sh ./run_zh-tw.sh
 sh ./run_zh-cn.sh
 sh ./replace_og.sh
 # PWA: 注入 build 版本到 service worker，讓每次部署換版並清掉舊快取

--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -9,7 +9,7 @@
 #   1. 確認 working tree clean（避免 replace_sitename in-place 改動污染未提交修改）
 #   2. 設 trap，任何狀況退出都 git restore 還原 source
 #   3. 跑 replace_sitename_anoni_ipfs.sh 把 source URL 改成 IPFS URL（in-place）
-#   4. mkdocs build 三語 + 主站，產物匯到 ./anoni-net-docs-ipfs/
+#   4. mkdocs build 三語（zh-TW 建在根路徑，en 與 zh-CN 各自語系區段），產物匯到 ./anoni-net-docs-ipfs/
 #   5. sanity check 確認鏡像內無殘留 https://anoni.net/docs URL
 #   6. (預設) 跑 upload_to_ipfs.sh 上傳 + publish IPNS
 
@@ -68,7 +68,6 @@ rm -rf .cache/plugin/privacy
 RUN replace_sitename_anoni_ipfs.sh
 RUN run.sh
 RUN run_en.sh
-RUN run_zh-tw.sh
 RUN run_zh-cn.sh
 mkdir -p ./anoni-net-docs-ipfs
 rm -rf ./anoni-net-docs-ipfs/*

--- a/docs/build_docs_anoni_onion.sh
+++ b/docs/build_docs_anoni_onion.sh
@@ -4,7 +4,6 @@ rm -rf ./output/*
 rm -rf .cache/plugin/privacy
 sh ./run.sh
 sh ./run_en.sh
-sh ./run_zh-tw.sh
 sh ./run_zh-cn.sh
 sh ./replace_og.sh
 rm -rf /srv/ooni-docs-output/*

--- a/docs/en/community/contributor-handbook.md
+++ b/docs/en/community/contributor-handbook.md
@@ -126,7 +126,7 @@ If you are not sure where an article belongs, ask on Matrix before opening a PR,
 
 When you move, rename, or delete a page that is already live, add the redirect in the same PR so the old URL does not turn into a 404. Old URLs live on in search engines, bookmarks, and other people's links.
 
-- Redirects go in `plugins.redirects.redirect_maps` in the three mkdocs configs: `mkdocs.yml` for zh-TW (covering both `/docs/` and `/docs/zh-tw/`), `mkdocs_en.yml` for en, and `mkdocs_cn.yml` for zh-cn.
+- Redirects go in `plugins.redirects.redirect_maps` in the three mkdocs configs: `mkdocs.yml` for zh-TW (`/docs/`), `mkdocs_en.yml` for en, and `mkdocs_cn.yml` for zh-cn.
 - The format is `old path: new path`, relative to each language's docs directory, without the `docs/<lang>/` prefix. For example, `'tools/what-is-ooni.md': 'tools/index.md'`.
 - Where there is no one-to-one replacement, point at the section index (`community/index.md`, `tools/index.md`).
 - Keep existing redirects. People keep arriving at old URLs. The one case for revisiting an entry is when its target page has itself been removed and the redirect now dead-ends.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -187,8 +187,11 @@ theme:
     - content.footnote.tooltips
 extra:
   alternate:
+    # zh-TW 填 /docs/，不填 /docs/zh-tw/。zh-TW 是站台預設語系，run.sh 直接把它建在
+    # 根路徑，沒有獨立的語系區段。填 /docs/ 讓 hreflang 有 self-reference（Google 要求
+    # 一組 annotation 內每個網址都指回自己），語言選單也直接落在正式網址上。
     - name: 臺灣正體（zh-TW）
-      link: /docs/zh-tw/
+      link: /docs/
       lang: zh-TW
     - name: 簡體中文（zh-CN）
       link: /docs/zh-cn/
@@ -228,7 +231,7 @@ plugins:
         'report/interseclab-the-internet-coup/index_6.md': 'reports/interseclab-network-coup/index_6.md'
         'report/interseclab-the-internet-coup/index_7.md': 'reports/interseclab-network-coup/index_7.md'
         'report/interseclab-the-internet-coup/index_8.md': 'reports/interseclab-network-coup/index_8.md'
-        # 2026 扁平結構 → 7 分類改版（ddad3ca）舊網址止血，同時覆蓋 /docs/ 與 /docs/zh-tw/
+        # 2026 扁平結構 → 7 分類改版（ddad3ca）舊網址止血
         'internet-freedom-matter.md': 'basics/internet-freedom.md'
         'intro/index.md': 'basics/index.md'
         'intro/ooni-run-v2.md': 'tools/ooni-run-v2.md'

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -166,8 +166,9 @@ theme:
     - content.footnote.tooltips
 extra:
   alternate:
+    # zh-TW 是站台預設語系，建在根路徑，沒有獨立語系區段。理由見 mkdocs.yml 的註解。
     - name: 臺灣正體（zh-TW）
-      link: /docs/zh-tw/
+      link: /docs/
       lang: zh-TW
     - name: 简体中文（zh-CN）
       link: /docs/zh-cn/

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -171,8 +171,9 @@ extra:
     - name: English (en-US)
       link: /docs/en/
       lang: en
+    # zh-TW 是站台預設語系，建在根路徑，沒有獨立語系區段。理由見 mkdocs.yml 的註解。
     - name: 臺灣正體（zh-TW）
-      link: /docs/zh-tw/
+      link: /docs/
       lang: zh-TW
     - name: 簡體中文（zh-CN）
       link: /docs/zh-cn/

--- a/docs/replace_og.sh
+++ b/docs/replace_og.sh
@@ -3,16 +3,15 @@
 # g0v-hackath65n -> 2025/02
 # rightscon25-tor-tails-ooni-after -> 2025/03
 
-for base in ./output ./output/zh-tw ./output/en; do
+for base in ./output ./output/en; do
   [ -d "$base" ] || continue
   mkdir -p "$base/assets/images/social/blog/2025/02" "$base/assets/images/social/blog/2025/03"
 done
 
 wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-zh-tw.png -O ./output/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
-[ -d ./output/zh-tw ] && wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-zh-tw.png -O ./output/zh-tw/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
 [ -d ./output/en ] && wget -q https://assets.anoni.net/og/rightscon25-tor-tails-ooni-en.png -O ./output/en/assets/images/social/blog/2025/02/rightscon25-tor-tails-ooni.png
 
-for base in ./output ./output/zh-tw ./output/en; do
+for base in ./output ./output/en; do
   [ -d "$base" ] || continue
   [ -f "$base/blog/assets/images/g0v-hackath65n.webp" ] && cp "$base/blog/assets/images/g0v-hackath65n.webp" "$base/assets/images/social/blog/2025/02/g0v-hackath65n.png"
   [ -f "$base/blog/assets/images/tor-tails-workshop-slide.webp" ] && cp "$base/blog/assets/images/tor-tails-workshop-slide.webp" "$base/assets/images/social/blog/2025/03/rightscon25-tor-tails-ooni-after.png"

--- a/docs/replace_sitename_anoni_ipfs.sh
+++ b/docs/replace_sitename_anoni_ipfs.sh
@@ -23,20 +23,13 @@ find ./ -path './onion' -prune -o \
 find .. -maxdepth 1 -type f -name '*.md' \
 	-exec sed -i 's|https://anoni.net/docs|https://anoni-net.ipns.dweb.link|g' {} +
 
+# 語言選單（extra.alternate）的 link 是站台根相對路徑，IPFS 鏡像換成 IPNS gateway 的
+# 絕對網址。一條規則涵蓋三個語系：/docs/ → gateway 根（zh-TW 預設語系建在根路徑）、
+# /docs/zh-cn/ → gateway 的 /zh-cn/、/docs/en/ → gateway 的 /en/。
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-tw/|link: https://anoni-net.ipns.dweb.link/zh-tw/|g' {} +
-
-find ./ -path './onion' -prune -o \
-	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
-	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-cn/|link: https://anoni-net.ipns.dweb.link/zh-cn/|g' {} +
-
-find ./ -path './onion' -prune -o \
-	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
-	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/en/|link: https://anoni-net.ipns.dweb.link/en/|g' {} +
+	-exec sed -i 's|link: /docs/|link: https://anoni-net.ipns.dweb.link/|g' {} +
 
 find ./output \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \

--- a/docs/replace_sitename_anoni_onion.sh
+++ b/docs/replace_sitename_anoni_onion.sh
@@ -41,20 +41,13 @@ find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
 	-exec sed -i 's|https://pad.anoni.net|http://pad.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' {} +
 
+# 語言選單（extra.alternate）的 link 是站台根相對路徑，clearnet 掛在 /docs/ 底下，
+# onion 站的 docs 就是自己的根，把前綴整段拔掉。一條規則涵蓋三個語系：
+# /docs/ → /（zh-TW 預設語系建在根路徑）、/docs/zh-cn/ → /zh-cn/、/docs/en/ → /en/。
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-tw/|link: /zh-tw/|g' {} +
-
-find ./ -path './onion' -prune -o \
-	-type f ! -name 'replace_sitename.sh' \
-	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-cn/|link: /zh-cn/|g' {} +
-
-find ./ -path './onion' -prune -o \
-	-type f ! -name 'replace_sitename.sh' \
-	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/en/|link: /en/|g' {} +
+	-exec sed -i 's|link: /docs/|link: /|g' {} +
 
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename.sh' \

--- a/docs/robots_onion.txt
+++ b/docs/robots_onion.txt
@@ -7,5 +7,3 @@ Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.on
 Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/en/sitemap.xml.gz
 Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/zh-cn/sitemap.xml
 Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/zh-cn/sitemap.xml.gz
-Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/zh-tw/sitemap.xml
-Sitemap: http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/zh-tw/sitemap.xml.gz

--- a/docs/run_zh-tw.sh
+++ b/docs/run_zh-tw.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-export DISABLE_MKDOCS_2_WARNING=true
-export NO_MKDOCS_2_WARNING=true
-export SITE_URL='https://anoni.net/docs/zh-tw/'
-
-mkdocs build -v -s -d ./output/zh-tw

--- a/docs/zh-CN/community/contributor-handbook.md
+++ b/docs/zh-CN/community/contributor-handbook.md
@@ -98,7 +98,7 @@ icon: material/book-open-variant
 
 移动、改名或删除已上线的页面时，在同一个 PR 补上 redirect，让旧网址不会变成 404。旧网址会长期活在搜索引擎、书签与外部链接里，少了 redirect 就流失既有读者与累积的 SEO 权重。
 
-- redirect 写在三支 mkdocs 设定的 `plugins.redirects.redirect_maps`：`mkdocs.yml` 对应 zh-TW（同时涵盖 `/docs/` 与 `/docs/zh-tw/`）、`mkdocs_en.yml` 对应 en、`mkdocs_cn.yml` 对应 zh-cn。
+- redirect 写在三支 mkdocs 设定的 `plugins.redirects.redirect_maps`：`mkdocs.yml` 对应 zh-TW（`/docs/`）、`mkdocs_en.yml` 对应 en、`mkdocs_cn.yml` 对应 zh-cn。
 - 格式是「旧路径: 新路径」，路径相对各语系的 docs 目录，不含 `docs/<lang>/` 前缀。例：`'tools/what-is-ooni.md': 'tools/index.md'`。
 - 找不到一对一的新页时，导向所属分类的 index 页（`community/index.md`、`tools/index.md` 等）。
 - 既有 redirect 保留不删，旧网址会一直有人点进来。唯一要回头改的情况：某条的目标页自己也被移掉，redirect 变成断链。

--- a/docs/zh-TW/community/contributor-handbook.md
+++ b/docs/zh-TW/community/contributor-handbook.md
@@ -147,7 +147,7 @@ icon: material/book-open-variant
 
 移動、改名或刪除已上線的頁面時，在同一個 PR 補上 redirect，讓舊網址不會變成 404。舊網址會長期活在搜尋引擎、書籤與外部連結裡，少了 redirect 就流失既有讀者與累積的 SEO 權重。
 
-- redirect 寫在三支 mkdocs 設定的 `plugins.redirects.redirect_maps`：`mkdocs.yml` 對應 zh-TW（同時涵蓋 `/docs/` 與 `/docs/zh-tw/`）、`mkdocs_en.yml` 對應 en、`mkdocs_cn.yml` 對應 zh-cn。
+- redirect 寫在三支 mkdocs 設定的 `plugins.redirects.redirect_maps`：`mkdocs.yml` 對應 zh-TW（`/docs/`）、`mkdocs_en.yml` 對應 en、`mkdocs_cn.yml` 對應 zh-cn。
 - 格式是「舊路徑: 新路徑」，路徑相對各語系的 docs 目錄，不含 `docs/<lang>/` 前綴。例：`'tools/what-is-ooni.md': 'tools/index.md'`。
 - 找不到一對一的新頁時，導向所屬分類的 index 頁（`community/index.md`、`tools/index.md` 等）。
 - 既有 redirect 保留不刪，舊網址會一直有人點進來。唯一要回頭改的情況：某條的目標頁自己也被移掉，redirect 變成斷鏈。

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -10,11 +10,9 @@
  * __BUILD_VERSION__ 由 build_docs_anoni.sh 於部署時替換，
  * 換版後 activate 階段會清除舊快取。
  *
- * manifest 的 id：docs/zh-TW/manifest.webmanifest 同時被 run.sh（輸出到 /docs/）
- * 與 run_zh-tw.sh（輸出到 /docs/zh-tw/）使用，兩個輸出目錄的內容逐位元組相同。
- * 裡面的 id 寫成 "/docs/"，而規格上 id 是相對 origin 解析，所以兩邊都會得到
- * https://anoni.net/docs/，瀏覽器視為同一個 App。這是刻意的：同一份內容不該
- * 出現兩個可安裝項目。en 與 zh-cn 各自有獨立的 manifest 與 id，不受影響。
+ * manifest 的 id：docs/zh-TW/manifest.webmanifest 由 run.sh 建到 /docs/，裡面的 id
+ * 寫成 "/docs/"。規格上 id 相對 origin 解析，結果是 https://anoni.net/docs/。
+ * en 與 zh-cn 各自有獨立的 manifest 與 id。
  *
  * 注意：theme 資產的 hash 檔名需與 overrides/base.html 同步，
  * 升級 mkdocs-material 時要一併更新。
@@ -32,13 +30,8 @@ const ASSETS_MAX_ENTRIES = 200;
 // SW scope 在正式站是 /docs/，本地開發（mkdocs serve）是 /
 const SCOPE_PATH = new URL(self.registration.scope).pathname;
 
-// 各語系 build 的根路徑前綴（相對於 scope）。預設 build（zh-TW）在根。
-//
-// 這裡不放 "zh-tw/"。站台跑四次 mkdocs build（run.sh、run_zh-tw.sh、run_zh-cn.sh、
-// run_en.sh），但 run.sh 輸出的根路徑與 run_zh-tw.sh 輸出的 /zh-tw/ 是同一份內容，
-// 兩邊都預快取等於同樣的四十幾頁抓兩次。實測整份 precache 是 21.3 MB，其中
-// 6.8 MB（31%）就是這份重複。讀者很可能在受限或計量的網路下第一次造訪，這個
-// 浪費是實打實的。/zh-tw/ 的頁面若真的被造訪，runtime 快取仍會接住。
+// 各語系 build 的根路徑前綴（相對於 scope）。站台跑三次 mkdocs build（run.sh、
+// run_zh-cn.sh、run_en.sh），預設語系 zh-TW 由 run.sh 建在根路徑，另兩語各有前綴。
 const LANG_PREFIXES = ["", "zh-cn/", "en/"];
 
 // theme app shell（hash 檔名與 overrides/base.html 同步）
@@ -52,7 +45,7 @@ const SHELL_ASSETS = [
   "assets/images/icon-192.png",
 ];
 
-// zh 版（zh-TW 根、/zh-tw/、/zh-cn/）章節結構一致，預快取完整指南集 + 緊急頁。
+// zh 版（zh-TW 根、/zh-cn/）章節結構一致，預快取完整指南集 + 緊急頁。
 // 個別語系若缺某頁（如 zh-CN 暫無 what-is-cryptpad），install 時 404 由 allSettled 容忍。
 const CORE_PAGES_ZH = [
   "",
@@ -271,9 +264,7 @@ self.addEventListener("activate", (event) => {
 
 function offlinePathFor(pathname) {
   const rel = pathname.slice(SCOPE_PATH.length);
-  // 這裡沒有 "zh-tw/"。run_zh-tw.sh 輸出的 /zh-tw/ 跟根路徑是同一份內容，precache
-  // 只收根路徑那份，導向 /zh-tw/offline/ 會落到一個不存在於快取的頁面，讀者就吃到
-  // 瀏覽器原生的錯誤畫面。落到最後的預設值（根路徑的 offline 頁）內容完全一樣。
+  // 只列有前綴的兩語，zh-TW 落到最後的預設值（根路徑的 offline 頁）。
   for (const prefix of ["zh-cn/", "en/"]) {
     if (rel.startsWith(prefix)) return SCOPE_PATH + prefix + "offline/";
   }


### PR DESCRIPTION
## 問題

`/docs/` 與 `/docs/zh-tw/` 是同一個 `docs_dir` 跑兩次 mkdocs build，內容逐位元組相同。

這棵第二樹來自 `6eb09fe`（2024-12-29）「Changed to using the lang selector from build-in feature」，當時的目的是讓語言選單的 zh-TW 項有一個跟 `/docs/en/`、`/docs/zh-cn/` 對稱的網址。選單填 `/docs/` 就成立，不需要真的存在一棵樹。

代價不只是多一次建置。mkdocs-material 的 `extra.alternate` 是**逐頁**產生 hreflang 的，所以 `/docs/` 底下每一頁都在告訴 Google「這頁的 zh-TW 版在 `/docs/zh-tw/`」，自己卻 self-canonical：

| 頁面 | canonical | zh-TW hreflang（改動前）|
|---|---|---|
| `/docs/tools/what-is-tor/` | `https://anoni.net/docs/tools/what-is-tor/` | `/docs/zh-tw/tools/what-is-tor/` |
| `/docs/zh-tw/tools/what-is-tor/` | `https://anoni.net/docs/zh-tw/tools/what-is-tor/` | `/docs/zh-tw/tools/what-is-tor/` |

整組 hreflang 缺 self-reference 因此不合規，兩棵樹又各自進 sitemap（clearnet 與 onion 兩份 robots.txt 都送），等於主路徑一直在把 zh-TW 的權重推給複製品。

## 改動

- 四支 mkdocs 設定的 `extra.alternate` 的 zh-TW 項改填 `/docs/`
- 刪 `docs/run_zh-tw.sh`，並從 `build_docs_anoni.sh`、`build_docs_anoni_onion.sh`、`build_docs_anoni_ipfs.sh` 與 `build_docs.yml` 拿掉呼叫
- `replace_og.sh` 與 workflow 的 OG 圖處理不再走 `output/zh-tw`
- onion 與 IPFS 的 `link: /docs/...` 改寫，三條 sed 併成一條前綴改寫，一併涵蓋 zh-cn 與 en
- `robots_onion.txt` 拿掉 `/zh-tw/` 的 sitemap 宣告
- `sw.js` 移除解釋「為何刻意不預快取 `/zh-tw/`」的註解，程式行為本來就不含它
- README、CLAUDE.md 的建置指令與三語貢獻者百科的 redirect 涵蓋範圍說明

改動後三語 hreflang 互相對稱且各自指回自己：

| 頁面 | zh-TW hreflang（改動後）|
|---|---|
| `/docs/tools/what-is-tor/` | `/docs/tools/what-is-tor/` |
| `/docs/en/tools/what-is-tor/` | `/docs/tools/what-is-tor/` |
| `/docs/zh-cn/tools/what-is-tor/` | `/docs/tools/what-is-tor/` |

## 驗證

- 三語 `mkdocs build -s` 全綠（zh-TW 17.8 秒），產物的 canonical 與 hreflang 逐頁檢查過
- `output/` 頂層已無 `zh-tw`
- 六支改動的 shell 腳本 `bash -n` 通過
- onion 與 IPFS 的 sed 規則用設定副本實測，三語結果都對（`/docs/` → `/`、`/docs/zh-cn/` → `/zh-cn/`、`/docs/en/` → `/en/`）

## 合併之前必須先做的事

**Cloudflare Redirect Rule 要在推 `docs` 分支之前建好。** 部署最後那步是 `aws s3 rm --recursive` 清空 `docs/` 前綴，`/docs/zh-tw/` 的物件會一起消失，規則沒先建好就是直接 404。Redirect Rules 跑在 cache lookup 之前，建好立刻生效，不受 edge 還握著舊 200 影響。

- Request URL：`https://anoni.net/docs/zh-tw/*`
- Target URL：`https://anoni.net/docs/${1}`
- Status 301，Preserve query string 開

站台是 `use_directory_urls`，網址都帶尾斜線，不帶尾斜線的 `/docs/zh-tw` 可以不理。想一條涵蓋兩種就改用 expression：條件 `starts_with(http.request.uri.path, "/docs/zh-tw/") or http.request.uri.path eq "/docs/zh-tw"`，目標 `concat("https://anoni.net/docs", substring(http.request.uri.path, 11))`。

## 後續

- m6 的 onion server block 加 `rewrite ^/zh-tw/(.*)$ /$1 permanent;`。onion 沒有 SEO 問題，但語言選單過去指向 `/zh-tw/`，Tor Browser 書籤可能存著
- Google Search Console 把 `/docs/zh-tw/sitemap.xml` 這筆刪掉。不要在 robots.txt 用 `Disallow` 擋 `/docs/zh-tw/`，那樣 Google 看不到 301
- clearnet robots.txt 在另一個 repo，對應 PR：https://github.com/toomore/anoni-net/pull/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)