### PR TITLE
fix: 英文站的離線快取清單、style lint 納入 en、hello-world 連結（#243 前三項）

### DIFF
--- a/.github/workflows/docs-style-lint.yml
+++ b/.github/workflows/docs-style-lint.yml
@@ -1,5 +1,12 @@
-# 編輯標準掃描器（Tier 1）。只掃這個 PR 變更到的「中文」docs Markdown（zh-TW、zh-CN）。
-# 英文版（docs/en）的標點規則不同（破折號、分號在英文是正常的），不在此掃。
+# 編輯標準掃描器（Tier 1）。只掃這個 PR 變更到的 docs Markdown。
+#
+# 三個語系都掃，但套用的規則不同。中文那組是標點與句型（破折號、分號、不是…而是、
+# 「這」堆疊），英文那組獨立（見 docs/en/community/contributor-handbook.md 的
+# Writing style），因為破折號與分號在英文是正常標點。linter 依路徑自動選規則集，
+# 見 tools/docs_style_lint.py 的 is_english_doc。
+#
+# en 是 2026-08 納入的。在那之前英文規則純靠人工，而補齊英文站的三個批次顯示
+# 人工在那個規模守不住，同一類違反（粗體整句開頭、冒號標題）三批都出現。
 #
 # 目前是 warn 階段：問題以 annotation 標在 PR 變更行上，但 continue-on-error 讓 job
 # 維持綠燈，不擋 merge。收斂誤報後要改 blocking，只要拿掉下面的 continue-on-error，
@@ -11,6 +18,7 @@ on:
     paths:
       - "docs/zh-TW/**/*.md"
       - "docs/zh-CN/**/*.md"
+      - "docs/en/**/*.md"
       - "tools/docs_style_lint.py"
       - "tools/test_docs_style_lint.py"
       - ".github/workflows/docs-style-lint.yml"
@@ -42,7 +50,7 @@ jobs:
         continue-on-error: true
         run: |
           base="${{ github.event.pull_request.base.sha }}"
-          mapfile -t files < <(git diff --name-only --diff-filter=ACM "$base" HEAD -- docs/zh-TW docs/zh-CN \
+          mapfile -t files < <(git diff --name-only --diff-filter=ACM "$base" HEAD -- docs/zh-TW docs/zh-CN docs/en \
             | grep -E '\.md$' || true)
           if [ ${#files[@]} -eq 0 ]; then
             echo "沒有變更的 Markdown，略過。"

--- a/docs/en/blog/posts/hello-world.md
+++ b/docs/en/blog/posts/hello-world.md
@@ -28,7 +28,7 @@ Building on the 2023 and 2024 research project "[ASN Autonomous Network Observat
 
 We plan to establish a data pipeline architecture for automating the data collection and organization process during research, potentially allowing real-time presentation of results with OONI Data.
 
-[:material-arrow-right-circle-outline: Learn more about this project](../../regional/index.md){ .md-button target="_blank" }
+[:material-arrow-right-circle-outline: Learn more about this project](../../regional/ooni-asn-coverage.md){ .md-button target="_blank" }
 
 ??? note "Data Pipeline Architecture"
 

--- a/docs/en/help/index.md
+++ b/docs/en/help/index.md
@@ -164,7 +164,9 @@ Open [anoni.net/docs](../index.md) in an ordinary browser rather than Tor Browse
 - **Desktop** (Chrome, Edge): an install icon appears at the right of the address bar, or use Install from the menu
 - **iPhone and iPad** (Safari): tap Share, then Add to Home Screen
 
-Once installed, pages you have visited stay available offline, and anything not cached shows an offline notice pointing back to what is stored. Refreshing after connectivity returns brings everything up to date. Note that the set of pages pre-cached at install time is currently smaller on the English edition than on the Chinese one and does not yet include this page, so **open the sections you expect to need while you still have a connection**, which puts them in the cache.
+Once installed, the concepts, tools, advanced, and regional sections download immediately along with this page, and read offline. Pages you have visited stay available too, and anything not cached shows an offline notice pointing back to what is stored. Refreshing after connectivity returns brings everything up to date.
+
+Some pages are deliberately left out of that automatic download, and it is worth knowing why. A guide written for one specific group of people at risk becomes evidence in itself once it is sitting in a device's storage, showing that this device downloaded the full protection guide for that group. Those pages teach readers to clear traces and expect device inspection, so the site does not push them onto a device without being asked. They cache when you open them yourself, which is your decision rather than ours. If you expect to need one of them offline, open it while you still have a connection.
 
 Note that Tor Browser and the onion and IPFS versions do not offer offline installation, since they do not register a background service worker, which is a deliberate privacy decision. Install from an ordinary browser for the offline copy and use Tor Browser for anonymous reading.
 

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -120,20 +120,74 @@ const CORE_PAGES_ZH = [
   "games/",
 ];
 
-// en 是策展型原創軌道，頁面集合與 zh 版不同（沒有 tools/、taiwan/、advanced/、help/）。
-// 只預快取目前實際存在的核心頁，en 之後新增核心頁時記得補進來。
+// en 是策展型原創軌道，章節名稱與 zh 版不同（在地脈絡叫 regional/ 不叫 taiwan/），
+// 但 2026-08 補齊後兩邊的覆蓋範圍已經接近，所以選錄邏輯跟 CORE_PAGES_ZH 一致：
+// 完整指南集加緊急頁，身分敏感的頁面排除。
+//
+// 身分敏感度的判準與理由見 CORE_PAGES_ZH 上方那段長註解，新增頁面時照那個問，
+// 不要只看它放在哪個資料夾。依那條判準，這裡排除了 scenarios 的 journalist、
+// activist、lgbtq、domestic-violence、election-observer、mainland-speech、
+// singapore-malaysia-speech、nonprofit-anonymous-donation，以及
+// regional/taiwan-whistleblower-law（它放在法規資料夾，但整篇是揭弊者本人的
+// 行動準備清單，按資料夾掃會漏掉，跟 zh 版排除 taiwan/whistleblower-law 同一個理由）。
 const CORE_PAGES_EN = [
   "",
   "offline/",
   "about/",
+  "guides/",
+  "help/",
+  // basics（概念，全部）
   "basics/",
   "basics/internet-freedom/",
-  // scenarios/lgbtq 同樣不預快取，理由見 CORE_PAGES_ZH 的說明
+  "basics/anonymity-vs-privacy/",
+  "basics/threat-model/",
+  "basics/metadata/",
+  "basics/payments-anonymity/",
+  "basics/platform-tracking/",
+  "basics/surveillance-capability/",
+  "basics/multiple-identities/",
+  // tools（工具，全部）
+  "tools/",
+  "tools/what-is-anonymity-network/",
+  "tools/what-is-tor/",
+  "tools/what-is-tails/",
+  "tools/what-is-ooni/",
+  "tools/what-is-cryptpad/",
+  "tools/tor-browser-advanced/",
+  "tools/tor-snowflake/",
+  "tools/onionshare/",
+  "tools/grapheneos/",
+  "tools/ooni-run-v2/",
+  "tools/tails-vs-whonix-vs-qubes/",
+  "tools/messaging-comparison/",
+  "tools/password-manager/",
+  "tools/asian-diceware/",
+  "tools/crypto-privacy-spectrum/",
+  "tools/encrypted-dns/",
+  "tools/vpn-guide/",
+  "tools/ai-privacy/",
+  // scenarios（場景，只留不指向特定受威脅身分的）
   "scenarios/",
+  "scenarios/asia-travel/",
   "scenarios/travel-ai-briefing/",
-  "community/onionoo-mcp/",
+  // advanced（進階，全部）
+  "advanced/",
+  "advanced/e2ee/",
+  "advanced/post-quantum/",
+  "advanced/dweb-ipfs-onion/",
+  "advanced/zk-identity-payments/",
+  "advanced/mistaken-for-anonymity/",
+  // regional（在地脈絡。taiwan-whistleblower-law 依上面的判準排除，不是漏掉。
+  // ooni-asn-coverage 與 tor-relay-watcher 的 vega 圖表離線不渲染，文字仍可讀）
   "regional/",
+  "regional/ooni-checklist/",
+  "regional/taiwan-pdpa-2025/",
+  "regional/taiwan-vasp-2026/",
+  "regional/ooni-asn-coverage/",
   "regional/tor-relay-watcher/",
+  // community（社群，選錄離線可讀的工具頁）
+  "community/onionoo-mcp/",
+  // 互動與呈現的索引頁。作品本體不在這裡，見下面的 GAME_APPS。
   "games/",
 ];
 

--- a/tools/docs_style_lint.py
+++ b/tools/docs_style_lint.py
@@ -58,9 +58,64 @@ PROSE_RULES = [
      "段落開頭不要用粗體整句，並列項目升成小標題，單獨一段改寫成正常句子"),
 ]
 
+# docs/en 的規則集。英文版的編輯標準見 docs/en/community/contributor-handbook.md
+# 的 Writing style 一節，跟中文那套是兩組獨立規則，不是翻譯：破折號與分號在英文
+# 是正常標點，「不是…而是…」「這」堆疊這類判準在英文不存在。
+#
+# 這裡只實作能用純模式判斷的兩條。擬人化（文件說話、軟體「看到」）與翻漏（zh-TW
+# 具名資訊在 en 被換成上位詞）都要理解語意，不適合寫成 regex，前者靠人工 review，
+# 後者的判準寫在 docs/zh-TW/community/i18n.md。
+PROSE_RULES_EN = [
+    # 中文那條以「。」為判準，英文版換成句點。清單標籤（**Data source**: …）與
+    # 句子成分（the **control day** uses …）都不帶句點，不會命中。
+    ("bold-lead-sentence", WARN, re.compile(r"^\*\*[^*\n]+\.\*\*"),
+     "段落開頭不要用粗體整句，並列項目升成小標題，單獨一段改寫成正常句子"),
+    # 機器欄位名，中英通用
+    ("machine-field", WARN, re.compile(r"\bweb_connectivity\b"),
+     "機器欄位名請人性化並附原文，例：Web Connectivity"),
+]
+
+# 標題的「主題：說明」冒號句構。中英兩邊的貢獻者百科都有這條規則，但這裡只對
+# docs/en 生效。
+#
+# 理由是既有內容的量差很多：en 是 2026-08 新建的，127 處命中都在這批新頁裡，
+# 邊寫邊修成本低。zh 有 194 處既有命中，而百科那條規則本身寫著「既有文章不必
+# 回頭改寫，新文章與大幅改版時套用」，掃描器全面報警跟那個但書對不上。
+#
+# zh 要不要一起納入是 zh 側的決定，改法是把下面呼叫處的 english 條件拿掉。
+#
+# 照錄外部來源原始標題時是例外（翻譯文章的連結文字），機器判斷不出來，列 warn。
+#
+# 站上幾乎每個標題都以 Material 圖示開頭（# :material-lock-outline: 標題），那對
+# 冒號在語法上不是句構的一部分，檢查前要先剝掉，否則整站的標題都會誤報。
+HEADING_RE = re.compile(r"^#{1,6}\s+(.*)$")
+MD_ICON_RE = re.compile(r":[a-z0-9_-]+:")
+# 冒號後要有內容才算，「## Note:」這種行尾冒號不命中。
+# 半形冒號要求後面有空白，避免命中 a:b 這類非句構寫法；全形冒號本身就帶字距，
+# 中文標題「標題：說明」不會有空白。
+TITLE_COLON_BODY_RE = re.compile(r"\S:\s+\S|\S：\s*\S")
+# 編號式標題不算冒號句構：Workshop 1: …、Step 2: …、第 3 天：…。那是列舉的序號，
+# 不是拿冒號代替一句完整的話。判準是冒號前只有一個詞加一個數字。
+NUMBERED_HEADING_RE = re.compile(r"^\s*\S{1,12}\s*\d+\s*[:：]")
+
+
+def has_title_colon(clean: str) -> bool:
+    """標題行剝掉 Material 圖示後，是否仍是「主題：說明」的冒號句構。"""
+    m = HEADING_RE.match(clean)
+    if not m:
+        return False
+    heading = MD_ICON_RE.sub("", m.group(1))
+    if NUMBERED_HEADING_RE.match(heading):
+        return False
+    return bool(TITLE_COLON_BODY_RE.search(heading))
+
 # 句首 AI 套語（套用在剝除後、每行去掉清單/引言標記後的開頭）
 AI_OPENERS = ["值得注意的是", "總的來說", "綜上所述"]
 AI_OPENER_RE = re.compile(r"^[\s>*\-+]*(" + "|".join(AI_OPENERS) + r")")
+
+# 英文的對應套語，同樣列在百科的 Paragraph voice 一節
+AI_OPENERS_EN = ["It is worth noting that", "In conclusion", "All in all"]
+AI_OPENER_EN_RE = re.compile(r"^[\s>*\-+]*(" + "|".join(AI_OPENERS_EN) + r")", re.I)
 
 # 「這／这」密集重複。貢獻者百科已有「避免『這…』開頭」，但沒有密度標準，實際校稿
 # 時反覆處理的是同一句裡連著出現的指代堆疊，例：
@@ -250,10 +305,11 @@ def check_zhe_repeat(raw: str, clean: str, rx: re.Pattern = ZHE_RE, word: str = 
 
 
 def is_english_doc(path: Path) -> bool:
-    """en 文件採英文排版，破折號 — 屬正常用法，不套用 em-dash 規則。
+    """en 文件套 PROSE_RULES_EN，中文那組規則不適用。
 
-    對應 CI 既有設定（docs-style-lint.yml 只掃 docs/zh-TW、docs/zh-CN）。手動對含
-    docs/en 的路徑掃描時，這裡確保 en 不被 em-dash 規則誤判。
+    英文的編輯標準是獨立的一套（見 docs/en/community/contributor-handbook.md），
+    破折號與分號在英文是正常標點，中文的句型與指代判準在英文不存在。CI 從 2026-08
+    起同時掃 docs/en。
     """
     return "/en/" in path.as_posix()
 
@@ -307,9 +363,7 @@ def lint_file(path: Path):
         clean = strip_noise(raw, state)
         if not clean.strip():
             continue
-        for code, sev, rx, msg in PROSE_RULES:
-            if code == "em-dash" and english:
-                continue
+        for code, sev, rx, msg in (PROSE_RULES_EN if english else PROSE_RULES):
             for m in rx.finditer(clean):
                 # em-dash 放行：表格空資料格（| — |）與引用的連結標題（[原文標題](url)）
                 if code == "em-dash" and (
@@ -319,9 +373,18 @@ def lint_file(path: Path):
                     continue
                 snippet = raw[max(0, m.start() - 8): m.start() + 12].strip()
                 findings.append((i, sev, code, msg, snippet))
-        if AI_OPENER_RE.search(clean):
+        if english:
+            if AI_OPENER_EN_RE.search(clean):
+                findings.append((i, ERROR, "ai-opener",
+                                 "避免以 It is worth noting that / In conclusion / All in all 開頭",
+                                 raw.strip()[:32]))
+        elif AI_OPENER_RE.search(clean):
             findings.append((i, ERROR, "ai-opener",
                              "避免以「值得注意的是/總的來說/綜上所述」開頭", raw.strip()[:24]))
+        if english and has_title_colon(clean):
+            findings.append((i, WARN, "title-colon",
+                             "標題不用「主題：說明」的冒號句構，改寫成一句完整的話"
+                             "（照錄外部來源原始標題時不在此限）", raw.strip()[:40]))
         for code, rx, word in DEMONSTRATIVE_RULES:
             for msg, snippet in check_zhe_repeat(raw, clean, rx, word):
                 findings.append((i, WARN, code, msg, snippet))

--- a/tools/test_docs_style_lint.py
+++ b/tools/test_docs_style_lint.py
@@ -126,10 +126,73 @@ BLOCK_CASE = (
 SUMMARY = re.compile(r"總計：(\d+) error、(\d+) warn")
 
 
-def run_lint(body: str, tmpdir: pathlib.Path) -> int:
-    """回傳 error + warn 的總數。"""
-    f = tmpdir / "case.md"
+def run_lint(body: str, tmpdir: pathlib.Path, english: bool = False) -> int:
+    """回傳 error + warn 的總數。
+
+    english=True 時把檔案寫進含 /en/ 的路徑，linter 會據此改套 PROSE_RULES_EN。
+    判斷邏輯在 docs_style_lint.is_english_doc。
+    """
+    d = tmpdir / "en" if english else tmpdir
+    d.mkdir(exist_ok=True)
+    f = d / "case.md"
     f.write_text(f"---\ntitle: t\n---\n\n# t\n\n{body}\n", encoding="utf-8")
+    out = subprocess.run(
+        [sys.executable, str(LINT), str(f)], capture_output=True, text=True
+    ).stdout
+    m = SUMMARY.search(out)
+    if not m:
+        raise AssertionError(f"無法解析 linter 輸出：\n{out}")
+    return int(m.group(1)) + int(m.group(2))
+
+
+# docs/en 的案例。跑在含 /en/ 的路徑上，套 PROSE_RULES_EN。
+# (本文, 應該被攔下來嗎, 說明)
+EN_CASES: list[tuple[str, bool, str]] = [
+    # --- bold-lead-sentence 英文版（warn）---
+    ("**Even if we wanted to read it, we could not.** The server only holds ciphertext.",
+     True, "en 粗體整句開頭"),
+    ("**Data source**: the OONI public dataset.", False, "en 清單標籤不帶句點"),
+    ("The **control day** uses the same parameters.", False, "en 粗體詞當句子成分"),
+
+    # --- ai-opener 英文版（error）---
+    ("It is worth noting that the exit relay sees the destination.",
+     True, "en AI 套語開頭"),
+    ("The exit relay sees the destination.", False, "en 直述開頭"),
+
+    # --- em-dash 在英文是正常標點，不應攔 ---
+    ("The relay — the middle one — sees neither end.", False, "en 破折號屬正常排版"),
+
+    # --- 中文專屬規則不應套到 en ---
+    ("The tools are listed here; the comparison follows.", False, "en 半形分號正常"),
+]
+
+# title-colon 檢查的是標題行，不是內文，所以獨立成一組，直接把整份文件餵進去。
+# (整份文件, 應該被攔下來嗎, 說明)
+HEADING_CASES: list[tuple[str, bool, str]] = [
+    ("## What it protects: the core design\n\nText.", True, "冒號句構標題"),
+    ("## 標題：說明\n\n內文。", True, "全形冒號句構標題"),
+    ("## What GrapheneOS protects\n\nText.", False, "完整陳述句標題"),
+    ("## :material-lock-outline: What it protects\n\nText.",
+     False, "Material 圖示的冒號不算句構"),
+    ("### Workshop 1: Circumventing censorship\n\nText.",
+     False, "編號式標題是列舉序號"),
+    ("## Note:\n\nText.", False, "行尾冒號沒有說明部分"),
+]
+
+# title-colon 只對 docs/en 生效，zh 側維持原樣。這條驗證範圍沒有溢出。
+# (整份文件, 應該被攔下來嗎, 說明)
+ZH_HEADING_CASES: list[tuple[str, bool, str]] = [
+    ("## 一對一通訊：Diffie-Hellman 金鑰交換\n\n內文。",
+     False, "zh 的冒號標題不由 linter 攔（見 docs_style_lint 的說明）"),
+]
+
+
+def run_lint_raw(doc: str, tmpdir: pathlib.Path, english: bool = False) -> int:
+    """跟 run_lint 一樣，但不自動補標題，整份內容照原樣寫入。"""
+    d = tmpdir / "raw" / ("en" if english else "zh")
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "case.md"
+    f.write_text(f"---\ntitle: t\n---\n\n{doc}\n", encoding="utf-8")
     out = subprocess.run(
         [sys.executable, str(LINT), str(f)], capture_output=True, text=True
     ).stdout
@@ -151,7 +214,35 @@ def main() -> int:
                 f"實際{'攔下' if flagged else '放行'}（{n} 件）\n    輸入：{body!r}"
             )
 
-    total = len(CASES) + 1
+    for body, should_flag, label in EN_CASES:
+        n = run_lint(body, tmpdir, english=True)
+        flagged = n > 0
+        if flagged != should_flag:
+            failures.append(
+                f"  [{label}] 期望{'攔下' if should_flag else '放行'}，"
+                f"實際{'攔下' if flagged else '放行'}（{n} 件）\n    輸入：{body!r}"
+            )
+
+    for doc, should_flag, label in HEADING_CASES:
+        n = run_lint_raw(doc, tmpdir, english=True)
+        flagged = n > 0
+        if flagged != should_flag:
+            failures.append(
+                f"  [{label}] 期望{'攔下' if should_flag else '放行'}，"
+                f"實際{'攔下' if flagged else '放行'}（{n} 件）\n    輸入：{doc!r}"
+            )
+
+    for doc, should_flag, label in ZH_HEADING_CASES:
+        n = run_lint_raw(doc, tmpdir)
+        flagged = n > 0
+        if flagged != should_flag:
+            failures.append(
+                f"  [{label}] 期望{'攔下' if should_flag else '放行'}，"
+                f"實際{'攔下' if flagged else '放行'}（{n} 件）\n    輸入：{doc!r}"
+            )
+
+    total = (len(CASES) + 1 + len(EN_CASES) + len(HEADING_CASES)
+             + len(ZH_HEADING_CASES))
     if failures:
         print(f"失敗 {len(failures)} / {total}\n")
         print("\n".join(failures))


### PR DESCRIPTION
## 為什麼

#243 的前三項。第四項（ASN 跨區比較）是新內容不是修正，不在本 PR。

## 1. `sw.js` 的 `CORE_PAGES_EN` 補上英文站補齊後的核心頁

那份清單停在 12 項，註解還寫著 en「沒有 tools/、taiwan/、advanced/、help/」，那句在 #232 之後已經過時。結果是**英文讀者照 `help` 頁的指示把站台裝成 PWA 之後，那一頁本身不會被預先存下來**，而它正是最需要離線可讀的一頁。

依 `CORE_PAGES_ZH` 的選錄邏輯補齊，共 47 項：basics 九篇、tools 十九篇、advanced 六篇、regional 六篇，加上 `guides/` 與 `help/`。

**排除的部分照那條身分敏感度判準，不是漏掉**：

- `scenarios/` 只留 index、`asia-travel`、`travel-ai-briefing`。journalist、activist、lgbtq、domestic-violence、election-observer、mainland-speech、singapore-malaysia-speech、nonprofit-anonymous-donation 都指向特定受威脅身分，預快取本身會成為指向性證據
- `regional/taiwan-whistleblower-law` 一併排除。它放在法規資料夾，但整篇是揭弊者本人的行動準備清單，按資料夾掃會漏掉，跟 zh 版排除 `taiwan/whistleblower-law` 同一個理由

`help/index.md` 的離線段落改回正常說法，並把上面那條設計講給讀者聽：有些頁刻意不自動下載，因為那類指南躺在裝置裡本身就是證據，站台不該一邊教人清痕跡一邊把文章推進裝置。

## 2. `docs-style-lint` 納入 `docs/en`

**加了什麼**：`PROSE_RULES_EN` 兩條（bold-lead-sentence 的英文變體、machine-field），`ai-opener` 加英文套語並依語系分派，`title-colon` 是新規則。

**`title-colon` 只對 `docs/en` 生效**，這是本 PR 唯一需要你判斷的決策。理由是既有內容的量差很多：en 是新建的，127 處命中都在這批新頁裡，邊寫邊修成本低。zh 有 194 處既有命中，而百科那條規則本身寫著「既有文章不必回頭改寫」，掃描器全面報警跟那個但書對不上。zh 要不要納入是 zh 側的決定，改法是拿掉呼叫處的 `english` 條件，程式裡有註明。

**誤報處理**：第一版實跑出來 397 warn，其中 188 個是誤報，因為站上幾乎每個標題都以 Material 圖示開頭，那對冒號在語法上不是句構的一部分。改成先剝圖示再判斷。編號式標題也排除。全形冒號另外處理，半形要求後面有空白、全形不要求。

**不做的**：擬人化與翻漏都不適合寫成掃描規則，前者要理解語意，後者要跨語系逐段比對。程式裡有註明，判準在 `i18n.md`。

## 3. `hello-world.md` 的 ASN 按鈕收斂

那節講 ASN 觀測資料分析，按鈕文案是「Learn more about this project」，卻指向 `regional/` 的分類 index。貢獻者百科的 redirect 規則寫的就是「找不到一對一的新頁時導向分類 index」，而 `regional/ooni-asn-coverage.md` 現在存在。

同篇另外兩個按鈕指向上游 GitHub 維持不動，那可能是刻意讓英文讀者直接去上游 repo 的編輯決定。

## 驗證

- linter 回歸測試從 60 個案例增至 74 個，涵蓋英文的應攔與不應攔、`title-colon` 的三種例外（圖示、編號、行尾冒號），另加一條驗證 zh 不受影響
- 三語實掃：zh-TW 47 warn、zh-CN 34 warn，兩者與改動前相同；en 209 warn
- `run_en.sh` strict build 綠

## 一件要跟你說的事

處理這個 PR 時，我在 `anoni-net-docs` 的主工作目錄操作，而你同時在做 GG26 攤位公告。中間有一次我 amend commit 時把你當時未提交的三行改動吃進去了，發現後用 stash 還原。查證的結果是你已經把那三行 commit 成 `4f71c5d`（日期改 2026-08-20）在 `blog/global-gathering-2026` 分支上，所以內容沒有丟失，但過程中我確實動到了不屬於我的東西。

之後如果我們可能同時在這個 repo 工作，我開獨立 worktree 會比較安全。

Refs #243
