### PR TITLE
refactor(nav): 社群區重分群，動手實作 17 頁拆成四群

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -102,32 +102,34 @@ nav:
           - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
-      - "開始參與":
+      - "加入社群":
           - community/how-to-contribute.md
-          - community/skill-level.md
-          - community/contributor-handbook.md
-          - community/become-anoni.md
-          - community/tor-project-ecosystem.md
-          - community/governance.md
-      - "動手實作":
           - community/tools.md
-          - community/setup-repo.md
+          - community/skill-level.md
+          - community/tor-project-ecosystem.md
+          - community/upload-sensitive.md
+          - community/governance.md
+      - "文件與開發":
+          - community/contributor-handbook.md
           - community/i18n.md
           - community/zh-hant-naming.md
+          - community/become-anoni.md
+          - community/setup-repo.md
+          - community/brand-assets.md
+      - "架設節點":
           - community/setup-tor-relay.md
           - community/setup-tor-webtunnel.md
           - community/campus-tor-relay-proposal.md
           - community/campus-tor-relay-sop.md
           - community/campus-relay-faq.md
-          - community/onionoo-mcp.md
-          - community/asn-coverage-howto.md
+          - community/pin-ipfs-mirror.md
+      - "讀懂觀測資料":
           - community/ooni-data-format.md
           - community/ooni-blocking-determination.md
           - community/ooni-nettests-map.md
-          - community/upload-sensitive.md
-          - community/pin-ipfs-mirror.md
-          - community/brand-assets.md
-      - "推動主題":
+          - community/asn-coverage-howto.md
+          - community/onionoo-mcp.md
+      - "2026 主題":
           - community/roadmap-2026.md
           - community/privacy-guide.md
           - community/relay-on-campus.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -84,29 +84,31 @@ nav:
           - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
-      - "开始参与":
+      - "加入社群":
           - community/how-to-contribute.md
-          - community/skill-level.md
-          - community/contributor-handbook.md
-          - community/become-anoni.md
-          - community/tor-project-ecosystem.md
-          - community/governance.md
-      - "动手实作":
           - community/tools.md
-          - community/setup-repo.md
+          - community/skill-level.md
+          - community/tor-project-ecosystem.md
+          - community/upload-sensitive.md
+          - community/governance.md
+      - "文档与开发":
+          - community/contributor-handbook.md
           - community/i18n.md
           - community/zh-hant-naming.md
+          - community/become-anoni.md
+          - community/setup-repo.md
+          - community/brand-assets.md
+      - "架设节点":
           - community/setup-tor-relay.md
           - community/setup-tor-webtunnel.md
-          - community/onionoo-mcp.md
-          - community/asn-coverage-howto.md
+          - community/pin-ipfs-mirror.md
+      - "读懂观测资料":
           - community/ooni-data-format.md
           - community/ooni-blocking-determination.md
           - community/ooni-nettests-map.md
-          - community/upload-sensitive.md
-          - community/pin-ipfs-mirror.md
-          - community/brand-assets.md
-      - "推动主题":
+          - community/asn-coverage-howto.md
+          - community/onionoo-mcp.md
+      - "2026 主题":
           - community/roadmap-2026.md
           - community/privacy-guide.md
           - community/relay-on-campus.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -90,33 +90,38 @@ nav:
           - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
-      - community/roadmap-2026.md
-      - community/how-to-contribute.md
-      - community/contributor-handbook.md
-      - community/skill-level.md
-      - community/governance.md
-      - community/i18n.md
-      - community/tools.md
-      - community/upload-sensitive.md
-      - community/become-anoni.md
-      - community/privacy-guide.md
-      - community/relay-on-campus.md
-      - community/payments-research.md
-      - community/campus-tor-relay-proposal.md
-      - community/campus-tor-relay-sop.md
-      - community/campus-relay-faq.md
-      - community/tor-project-ecosystem.md
-      - community/zh-hant-naming.md
-      - community/brand-assets.md
-      - community/setup-repo.md
-      - community/asn-coverage-howto.md
-      - community/ooni-data-format.md
-      - community/ooni-blocking-determination.md
-      - community/ooni-nettests-map.md
-      - community/setup-tor-relay.md
-      - community/setup-tor-webtunnel.md
-      - community/onionoo-mcp.md
-      - community/pin-ipfs-mirror.md
+      - "Get Involved":
+          - community/how-to-contribute.md
+          - community/tools.md
+          - community/skill-level.md
+          - community/tor-project-ecosystem.md
+          - community/upload-sensitive.md
+          - community/governance.md
+      - "Docs and Development":
+          - community/contributor-handbook.md
+          - community/i18n.md
+          - community/zh-hant-naming.md
+          - community/become-anoni.md
+          - community/setup-repo.md
+          - community/brand-assets.md
+      - "Run a Node":
+          - community/setup-tor-relay.md
+          - community/setup-tor-webtunnel.md
+          - community/campus-tor-relay-proposal.md
+          - community/campus-tor-relay-sop.md
+          - community/campus-relay-faq.md
+          - community/pin-ipfs-mirror.md
+      - "Reading Measurement Data":
+          - community/ooni-data-format.md
+          - community/ooni-blocking-determination.md
+          - community/ooni-nettests-map.md
+          - community/asn-coverage-howto.md
+          - community/onionoo-mcp.md
+      - "2026 Themes":
+          - community/roadmap-2026.md
+          - community/privacy-guide.md
+          - community/relay-on-campus.md
+          - community/payments-research.md
   - !ENV [NAV_EVENT, "Events"]:
       - activity/index.md
       - activity/coscup-2026-cfp.md


### PR DESCRIPTION
## 為什麼

社群區原本三群，「動手實作」一群塞了 17 頁，而且名稱涵蓋不了裡面的內容：立場聲明（`zh-hant-naming`）、素材下載（`brand-assets`）、服務入口（`tools`、`onionoo-mcp`）、資料判讀（OONI 三頁）都被歸在同一個標籤下，讀者掃側欄時沒辦法用群名預測底下有什麼。

另外校園 Tor Relay 的三頁工具包在「動手實作」，它們的入口頁 `relay-on-campus.md` 在「推動主題」，同一主題被 nav 拆成兩處。英文版則完全沒有分群，是 27 頁的扁平清單。

## 改了什麼

社群區從三群改成五群，每群 4 到 6 頁：

| 群 | 頁數（zh-TW / zh-CN / en） | 內容 |
|---|---|---|
| 加入社群 | 6 / 6 / 6 | 參與方式、自架服務、技能評估、上游對接、機敏上傳、治理 |
| 文件與開發 | 6 / 6 / 6 | 貢獻者百科、翻譯、正體中文用詞、BECOME_ANONI、環境設定、品牌素材 |
| 架設節點 | 6 / 3 / 6 | 個人 relay、WebTunnel、校園三頁工具包、IPFS 鏡像 |
| 讀懂觀測資料 | 5 / 5 / 5 | OONI 資料結構、封鎖判定、測項速查、ASN 擷取、onionoo MCP |
| 2026 主題 | 4 / 4 / 4 | 維持原「推動主題」內容 |

zh-CN 的「架设节点」只有 3 頁，因為 `campus-tor-relay-proposal`、`campus-tor-relay-sop`、`campus-relay-faq` 還沒有簡中版，這是原本就有的狀態。

`relay-on-campus.md` 刻意留在「2026 主題」，靠它既有的工具包索引往下連，避免同一檔案在 nav 出現兩次造成 breadcrumb 與 prev/next 混亂。

## 影響範圍

只動 nav 的分群與排序。檔案路徑、對外 URL、`redirect_maps`、文章內文都沒改，所以這次不需要補 redirect。

## 驗證

- 三語各跑過 `mkdocs build -s`（strict），全數通過，沒有新的 warning
- 比對改動前後 nav 引用的 `community/*.md` 清單，三份設定都是完全一致的集合，沒有漏頁也沒有重複
- 本機 `mkdocs serve` 確認側欄五個群名正確顯示

## 後續

`community/index.md` 目前只列出 4 個入口，27 頁裡多數還是只能從側欄找到。之後可以比照 `guides/index.md` 補一份 grid cards 的任務地圖，三語各一份，另開 PR 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)