### PR TITLE
fix(onion): 拿掉 assets.anoni.net 的改寫規則，它讓 onion 建置失敗

### DIFF
--- a/docs/replace_sitename_anoni_onion.sh
+++ b/docs/replace_sitename_anoni_onion.sh
@@ -41,14 +41,14 @@ find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
 	-exec sed -i 's|https://pad.anoni.net|http://pad.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' {} +
 
-# 圖片主機。assets.anoni.net 是 clearnet 網域，onion 鏡像原樣留著的話，讀者的
-# Tor Browser 得繞出口去抓圖，慢又等於把「我在看這頁」透露給出口與 CDN。
-# 主站的 onion vhost 有 location /assets 指到同一顆 /srv/images-anoni-net/，
-# 換過去就走完整的 onion 路徑。docs onion 自己沒有 /assets，所以指的是主站那個。
-find ./ -path './onion' -prune -o \
-	-type f ! -name 'replace_sitename.sh' \
-	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|https://assets.anoni.net/|http://anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/assets/|g' {} +
+# assets.anoni.net 刻意不改寫。這裡曾經加過一條把它換成 onion /assets 的規則，
+# 理由是「onion 讀者不該繞出口抓圖」，那個前提是錯的：mkdocs 的 privacy plugin
+# 本來就會在建置時把外部資源抓下來鏡像進站內，產出的 HTML 指向
+# assets/external/assets.anoni.net/...，三個版本都一樣，onion 讀者拿到的一直是本機檔案。
+#
+# 換成 .onion 之後反而會壞：這支在 mkdocs build 之前跑，privacy plugin 接著要去下載
+# 那些網址，CI runner 解析不了 .onion，抓不到就在寫鏡像檔時 FileNotFoundError 中止。
+# 詳見 run 32053989479。要動 assets 的話請改 privacy plugin 的 assets_exclude，不要在這裡 sed。
 
 # 語言選單（extra.alternate）的 link 是站台根相對路徑，clearnet 掛在 /docs/ 底下，
 # onion 站的 docs 就是自己的根，把前綴整段拔掉。一條規則涵蓋三個語系：


### PR DESCRIPTION
onion 建置現在是紅的，這個 PR 修它。

## 症狀

[run 32053989479](https://github.com/anoni-net/docs/actions/runs/32053989479) 的 `build (onion)` 失敗，clearnet 那格成功：

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../.cache/plugin/privacy/assets/external/anoninetru5t....onion/assets/event/anoni-net-eth-taipei.webp'
```

前面伴隨大量：

```
WARNING - Couldn't retrieve http://anoninetru5t....onion/assets/... :
  Failed to resolve 'anoninetru5t....onion' ([Errno -2] Name or service not known)
```

## 原因

#249 在 `replace_sitename_anoni_onion.sh` 加了一條把 `assets.anoni.net` 換成主站 onion `/assets` 的 sed。那支腳本在 `mkdocs build` **之前**跑，改完之後 privacy plugin 要去下載那些網址做鏡像，CI runner 解析不了 `.onion`，抓不到就在寫鏡像檔時中止。

## 加那條的前提本身也是錯的

當時的理由是「onion 讀者原樣留著就得繞出口抓圖」。實際上 privacy plugin 本來就把外部資源抓下來鏡像進站內，建置產物長這樣：

```
$ grep -o 'src="[^"]*onion-routing-board[^"]*"' output/games/onion-routing/index.html
src="../../assets/external/assets.anoni.net/games/onion-routing-board.webp"
```

三個版本都一樣，onion 讀者拿到的一直是本機檔案，沒有繞出口這回事。`mkdocs.yml` 的 privacy `assets_exclude` 只排除了 `aa.anoni.net/*` 與 `static.cloudflareinsights.com/*`，`assets.anoni.net` 不在裡面。

## 改動

移除那條規則，原地留註解說明為什麼不要再加回來，以及真的要動 assets 的話該改 `assets_exclude` 而不是在這裡 sed。單檔，8 行進 8 行出。

## 合併之後

要重推一次 `docs` 分支讓 onion 補建：

```bash
git push origin origin/main:refs/heads/docs
```

clearnet 這輪已經成功上線，onion 那邊維持在前一版沒有動到，內容自洽只是舊的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)