### PR TITLE
feat(games): 三語系各截一份作品截圖，OG 卡片也分語系

### DIFF
--- a/docs/en/blog/posts/games-globe-open-data.md
+++ b/docs/en/blog/posts/games-globe-open-data.md
@@ -7,14 +7,14 @@ categories:
     - Tech
     - Tor
 slug: games-globe-open-data
-image: "https://assets.anoni.net/games/tor-network.png"
+image: "https://assets.anoni.net/games/tor-network-en.png"
 summary: "The docs site now has an Interactive section that renders anonymity network infrastructure as 3D visuals. Building the relay globe meant checking more than twenty public datasets, of which only six were usable. Almost nothing failed for technical reasons - the endpoints worked, the terms did not allow redistribution. This is a record of what we could and could not use, and why an open licence matters more than an open API."
 description: "The docs site now has an Interactive section that renders anonymity network infrastructure as 3D visuals. Building the relay globe meant checking more than twenty public datasets, of which only six were usable. Almost nothing failed for technical reasons - the endpoints worked, the terms did not allow redistribution. This is a record of what we could and could not use, and why an open licence matters more than an open API."
 ---
 
 # Drawing an anonymity network onto a globe: the Interactive section, and the open-data walls we hit
 
-![Tor Relay Globe](https://assets.anoni.net/games/tor-network.png){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![Tor Relay Globe](https://assets.anoni.net/games/tor-network-en.png){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 The docs site now has an [Interactive](../../games/index.md) section holding three pieces, all centred on Tor. The one carrying the most data is the <a href="../../../../../games/tor-network/play/index.html?lang=en">Tor Relay Globe</a>, which plots nearly ten thousand running relays onto a sphere. Over sixty percent of them sit in the United States, Germany and the Netherlands.
 

--- a/docs/en/games/index.md
+++ b/docs/en/games/index.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image: https://assets.anoni.net/games/tor-network-en.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-cube-outline: Interactive
@@ -115,7 +115,7 @@ These are the first three pieces, all focused on Tor. Plenty of other privacy to
             "@id": "https://anoni.net/docs/games/onion-routing/#work",
             "name": "Tor Routing Puzzle",
             "url": "https://anoni.net/docs/games/onion-routing/?lang=en",
-            "image": "https://assets.anoni.net/games/onion-routing.png",
+            "image": "https://assets.anoni.net/games/onion-routing-en.png",
             "description": "A playable puzzle. Pick three relays to form a Tor guard, middle and exit path, avoid monitored nodes, spread the three hops across different ASNs, and switch to a bridge when blocked."
           }
         },
@@ -127,7 +127,7 @@ These are the first three pieces, all focused on Tor. Plenty of other privacy to
             "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
             "name": "Tor Traffic Flow",
             "url": "https://anoni.net/docs/games/onion-rendezvous/?lang=en",
-            "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+            "image": "https://assets.anoni.net/games/onion-rendezvous-en.png",
             "applicationCategory": "EducationalApplication",
             "description": "A piece to watch rather than play. Glowing particles trace the two shapes Tor traffic takes, with .onion connections meeting at a rendezvous point picked at random."
           }
@@ -140,7 +140,7 @@ These are the first three pieces, all focused on Tor. Plenty of other privacy to
             "@id": "https://anoni.net/docs/games/tor-network/#work",
             "name": "Tor Relay Globe",
             "url": "https://anoni.net/docs/games/tor-network/?lang=en",
-            "image": "https://assets.anoni.net/games/tor-network.png",
+            "image": "https://assets.anoni.net/games/tor-network-en.png",
             "applicationCategory": "EducationalApplication",
             "description": "A globe built from real data. Nearly ten thousand running Tor relays placed inside their own borders, layered with connectivity observations, user estimates, shutdown records, submarine cables and internet-usage rates, plus county boundaries, cable landing points, substations, power plants and the grid at Taiwan scale."
           }

--- a/docs/en/games/onion-rendezvous.md
+++ b/docs/en/games/onion-rendezvous.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/onion-rendezvous.png
-  image_width: 2990
-  image_height: 1706
+  image: https://assets.anoni.net/games/onion-rendezvous-en.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-lan: Tor Traffic Flow
@@ -68,7 +68,7 @@ Red nodes represent relays already flagged as problematic. Real Tor path selecti
       "url": "https://anoni.net/docs/games/onion-rendezvous/play/?lang=en",
       "mainEntityOfPage": "https://anoni.net/docs/en/games/onion-rendezvous/",
       "description": "A watch-first visualisation. Glowing particles and afterimages trace Tor's two traffic paths, with a .onion connection having both sides build a 3-hop circuit and meet at a randomly chosen rendezvous point.",
-      "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+      "image": "https://assets.anoni.net/games/onion-rendezvous-en.png",
       "inLanguage": ["en", "zh-Hant", "zh-Hans"],
       "applicationCategory": "EducationalApplication",
       "browserRequirements": "A browser with WebGPU or WebGL2 support, no installation needed",

--- a/docs/en/games/onion-rendezvous.md
+++ b/docs/en/games/onion-rendezvous.md
@@ -13,7 +13,7 @@ og:
 
 # :material-lan: Tor Traffic Flow
 
-![The Tor Traffic Flow scene, with glowing curves weaving across a dark background, white rendezvous points and red harmful nodes scattered among them](https://assets.anoni.net/games/onion-rendezvous-flow.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![The Tor Traffic Flow scene, with glowing curves weaving across a dark background, white rendezvous points and red harmful nodes scattered among them](https://assets.anoni.net/games/onion-rendezvous-flow-en.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 The one work you can just watch. What runs on screen are Tor's two traffic paths, drawn with small glowing particles and afterimages so you can see which stops a packet is moving between.
 

--- a/docs/en/games/onion-routing.md
+++ b/docs/en/games/onion-routing.md
@@ -13,7 +13,7 @@ og:
 
 # :material-shuffle-variant: Tor Routing Puzzle
 
-![The opening board of the Tor Routing Puzzle, with the sender on the left, the recipient on the right, and five differently coloured relays floating in between](https://assets.anoni.net/games/onion-routing-board.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![The opening board of the Tor Routing Puzzle, with the sender on the left, the recipient on the right, and five differently coloured relays floating in between](https://assets.anoni.net/games/onion-routing-board-en.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 Send a message from you on the left to the recipient on the right, choosing 3 relays to form the path. Each of the four levels blocks you once, and what it blocks is a constraint Tor genuinely has to handle when it selects a path.
 
@@ -23,7 +23,7 @@ Send a message from you on the left to the recipient on the right, choosing 3 re
 
 The floating spheres are relays, coloured by the ASN they sit in. Click three in order and they become the guard, middle and exit hops in that order; click one again to deselect it. Drag to rotate the view, scroll or pinch to zoom. Press "Send message" and the message travels along the path you drew.
 
-![Three hops selected, with a curve running from the sender through three relays to the recipient, and the slots below reading Taiwan AS3462, Japan AS2914 and Netherlands AS16276](https://assets.anoni.net/games/onion-routing-path.webp){style="border-radius: 10px;"}
+![Three hops selected, with a curve running from the sender through three relays to the recipient, and the slots below reading Taiwan AS3462, Japan AS2914 and Netherlands AS16276](https://assets.anoni.net/games/onion-routing-path-en.webp){style="border-radius: 10px;"}
 
 The three slots at the bottom show where each hop lands and which ASN it belongs to. All three must be filled before the message can go, and a path that breaks the rules is stopped with an explanation.
 
@@ -39,7 +39,7 @@ Red relays appear on the board, marking ones known to be watched. Pick a path th
 
 ### Level 3: spread the hops across ASNs
 
-![All three hops picked from Taiwan, with all three slots reading Taiwan AS3462 and a red message below explaining that the hops are not spread across three different ASNs](https://assets.anoni.net/games/onion-routing-asn.webp){style="border-radius: 10px;"}
+![All three hops picked from Taiwan, with all three slots reading Taiwan AS3462 and a red message below explaining that the hops are not spread across three different ASNs](https://assets.anoni.net/games/onion-routing-asn-en.webp){style="border-radius: 10px;"}
 
 Matching colours mean the same ASN. An ASN (Autonomous System) can be read loosely as a stretch of network under one organisation or person. If all three hops land in the same ASN, an adversary watching that one ASN sees both entry and exit traffic at once, and the stops in between stop mattering.
 
@@ -47,7 +47,7 @@ Documentation says "spread the three hops across different ASNs" and it reads st
 
 ### Level 4: use a bridge when blocked
 
-![The level 4 board, with two relays ringed in red to mark them as blocked and two diamond-shaped bridge nodes on the left](https://assets.anoni.net/games/onion-routing-bridge.webp){style="border-radius: 10px;"}
+![The level 4 board, with two relays ringed in red to mark them as blocked and two diamond-shaped bridge nodes on the left](https://assets.anoni.net/games/onion-routing-bridge-en.webp){style="border-radius: 10px;"}
 
 Direct entry is blocked, marked with red rings, and the first hop has to be one of the diamond-shaped bridge nodes. Bridges are entry points that are not published in the directory, so whoever is doing the blocking cannot get a complete list and cannot block them cleanly. The two bridges on the board are labelled Snowflake and obfs4, two pluggable transports that differ in what the traffic is disguised as.
 

--- a/docs/en/games/onion-routing.md
+++ b/docs/en/games/onion-routing.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/onion-routing.png
-  image_width: 2990
-  image_height: 1706
+  image: https://assets.anoni.net/games/onion-routing-en.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-shuffle-variant: Tor Routing Puzzle
@@ -81,7 +81,7 @@ All three language versions share one program. The language is set by a URL para
       "url": "https://anoni.net/docs/games/onion-routing/play/?lang=en",
       "mainEntityOfPage": "https://anoni.net/docs/en/games/onion-routing/",
       "description": "A hands-on puzzle. Pick 3 relays to form Tor's guard, middle and exit path, avoid surveilled nodes, spread the 3 hops across different ASNs, and switch to bridges when blocked. Each of the four levels maps to a real path-selection constraint.",
-      "image": "https://assets.anoni.net/games/onion-routing.png",
+      "image": "https://assets.anoni.net/games/onion-routing-en.png",
       "inLanguage": ["en", "zh-Hant", "zh-Hans"],
       "genre": ["Puzzle", "Educational"],
       "applicationCategory": "GameApplication",

--- a/docs/en/games/tor-network.md
+++ b/docs/en/games/tor-network.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image: https://assets.anoni.net/games/tor-network-en.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-earth: Tor Relay Globe
@@ -123,7 +123,7 @@ Every data file carries `source`, `sourceUrl`, `license` and `licenseUrl` fields
       "url": "https://anoni.net/docs/games/tor-network/play/?lang=en",
       "mainEntityOfPage": "https://anoni.net/docs/en/games/tor-network/",
       "description": "A globe built from real data. Nearly ten thousand running Tor relays placed inside their own borders, with censorship observations, user estimates, shutdown records, submarine cables and internet usage layered on top, plus county boundaries, cable landing points, substations, power plants and the grid when you zoom in on Taiwan.",
-      "image": "https://assets.anoni.net/games/tor-network.png",
+      "image": "https://assets.anoni.net/games/tor-network-en.png",
       "inLanguage": ["en", "zh-Hant", "zh-Hans"],
       "applicationCategory": "EducationalApplication",
       "browserRequirements": "A browser with WebGPU or WebGL2 support, no installation needed",

--- a/docs/en/games/tor-network.md
+++ b/docs/en/games/tor-network.md
@@ -13,7 +13,7 @@ og:
 
 # :material-earth: Tor Relay Globe
 
-![The Tor Relay Globe with the sphere turned to Asia, relays drawn as coloured dots inside their borders, and the left panel listing relay counts per country and a hosting provider ranking](https://assets.anoni.net/games/tor-network-globe.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![The Tor Relay Globe with the sphere turned to Asia, relays drawn as coloured dots inside their borders, and the left panel listing relay counts per country and a hosting provider ranking](https://assets.anoni.net/games/tor-network-globe-en.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 Of the three works, the globe pulls in the most data. It puts public datasets scattered across different organisations onto one sphere, so that "where relays can be run" and "where Tor can be reached" can be read side by side. Zoom in on Taiwan and one more layer appears: the physical infrastructure those connections actually depend on.
 
@@ -27,7 +27,7 @@ Drag to rotate, scroll or pinch to zoom and more country labels surface. Adding 
 
 ### Landmass brightness switches between four metrics
 
-![Landmass brightness switched to consensus weight, with country labels now showing percentages, Germany at 29.1% and Sweden at 6.1%](https://assets.anoni.net/games/tor-network-weight.webp){style="border-radius: 10px;"}
+![Landmass brightness switched to consensus weight, with country labels now showing percentages, Germany at 29.5% and Sweden at 6.1%](https://assets.anoni.net/games/tor-network-weight-en.webp){style="border-radius: 10px;"}
 
 - **Relay count**: how many relays the country hosts
 - **Consensus weight**: the share of traffic the country actually carries in the Tor network, which often diverges noticeably from the raw count
@@ -38,7 +38,7 @@ The gap between count and weight is worth switching over to see once. The United
 
 ### Clicking a country label opens its card
 
-![Germany's information card, showing 1,706 relays, 16.8% of the network, 29.1% consensus weight, the role mix, hosting providers and OONI test results](https://assets.anoni.net/games/tor-network-country.webp){style="border-radius: 10px;"}
+![Germany's information card, showing 1,715 relays, 16.9% of the network, 29.5% consensus weight, the role mix, hosting providers and OONI test results](https://assets.anoni.net/games/tor-network-country-en.webp){style="border-radius: 10px;"}
 
 The card carries its role mix, bandwidth share, the proportion running the officially recommended version, its main hosting providers, and how the country appears in the other datasets: user estimates, the OONI anomaly rate, and the pluggable transport breakdown of bridge usage.
 
@@ -72,7 +72,7 @@ The internet usage rate on each country card exists to serve as a denominator. "
 
 ## Zooming in on Taiwan
 
-![The globe zoomed to Taiwan, with county boundaries and 345 kV transmission lines over the island and relays concentrated down the western half](https://assets.anoni.net/games/tor-network-taiwan.webp){style="border-radius: 10px;"}
+![The globe zoomed to Taiwan, with county boundaries and 345 kV transmission lines over the island and relays concentrated down the western half](https://assets.anoni.net/games/tor-network-taiwan-en.webp){style="border-radius: 10px;"}
 
 Taiwan is the only region on this globe drawn down to county scale, and approaching it brings up five more layers. The left-hand panel groups everything Taiwan-related together, and the "Focus Taiwan" button flies straight there.
 
@@ -86,7 +86,7 @@ Plants, substations, renewable sites, landing points and transmission lines can 
 
 ### Demand reads two ways
 
-![The left panel switched to industrial share, with Hsinchu County first at 80.4%, Tainan at 78.5% and Miaoli at 77.9% behind it](https://assets.anoni.net/games/tor-network-industry.webp){style="border-radius: 10px;"}
+![The left panel switched to industrial share, with Hsinchu County first at 80.4%, Tainan at 78.5% and Miaoli at 77.9% behind it](https://assets.anoni.net/games/tor-network-industry-en.webp){style="border-radius: 10px;"}
 
 By total consumption the six special municipalities lead. Switch to industrial share and Hsinchu County jumps to the top, which is what the science parks look like in this dataset. The park straddles East District in Hsinchu City and Baoshan Township in Hsinchu County, two separate administrative rows, so a total splits it in half while a share does not.
 

--- a/docs/zh-CN/blog/posts/games-globe-open-data.md
+++ b/docs/zh-CN/blog/posts/games-globe-open-data.md
@@ -7,14 +7,14 @@ categories:
     - 技术
     - Tor
 slug: games-globe-open-data
-image: "https://assets.anoni.net/games/tor-network.png"
+image: "https://assets.anoni.net/games/tor-network-zh-cn.png"
 summary: "文档站新增「互动与呈现」区，用 3D 画面呈现匿名网络的基础建设。做地球仪的过程中查了二十几份公开数据，能用的只有六份。卡住的原因几乎都跟技术无关，API 大多打得通，挡下来的是条款不给再散布。这篇记录那些能用与不能用的数据，以及为什么开放许可比开放 API 更关键。"
 description: "文档站新增「互动与呈现」区，用 3D 画面呈现匿名网络的基础建设。做地球仪的过程中查了二十几份公开数据，能用的只有六份。卡住的原因几乎都跟技术无关，API 大多打得通，挡下来的是条款不给再散布。这篇记录那些能用与不能用的数据，以及为什么开放许可比开放 API 更关键。"
 ---
 
 # 把匿名网络画成一颗地球：互动区上线，以及我们在开放数据上撞到的墙
 
-![Tor 中继地球仪](https://assets.anoni.net/games/tor-network.png){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![Tor 中继地球仪](https://assets.anoni.net/games/tor-network-zh-cn.png){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 文档站新增了[互动与呈现](../../games/index.md)区，目前放了三件作品，都以 Tor 为题。其中数据量最大的是 <a href="../../../../../games/tor-network/play/index.html?lang=zh-cn">Tor 中继地球仪</a>，把全球近万台运作中的中继标到球面上，超过六成集中在美国、德国、荷兰三个国家。
 

--- a/docs/zh-CN/games/index.md
+++ b/docs/zh-CN/games/index.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image: https://assets.anoni.net/games/tor-network-zh-cn.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-cube-outline: 互动与呈现
@@ -114,7 +114,7 @@ og:
             "@id": "https://anoni.net/docs/games/onion-routing/#work",
             "name": "Tor 路由解谜",
             "url": "https://anoni.net/docs/games/onion-routing/?lang=zh-cn",
-            "image": "https://assets.anoni.net/games/onion-routing.png",
+            "image": "https://assets.anoni.net/games/onion-routing-zh-cn.png",
             "description": "可操作的解谜。自行挑选 3 个中继组成 Tor 的 guard、middle、exit 路径，避开被监听的节点、将 3 跳分散到不同 ASN，遇到封锁则改走网桥。"
           }
         },
@@ -126,7 +126,7 @@ og:
             "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
             "name": "Tor 连线流量",
             "url": "https://anoni.net/docs/games/onion-rendezvous/?lang=zh-cn",
-            "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+            "image": "https://assets.anoni.net/games/onion-rendezvous-zh-cn.png",
             "applicationCategory": "EducationalApplication",
             "description": "以观看为主的呈现。用发光粒子与残影表现 Tor 流量的两种路径，连线 .onion 服务时双方各建一条 3 跳线路，在随机挑出的会合点相遇。"
           }
@@ -139,7 +139,7 @@ og:
             "@id": "https://anoni.net/docs/games/tor-network/#work",
             "name": "Tor 中继地球仪",
             "url": "https://anoni.net/docs/games/tor-network/?lang=zh-cn",
-            "image": "https://assets.anoni.net/games/tor-network.png",
+            "image": "https://assets.anoni.net/games/tor-network-zh-cn.png",
             "applicationCategory": "EducationalApplication",
             "description": "以真实数据构成的地球仪。将全球正在运行的近万台 Tor 中继落在各自的国界之内，另外整合连线受阻观测、用户估计、断网事件、海底电缆与上网人口，放大到台湾还有县市界、海缆登陆点、变电站、发电厂与电网。"
           }

--- a/docs/zh-CN/games/onion-rendezvous.md
+++ b/docs/zh-CN/games/onion-rendezvous.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/onion-rendezvous.png
-  image_width: 2990
-  image_height: 1706
+  image: https://assets.anoni.net/games/onion-rendezvous-zh-cn.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-lan: Tor 连线流量
@@ -68,7 +68,7 @@ og:
       "url": "https://anoni.net/docs/games/onion-rendezvous/play/?lang=zh-cn",
       "mainEntityOfPage": "https://anoni.net/docs/zh-cn/games/onion-rendezvous/",
       "description": "以观看为主的呈现。用发光粒子与残影表现 Tor 流量的两种路径，连线 .onion 服务时双方各建一条 3 跳电路，在随机挑出的会合点相遇。",
-      "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+      "image": "https://assets.anoni.net/games/onion-rendezvous-zh-cn.png",
       "inLanguage": ["zh-Hans", "zh-Hant", "en"],
       "applicationCategory": "EducationalApplication",
       "browserRequirements": "需要支持 WebGPU 或 WebGL2 的浏览器，免安装",

--- a/docs/zh-CN/games/onion-rendezvous.md
+++ b/docs/zh-CN/games/onion-rendezvous.md
@@ -13,7 +13,7 @@ og:
 
 # :material-lan: Tor 连线流量
 
-![Tor 连线流量的画面，多条发光曲线在深色背景中交织，白色的会合点与红色的有害节点散布其间](https://assets.anoni.net/games/onion-rendezvous-flow.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![Tor 连线流量的画面，多条发光曲线在深色背景中交织，白色的会合点与红色的有害节点散布其间](https://assets.anoni.net/games/onion-rendezvous-flow-zh-cn.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 不用操作也能看的一件作品。画面上呈现的是 Tor 的两种流量路径，用细小的发光粒子与残影画出来，看得出数据包在哪几站之间移动。
 

--- a/docs/zh-CN/games/onion-routing.md
+++ b/docs/zh-CN/games/onion-routing.md
@@ -13,7 +13,7 @@ og:
 
 # :material-shuffle-variant: Tor 路由解谜
 
-![Tor 路由解谜的起始盘面，左侧是发件端，右侧是收件人，中间浮着五个颜色不同的中继](https://assets.anoni.net/games/onion-routing-board.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![Tor 路由解谜的起始盘面，左侧是发件端，右侧是收件人，中间浮着五个颜色不同的中继](https://assets.anoni.net/games/onion-routing-board-zh-cn.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 把消息从左边的你送到右边的收件人，中间要自己挑 3 个中继组成路径。四个关卡各挡一次，每一关挡的都是 Tor 选路时真的要处理的一项限制。
 
@@ -23,7 +23,7 @@ og:
 
 画面上浮着的球是中继，颜色代表它所在的 ASN。依序点三个，就会照点选顺序组成 guard、middle、exit 三跳，再点一次可以取消。拖曳能旋转视角，滚轮或双指缩放。挑好之后按「发送消息」，消息会沿着你画出的路径走一遍。
 
-![选好三跳之后的画面，一条曲线从发件端串过三个中继连到收件人，下方显示台湾 AS3462、日本 AS2914、荷兰 AS16276](https://assets.anoni.net/games/onion-routing-path.webp){style="border-radius: 10px;"}
+![选好三跳之后的画面，一条曲线从发件端串过三个中继连到收件人，下方显示台湾 AS3462、日本 AS2914、荷兰 AS16276](https://assets.anoni.net/games/onion-routing-path-zh-cn.webp){style="border-radius: 10px;"}
 
 下方三格会显示每一跳落在哪里与它的 ASN。三跳都填满才发得出去，路径不合规则的话会挡下来并说明原因。
 
@@ -39,7 +39,7 @@ og:
 
 ### 关卡 3：三跳要分散到不同 ASN
 
-![三跳全挑了台湾的中继，三格都显示台湾 AS3462，下方红字说明这 3 跳没有分散到 3 个不同的 ASN](https://assets.anoni.net/games/onion-routing-asn.webp){style="border-radius: 10px;"}
+![三跳全挑了台湾的中继，三格都显示台湾 AS3462，下方红字说明这 3 跳没有分散到 3 个不同的 ASN](https://assets.anoni.net/games/onion-routing-asn-zh-cn.webp){style="border-radius: 10px;"}
 
 同色代表同一个 ASN。ASN 是自治系统（Autonomous System），可以粗略理解成一个组织或个人掌管的一段网络。三跳落在同一个 ASN 的话，对手只要盯住那一个 ASN，就同时看得到入口与出口的流量，中间绕了几站都没有意义。
 
@@ -47,7 +47,7 @@ og:
 
 ### 关卡 4：封锁时走网桥
 
-![关卡 4 的盘面，两个中继被红圈标记为封锁，左侧出现两个菱形的网桥节点](https://assets.anoni.net/games/onion-routing-bridge.webp){style="border-radius: 10px;"}
+![关卡 4 的盘面，两个中继被红圈标记为封锁，左侧出现两个菱形的网桥节点](https://assets.anoni.net/games/onion-routing-bridge-zh-cn.webp){style="border-radius: 10px;"}
 
 直连的入口被封锁了，画面上用红圈标出来，第一跳必须改用菱形的网桥节点。网桥是没有公开在目录里的入口，封锁方拿不到完整清单，所以挡不干净。盘面上两个网桥分别标了 Snowflake 与 obfs4，那是两种 pluggable transport，差别在于流量伪装成什么样子。
 

--- a/docs/zh-CN/games/onion-routing.md
+++ b/docs/zh-CN/games/onion-routing.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/onion-routing.png
-  image_width: 2990
-  image_height: 1706
+  image: https://assets.anoni.net/games/onion-routing-zh-cn.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-shuffle-variant: Tor 路由解谜
@@ -81,7 +81,7 @@ og:
       "url": "https://anoni.net/docs/games/onion-routing/play/?lang=zh-cn",
       "mainEntityOfPage": "https://anoni.net/docs/zh-cn/games/onion-routing/",
       "description": "可操作的解谜。自行挑选 3 个中继组成 Tor 的 guard、middle、exit 路径，避开被监听的节点、将 3 跳分散到不同 ASN，遇到封锁则改走网桥。四个关卡各对应一项真实的选路考量。",
-      "image": "https://assets.anoni.net/games/onion-routing.png",
+      "image": "https://assets.anoni.net/games/onion-routing-zh-cn.png",
       "inLanguage": ["zh-Hans", "zh-Hant", "en"],
       "genre": ["解谜", "教育"],
       "applicationCategory": "GameApplication",

--- a/docs/zh-CN/games/tor-network.md
+++ b/docs/zh-CN/games/tor-network.md
@@ -6,9 +6,9 @@ social:
   cards: false
 og:
   enabled: true
-  image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image: https://assets.anoni.net/games/tor-network-zh-cn.png
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-earth: Tor 中继地球仪
@@ -123,7 +123,7 @@ og:
       "url": "https://anoni.net/docs/games/tor-network/play/?lang=zh-cn",
       "mainEntityOfPage": "https://anoni.net/docs/zh-cn/games/tor-network/",
       "description": "以真实数据构成的地球仪。将全球正在运作的近万台 Tor 中继落在各自的国界之内，另外整合连线受阻观测、用户估计、断网事件、海底电缆与上网人口，放大到台湾还有县市界、海缆登陆点、变电站、发电厂与电网。",
-      "image": "https://assets.anoni.net/games/tor-network.png",
+      "image": "https://assets.anoni.net/games/tor-network-zh-cn.png",
       "inLanguage": ["zh-Hans", "zh-Hant", "en"],
       "applicationCategory": "EducationalApplication",
       "browserRequirements": "需要支持 WebGPU 或 WebGL2 的浏览器，免安装",

--- a/docs/zh-CN/games/tor-network.md
+++ b/docs/zh-CN/games/tor-network.md
@@ -13,7 +13,7 @@ og:
 
 # :material-earth: Tor 中继地球仪
 
-![Tor 中继地球仪的画面，地球转到亚洲一侧，中继以彩色点分布在各国界内，左侧面板列出各国中继数与托管商排行](https://assets.anoni.net/games/tor-network-globe.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+![Tor 中继地球仪的画面，地球转到亚洲一侧，中继以彩色点分布在各国界内，左侧面板列出各国中继数与托管商排行](https://assets.anoni.net/games/tor-network-globe-zh-cn.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
 三件作品之中数据最多的一件。它把散落在不同机构的公开数据放到同一颗球上，让「哪里架得起中继」与「哪里连得上 Tor」两件事得以并置对照。放大到台湾之后还多出一层，那些连线实际上依赖哪些实体设施。
 
@@ -27,7 +27,7 @@ og:
 
 ### 陆地亮度可以换四种指标
 
-![陆地亮度切换到共识权重之后的画面，国家标签改成显示百分比，德国 29.1%、瑞典 6.1%](https://assets.anoni.net/games/tor-network-weight.webp){style="border-radius: 10px;"}
+![陆地亮度切换到共识权重之后的画面，国家标签改成显示百分比，德国 29.5%、瑞典 6.1%](https://assets.anoni.net/games/tor-network-weight-zh-cn.webp){style="border-radius: 10px;"}
 
 - **中继台数**：该国托管的中继数量
 - **共识权重**：该国在 Tor 网络中实际承担的流量比重，与台数常有明显落差
@@ -38,7 +38,7 @@ og:
 
 ### 点国家标签展开信息卡
 
-![点开德国的信息卡，列出 1706 台、占全网 16.8%、权重 29.1%、角色组成、托管商与 OONI 测试结果](https://assets.anoni.net/games/tor-network-country.webp){style="border-radius: 10px;"}
+![点开德国的信息卡，列出 1715 台、占全网 16.9%、权重 29.5%、角色组成、托管商与 OONI 测试结果](https://assets.anoni.net/games/tor-network-country-zh-cn.webp){style="border-radius: 10px;"}
 
 卡片内容包含角色组成、带宽占比、运行官方建议版本的比例、主要托管商，以及该国在其他几份数据中的状况：用户估计、OONI 的异常率、网桥绕道的 pluggable transport 分布。
 
@@ -72,7 +72,7 @@ og:
 
 ## 放大到台湾
 
-![地球仪放大到台湾，县市界线与 345kV 输电线叠在岛上，中继以彩色点集中在西半部](https://assets.anoni.net/games/tor-network-taiwan.webp){style="border-radius: 10px;"}
+![地球仪放大到台湾，县市界线与 345kV 输电线叠在岛上，中继以彩色点集中在西半部](https://assets.anoni.net/games/tor-network-taiwan-zh-cn.webp){style="border-radius: 10px;"}
 
 台湾是这颗地球仪唯一做到县市尺度的地区，贴近之后会多出五层。左侧面板把台湾相关的信息独立成一区，按「关注台湾」会直接飞过去。
 
@@ -86,7 +86,7 @@ og:
 
 ### 用电那段可以换两种看法
 
-![左侧面板切到工业用电占比，新竹县以 80.4% 排在第一，台南市 78.5%、苗栗县 77.9% 跟在后面](https://assets.anoni.net/games/tor-network-industry.webp){style="border-radius: 10px;"}
+![左侧面板切到工业用电占比，新竹县以 80.4% 排在第一，台南市 78.5%、苗栗县 77.9% 跟在后面](https://assets.anoni.net/games/tor-network-industry-zh-cn.webp){style="border-radius: 10px;"}
 
 看售电量的话六都排在前面，换成工业用电占比，新竹县会跳到第一，科学园区的形状就出来了。园区横跨新竹市东区与新竹县宝山乡，行政上是分开的两列，看总量会被切成两半，看占比则不受影响。
 

--- a/docs/zh-TW/games/index.md
+++ b/docs/zh-TW/games/index.md
@@ -7,8 +7,8 @@ social:
 og:
   enabled: true
   image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-cube-outline: 互動與呈現

--- a/docs/zh-TW/games/onion-rendezvous.md
+++ b/docs/zh-TW/games/onion-rendezvous.md
@@ -7,8 +7,8 @@ social:
 og:
   enabled: true
   image: https://assets.anoni.net/games/onion-rendezvous.png
-  image_width: 2990
-  image_height: 1706
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-lan: Tor 連線流量

--- a/docs/zh-TW/games/onion-routing.md
+++ b/docs/zh-TW/games/onion-routing.md
@@ -7,8 +7,8 @@ social:
 og:
   enabled: true
   image: https://assets.anoni.net/games/onion-routing.png
-  image_width: 2990
-  image_height: 1706
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-shuffle-variant: Tor 路由解謎

--- a/docs/zh-TW/games/tor-network.md
+++ b/docs/zh-TW/games/tor-network.md
@@ -27,7 +27,7 @@ og:
 
 ### 陸地亮度可以換四種指標
 
-![陸地亮度切換到共識權重之後的畫面，國家標籤改成顯示百分比，德國 29.1%、瑞典 6.1%](https://assets.anoni.net/games/tor-network-weight.webp){style="border-radius: 10px;"}
+![陸地亮度切換到共識權重之後的畫面，國家標籤改成顯示百分比，德國 29.5%、瑞典 6.1%](https://assets.anoni.net/games/tor-network-weight.webp){style="border-radius: 10px;"}
 
 - **中繼台數**：該國託管的中繼數量
 - **共識權重**：該國在 Tor 網路中實際承擔的流量比重，與台數常有明顯落差
@@ -38,7 +38,7 @@ og:
 
 ### 點國家標籤展開資訊卡
 
-![點開德國的資訊卡，列出 1706 台、佔全網 16.8%、權重 29.1%、角色組成、托管商與 OONI 測試結果](https://assets.anoni.net/games/tor-network-country.webp){style="border-radius: 10px;"}
+![點開德國的資訊卡，列出 1715 台、佔全網 16.9%、權重 29.5%、角色組成、托管商與 OONI 測試結果](https://assets.anoni.net/games/tor-network-country.webp){style="border-radius: 10px;"}
 
 卡片內容包含角色組成、頻寬佔比、執行官方建議版本的比例、主要托管商，以及該國在其他幾份資料中的狀況：使用者估計、OONI 的異常率、橋接繞道的 pluggable transport 分布。
 

--- a/docs/zh-TW/games/tor-network.md
+++ b/docs/zh-TW/games/tor-network.md
@@ -7,8 +7,8 @@ social:
 og:
   enabled: true
   image: https://assets.anoni.net/games/tor-network.png
-  image_width: 2993
-  image_height: 1713
+  image_width: 2560
+  image_height: 1440
 ---
 
 # :material-earth: Tor 中繼地球儀

--- a/tools/shoot_games.mjs
+++ b/tools/shoot_games.mjs
@@ -22,9 +22,20 @@
  * 那個組合會把時鐘快轉，地球儀的 JSON 還沒抓完就被截走，圖上停在「載入中…」。
  * 所以改用 CDP：導頁、輪詢 ready 判斷式、跑完 actions、等 settle、才 captureScreenshot。
  *
+ * === 三個語系各截一份 ===
+ *
+ * 作品的介面語言看網址參數（i18n.js 的 pickLang），不看 navigator.language，
+ * 所以 headless 也能穩定指定。zh-TW 是預設值不帶參數，檔名也不加後綴，站上既有的
+ * zh-TW 圖網址不用動。en 與 zh-cn 各自加後綴，說明頁依語系引用自己那份。
+ *
+ * 外層迴圈跑鏡頭、內層跑語系，同一張圖的三個語言版本會在幾十秒內連續截完。
+ * 地球儀讀的是 assets.anoni.net 每小時重生的 snapshot.json，反過來寫的話
+ * 一輪跑十分鐘就可能跨過整點，同一張圖的三語版本會出現不一樣的數字。
+ *
  * 用法：
- *   node tools/shoot_games.mjs                 # 全部重截
+ *   node tools/shoot_games.mjs                 # 三語系全部重截
  *   node tools/shoot_games.mjs tor-network     # 只截名稱含這段字的
+ *   node tools/shoot_games.mjs --lang=en       # 只截某個語系
  *   node tools/shoot_games.mjs --no-webp       # 只留 PNG
  *
  * 產物在 tools/.shots/，PNG 與 WebP 各一份。確認過畫面才發布：
@@ -45,6 +56,7 @@ const W = 1280, H = 720;                                // 16:9，縮圖與 OG �
 
 const args = process.argv.slice(2);
 const NO_WEBP = args.includes('--no-webp');
+const LANG_ARG = (args.find((a) => a.startsWith('--lang=')) || '').split('=')[1] || '';
 const ONLY = args.filter((a) => !a.startsWith('--'));
 
 /**
@@ -132,6 +144,21 @@ const SHOTS = [
   },
 ];
 
+// zh-TW 不帶參數也不加後綴，維持正規網址與既有檔名
+// html 欄位是三件作品啟動時寫進 <html lang> 的值，截圖前拿它確認語系真的切過去了
+const LANGS = [
+  { code: 'zh-TW', q: null, sfx: '', html: 'zh-Hant' },
+  { code: 'zh-cn', q: 'zh-cn', sfx: '-zh-cn', html: 'zh-Hans' },
+  { code: 'en', q: 'en', sfx: '-en', html: 'en' },
+];
+
+/** ?lang= 要插在 hash 前面。地球儀用 #tw 指定開場國家，順序反了參數會被當成 hash 的一部分 */
+function withLang(url, q) {
+  if (!q) return url;
+  const [p, h] = url.split('#');
+  return `${p}${p.includes('?') ? '&' : '?'}lang=${q}${h ? '#' + h : ''}`;
+}
+
 if (!fs.existsSync(ROOT)) { console.error(`找不到 ${ROOT}`); process.exit(1); }
 try { execFileSync('bash', ['-c', 'command -v google-chrome'], { stdio: 'ignore' }); }
 catch { console.error('找不到 google-chrome'); process.exit(1); }
@@ -193,48 +220,58 @@ async function clickXY(x, y) {
 
 const todo = SHOTS.filter((s) => !ONLY.length || ONLY.some((o) => s.nm.includes(o)));
 if (!todo.length) { console.error(`沒有符合 ${ONLY.join(', ')} 的項目`); process.exit(1); }
+const langs = LANGS.filter((l) => !LANG_ARG || l.code.toLowerCase() === LANG_ARG.toLowerCase());
+if (!langs.length) { console.error(`--lang 只收 ${LANGS.map((l) => l.code).join('、')}`); process.exit(1); }
+console.log(`${todo.length} 個鏡頭 × ${langs.length} 個語系 = ${todo.length * langs.length} 張\n`);
 
 let bad = 0;
 for (const s of todo) {
-  const t0 = Date.now(); errs = [];
-  await send('Emulation.setEmulatedMedia', s.reduced
-    ? { features: [{ name: 'prefers-reduced-motion', value: 'reduce' }] } : { features: [] });
-  await send('Emulation.setDeviceMetricsOverride', { width: W, height: H, deviceScaleFactor: SCALE, mobile: false });
-  // 同一個網址只有 hash 不同時 navigate 不會重載，先清掉再導
-  await send('Page.navigate', { url: 'about:blank' });
-  await sleep(200);
-  await send('Page.navigate', { url: base + s.url });
-  await sleep(1500);
+  for (const L of langs) {
+    const nm = s.nm + L.sfx;
+    const t0 = Date.now(); errs = [];
+    await send('Emulation.setEmulatedMedia', s.reduced
+      ? { features: [{ name: 'prefers-reduced-motion', value: 'reduce' }] } : { features: [] });
+    await send('Emulation.setDeviceMetricsOverride', { width: W, height: H, deviceScaleFactor: SCALE, mobile: false });
+    // 同一個網址只有 hash 不同時 navigate 不會重載，先清掉再導
+    await send('Page.navigate', { url: 'about:blank' });
+    await sleep(200);
+    await send('Page.navigate', { url: base + withLang(s.url, L.q) });
+    await sleep(1500);
 
-  let ok = true;
-  if (s.ready) {
-    ok = false;
-    for (let i = 0; i < 240 && !ok; i++) { ok = await ev(s.ready); if (!ok) await sleep(500); }
-  }
-  if (!ok) { console.log(`✗ ${s.nm}：等不到就緒`); bad++; continue; }
+    let ok = true;
+    if (s.ready) {
+      ok = false;
+      for (let i = 0; i < 240 && !ok; i++) { ok = await ev(s.ready); if (!ok) await sleep(500); }
+    }
+    if (!ok) { console.log(`✗ ${nm}：等不到就緒`); bad++; continue; }
 
-  for (const [kind, a, b] of (s.actions || [])) {
-    if (kind === 'sel') await ev(`document.querySelector(${JSON.stringify(a)})?.click()`);
-    else if (kind === 'eval') await ev(a);
-    else if (kind === 'xy') await clickXY(a, b);
-    else if (kind === 'wait') await sleep(a);
-    await sleep(150);
-  }
-  await sleep(s.settle ?? 3000);
+    for (const [kind, a, b] of (s.actions || [])) {
+      if (kind === 'sel') await ev(`document.querySelector(${JSON.stringify(a)})?.click()`);
+      else if (kind === 'eval') await ev(a);
+      else if (kind === 'xy') await clickXY(a, b);
+      else if (kind === 'wait') await sleep(a);
+      await sleep(150);
+    }
+    await sleep(s.settle ?? 3000);
 
-  const { data } = await send('Page.captureScreenshot', { format: 'png' });
-  const png = path.join(OUT, `${s.nm}.png`);
-  fs.writeFileSync(png, Buffer.from(data, 'base64'));
-  let note = `${(fs.statSync(png).size / 1024).toFixed(0)} KB`;
-  if (!NO_WEBP) {
-    const webp = png.replace(/\.png$/, '.webp');
-    try {
-      execFileSync('cwebp', ['-quiet', '-q', '82', png, '-o', webp]);
-      note += ` → webp ${(fs.statSync(webp).size / 1024).toFixed(0)} KB`;
-    } catch { note += '（cwebp 失敗，只留 PNG）'; }
+    // 免得參數打錯還安靜產出三份一樣的圖
+    const got = await ev(`document.documentElement.lang || ''`);
+    if (got !== L.html) console.log(`  ⚠ ${nm}：頁面 lang 是 ${got}，預期 ${L.html}`);
+
+    const { data } = await send('Page.captureScreenshot', { format: 'png' });
+    const png = path.join(OUT, `${nm}.png`);
+    fs.writeFileSync(png, Buffer.from(data, 'base64'));
+    let note = `${(fs.statSync(png).size / 1024).toFixed(0)} KB`;
+    if (!NO_WEBP) {
+      const webp = png.replace(/\.png$/, '.webp');
+      try {
+        execFileSync('cwebp', ['-quiet', '-q', '82', png, '-o', webp]);
+        note += ` → webp ${(fs.statSync(webp).size / 1024).toFixed(0)} KB`;
+      } catch { note += '（cwebp 失敗，只留 PNG）'; }
+    }
+    console.log(`✓ ${nm.padEnd(32)} ${note}  ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    if (errs.length) console.log(`  ⚠ 頁面丟出例外：${errs[0]}`);
   }
-  console.log(`✓ ${s.nm.padEnd(26)} ${note}  ${((Date.now() - t0) / 1000).toFixed(1)}s`);
-  if (errs.length) console.log(`  ⚠ 頁面丟出例外：${errs[0]}`);
 }
 
 ws.close();

--- a/tools/shoot_games.mjs
+++ b/tools/shoot_games.mjs
@@ -38,8 +38,9 @@
  *   node tools/shoot_games.mjs --lang=en       # 只截某個語系
  *   node tools/shoot_games.mjs --no-webp       # 只留 PNG
  *
- * 產物在 tools/.shots/，PNG 與 WebP 各一份。確認過畫面才發布：
- *   rsync -av tools/.shots/*.webp m6_tailscale:/srv/images-anoni-net/games/
+ * 產物在 tools/.shots/，PNG 與 WebP 各一份，OG 卡片另外複製到 tools/.shots/og/。
+ * 確認過畫面才發布：
+ *   rsync -av tools/.shots/*.webp tools/.shots/og/*.png m6_tailscale:/srv/images-anoni-net/games/
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -50,6 +51,7 @@ import { fileURLToPath } from 'node:url';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(HERE, '..', 'docs', 'zh-TW');   // 作品本體只有這一棵樹有
 const OUT = path.join(HERE, '.shots');
+const OUT_OG = path.join(OUT, 'og');       // OG 卡片，檔名就是圖床上的名字
 const PORT_CDP = 9455;
 const SCALE = 2;                                        // 輸出兩倍圖，站上再縮
 const W = 1280, H = 720;                                // 16:9，縮圖與 OG 都好排
@@ -66,6 +68,8 @@ const ONLY = args.filter((a) => !a.startsWith('--'));
  *            開了才不會每次截到不同角度。另外兩件靠它撐畫面，不能開
  *   actions  ['sel', 選擇器] 點 DOM、['xy', x, y] 點畫布、['eval', 程式碼]、['wait', 毫秒]
  *   settle   動作跑完再等幾毫秒，讓動畫走到好看的狀態
+ *   ogAs     這一張同時當某頁的 OG 卡片，把 PNG 另存一份到 .shots/og/，檔名用這個值。
+ *            社群平台抓的是 PNG，LinkedIn 這類抓取器對 WebP 的支援仍不一致
  */
 // 送出訊息之後電路動畫跑 3.2 秒，再 0.45 秒才彈出教學卡，等 5 秒穩妥
 const SEND_NEXT = [['sel', '#btn-send'], ['wait', 5000], ['sel', '#btn-next'], ['wait', 1500]];
@@ -82,7 +86,7 @@ const SHOTS = [
   // 節點座標寫死在 levels.js，相機初始角度固定，所以畫布上的位置每次都一樣。
   // 這裡的 xy 是量出來的，關卡定義改了要重量。閒置 6 秒會自轉，所以要開 reduced。
   {
-    nm: 'onion-routing-board', url: GAME, reduced: true,
+    nm: 'onion-routing-board', url: GAME, reduced: true, ogAs: 'onion-routing',
     actions: [['sel', '#hint-close']], settle: 2500,
   },
   {
@@ -112,12 +116,12 @@ const SHOTS = [
   // 粒子與殘影是這件作品的主體，不能開 reduced，等久一點讓電路鋪滿畫面
   {
     nm: 'onion-rendezvous-flow', url: '/games/onion-rendezvous/play/index.html',
-    actions: [['sel', '#hint-close']], settle: 12000,
+    ogAs: 'onion-rendezvous', actions: [['sel', '#hint-close']], settle: 12000,
   },
 
   // ── Tor 中繼地球儀 ──
   {
-    nm: 'tor-network-globe', url: GLOBE, ready: GLOBE_READY,
+    nm: 'tor-network-globe', url: GLOBE, ready: GLOBE_READY, ogAs: 'tor-network',
     actions: [['sel', '#hint-close']], settle: 9000,
   },
   {
@@ -209,6 +213,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 await send('Runtime.enable'); await send('Page.enable');
 fs.mkdirSync(OUT, { recursive: true });
+fs.mkdirSync(OUT_OG, { recursive: true });
 
 /** 點畫布。作品聽的是 pointerdown，CDP 的 mouse 事件會一併產生 pointer 事件 */
 async function clickXY(x, y) {
@@ -262,6 +267,10 @@ for (const s of todo) {
     const png = path.join(OUT, `${nm}.png`);
     fs.writeFileSync(png, Buffer.from(data, 'base64'));
     let note = `${(fs.statSync(png).size / 1024).toFixed(0)} KB`;
+    if (s.ogAs) {
+      fs.copyFileSync(png, path.join(OUT_OG, `${s.ogAs}${L.sfx}.png`));
+      note += ` → og/${s.ogAs}${L.sfx}.png`;
+    }
     if (!NO_WEBP) {
       const webp = png.replace(/\.png$/, '.webp');
       try {
@@ -276,5 +285,5 @@ for (const s of todo) {
 
 ws.close();
 console.log(`\n產物在 ${path.relative(process.cwd(), OUT)}/，看過畫面再發布：`);
-console.log('  rsync -av tools/.shots/*.webp m6_tailscale:/srv/images-anoni-net/games/');
+console.log('  rsync -av tools/.shots/*.webp tools/.shots/og/*.png m6_tailscale:/srv/images-anoni-net/games/');
 process.exit(bad ? 1 : 0);


### PR DESCRIPTION
原本九頁說明共用同一組圖，圖上的介面全是正體中文，英文與簡中的讀者看到的畫面跟自己按下去會看到的對不起來。社群分享的 OG 卡片也是同一張。這個 PR 讓每個語系用自己那份。

## 截圖工具

`tools/shoot_games.mjs` 加一層語系維度：

- 三件作品的語言看網址參數（`i18n.js` 的 `pickLang`），不看 `navigator.language`，headless 也指定得動
- en 檔名加 `-en`、zh-cn 加 `-zh-cn`，zh-TW 維持不帶參數也不加後綴，站上既有的圖網址不用動
- 迴圈是外層鏡頭、內層語系。地球儀讀的是每小時重生的 `snapshot.json`，反過來寫的話一輪跑十分鐘就可能跨過整點，同一張圖的三個語言版本會出現不一樣的數字
- 截圖前比對 `<html lang>`，參數打錯不會安靜產出三份一樣的圖
- 鏡頭新增 `ogAs` 欄位，截完把 PNG 複製一份到 `.shots/og/`，檔名就是圖床上的名字。OG 只出 PNG，LinkedIn 這類抓取器對 WebP 的支援仍不一致
- `--lang=en` 可以只重截單一語系

## 圖片

- 頁內示意圖：10 個鏡頭 × 3 語系 = 30 張 WebP
- OG 卡片：3 件作品 × 3 語系 = 9 張 PNG，取自各自 hero 那一張

都已上傳 `assets.anoni.net/games/`。zh-TW 那批是同一輪重截的覆蓋。

## 一併更新

- OG 尺寸從 2990×1706 換成這批截圖的 2560×1440，`og:image:width` 與 `height` 跟著改
- 資料快照是 2026-08-18 08:00 UTC，德國共識權重 29.1% → 29.5%、台數 1706 → 1715、佔比 16.8% → 16.9%，三語系 alt 一併更新
- `games-globe-open-data` 這篇的 en 與 zh-CN 版，內文的地球儀圖也換成自己語系那張

## 驗證

- `mkdocs build -s` 三個語系都過，產出 HTML 確認 `og:image` 指向各語系的絕對網址、頁內圖指向各語系的鏡像檔
- `tools/docs_style_lint.py` 0 error
- 逐張看過畫面，介面語言與版面都正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)
