### PR TITLE
docs: lint 已改成 blocking，同步過期的說明

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,8 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 - **docs-style-lint.yml**: 對 PR 變更到的中文 Markdown 跑 `tools/docs_style_lint.py`
   - 觸發路徑：`docs/zh-TW/**/*.md`、`docs/zh-CN/**/*.md`、`docs/en/**/*.md` 與 linter 本身
   - 只掃這次 PR 變更的檔案，避免舊文的遺留違規擋住新貢獻
-  - 目前是 warn 階段，問題以 annotation 標在變更行上，`continue-on-error` 讓 job 維持綠燈。要改成 blocking 需拿掉 `continue-on-error` 並在 repo 設定加上 branch protection
+  - 這個 job 會擋 merge。error 級規則讓 linter 回 exit 1，job 就紅；warn 級規則仍只以 annotation 標在變更行上，不影響 exit code
+  - 待辦：repo 設定尚未把這個 check 列為 branch protection 必過，所以目前擋得住 PR 的紅燈，擋不住有權限的人直接合併
 
 - **games-checks.yml**: 「Tor 中繼地球儀」的互動與版面檢查（headless Chrome）
   - 觸發路徑：`docs/zh-TW/games/tor-network/**`、`tools/check_*.mjs`
@@ -304,6 +305,6 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
   - 行長度: 100 字元
   - 啟用規則: E (錯誤), F (pyflakes), I (import sorting)
 
-- 中文文件：使用 `tools/docs_style_lint.py`，規則出自貢獻者百科，目前為 warn 階段不擋 merge
+- 文件：使用 `tools/docs_style_lint.py`，規則出自貢獻者百科，三語系都掃。error 級擋 merge，warn 級只提醒
 - 使用 uv 管理所有 Python 專案依賴
 - 所有專案使用 Python 3.12+

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 把公開[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)「寫作風格規範」裡可機器判斷的硬規則做成檢查，輸出 `file:line` 與規則代碼。
 
-編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。三個語系都掃，但套用的規則不同。中文那組是標點與句型，套用在 zh-TW 與 zh-CN。英文那組獨立（破折號與分號在英文是正常標點），2026-08 起納入 docs/en，目前實作 `bold-lead-sentence`、`title-colon` 與 `machine-field` 三條。linter 依路徑自動選規則集，見 `is_english_doc`。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動跑，目前為 warn 階段（提醒不擋）。
+編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。三個語系都掃，但套用的規則不同。中文那組是標點與句型，套用在 zh-TW 與 zh-CN。英文那組獨立（破折號與分號在英文是正常標點），2026-08 起納入 docs/en，目前實作 `bold-lead-sentence`、`title-colon` 與 `machine-field` 三條。linter 依路徑自動選規則集，見 `is_english_doc`。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動跑。error 級擋 merge，warn 級只提醒。
 
 ## 用法
 
@@ -23,9 +23,11 @@ python3 tools/docs_style_lint.py --format json <path>
 
 ## CI：GitHub Action（只掃變更檔）
 
-舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的中文 Markdown（`docs/zh-TW`、`docs/zh-CN`，不含 en），跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
+舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的 Markdown（`docs/zh-TW`、`docs/zh-CN`、`docs/en`），跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
 
-目前是 **warn 階段**：問題只提醒，job 維持綠燈，不擋 merge。要改 blocking：拿掉 workflow 裡的 `continue-on-error`，並在 repo 設定把這個 check 設為 branch protection 必過。
+**這個 job 會擋 merge**：有任一 error 時 linter 回 exit 1，job 就紅。warn 級規則只標 annotation，不影響 exit code，因為改法要看語境，機器不宜代勞。要讓 warn 也擋，得先把對應規則升成 error。
+
+repo 設定還沒把這個 check 列為 branch protection 必過，所以它擋得住 PR 的紅燈，擋不住有權限的人直接合併。
 
 本機重現 CI 的掃法：
 
@@ -108,6 +110,6 @@ git diff --name-only --diff-filter=ACM origin/main... \
 ## 上線進程
 
 1. 私有試跑穩定。✅
-2. 移入公開 `anoni-net/docs`，GitHub Action 對變更檔跑「warn 不擋」。← 現在
-3. 收斂誤報後升為 blocking gate（拿掉 `continue-on-error` + 設 branch protection 必過）。
+2. 移入公開 `anoni-net/docs`，GitHub Action 對變更檔跑「warn 不擋」。✅
+3. 升為 blocking gate。已拿掉 `continue-on-error`，error 級會擋。← 現在，尚缺 repo 設定的 branch protection 必過。
 4. 視需要做一次全庫清理 pass，把舊文遺留違規補掉。


### PR DESCRIPTION
`#254` 把 `docs-style-lint.yml` 的 `continue-on-error` 拿掉了，但說明文件有五處還寫著「warn 階段、不擋 merge」，跟實際行為不符。當時只改了 `CLAUDE.md` 的 tools 表與觸發路徑兩處，漏掉其餘。

## 修正的位置

- `CLAUDE.md:258` CI/CD 段落的 docs-style-lint 說明
- `CLAUDE.md:307` 程式碼風格段落
- `tools/README.md:5` 開頭的工具定位
- `tools/README.md:28` CI 段落
- `tools/README.md:112` 上線進程的第 2、3 步

## 一併寫清楚的兩件事

**擋的是 error 級規則。** `bold-lead-sentence`、`title-colon` 這些 warn 級規則仍只標 annotation，不影響 exit code，因為改法要看語境、機器不宜代勞。要讓 warn 也擋，得先把對應規則升成 error。原本的文件沒有區分這一層，容易讓人以為所有規則都會擋。

**branch protection 還沒設。** repo 設定尚未把這個 check 列為必過，所以它擋得住 PR 的紅燈，擋不住有權限的人直接合併。這一步 workflow 管不到，已列為待辦寫在文件裡。

`tools/README.md` 的 CI 段落順帶補上觸發路徑已含 `docs/en`，原文還寫著「不含 en」。

## 沒有動到的

純文件修正，不碰 workflow 與 linter 行為。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
