### PR TITLE
docs(changelog): 補上 Tor Browser 15.0.20、Tails 7.10.1、OONI Probe 6.2.0

### DIFF
--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -8,6 +8,20 @@ icon: material/access-point-network
 
 [OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
 
+## OONI Probe 6.2.0
+
+> 2026-08-13 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.2.0){target="_blank"}
+
+- Measurement engine moves to OONI Probe CLI v3.30.0, the first engine bump of the 6.x series after every earlier release stayed on v3.29.0.
+- Android adds in-app language selection, matching what desktop gained in 6.1.1.
+- Improved offline handling and retry logic. Unparseable reports are handled gracefully during submission, and file writes are now atomic.
+- Anonymous credentials gain a management UI and a reset function.
+- Passport updated to 0.1.5, with support for proxies and timeouts.
+- Secure storage on macOS and iOS gains error handling and a retry mechanism.
+- Added an indexed query for counting unviewed completed results.
+- Dependency updates: Kotlin to 2.4.10 and the Android Gradle Plugin to 9.1.1.
+- Updated translations.
+
 ## OONI Probe 6.1.1
 
 > 2026-07-07 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}

--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.10.1
+
+> 2026-08-05 · [Upstream announcement](https://tails.net/news/version_7.10.1/){target="_blank"}
+
+- Emergency security release fixing critical flaws in the Linux kernel and the expat XML library.
+- The kernel is updated to 6.12.100, fixing CVE-2026-64560, which could let Tor Browser inside Tails gain administrator privileges. A malicious website that exploits it could fully compromise Tails and deanonymize the user. The attack is unlikely and would take a strong adversary such as a government or a hacking firm; no active exploitation has been observed.
+- The expat XML library is updated to 2.8.2, fixing DSA-6404-1, a set of flaws that could let applications using expat gain administrator privileges. Opening a malicious file in LibreOffice, Audacity, or Git could lead to the same full compromise and deanonymization. No active exploitation has been observed.
+- USB images and automatic upgrades are 70 MB smaller after removing unused firmware.
+- Automatic upgrades are now compressed with zstd for a faster startup, matching what the USB image has done since Tails 7.0.
+- This is a security-only release that keeps 7.10's software set. Automatic upgrades are available from Tails 7.0 or later.
+
 ## Tails 7.10
 
 > 2026-07-23 · [Upstream announcement](https://tails.net/news/version_7.10/){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 15.0.20
+
+> 2026-08-18 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
+
+- A small release focused on Firefox security fixes.
+- Rebased the Firefox base onto 140.14.0esr (tor-browser#45204); desktop and Android GeckoView also moved to 140.14.0esr.
+- Backported security fixes from Firefox 154 (tor-browser#45219).
+- Updated libevent to 2.1.13 in the build toolchain (tor-browser-build#41839).
+- Updated Go to 1.25.13 for Windows, Linux, and Android builds.
+- Updated the torbrowser.gpg keyring with a new subkey and a revised expiration date for the main key (tor-browser-build#41850).
+
 ## Tor Browser 16.0a9 (alpha)
 
 > 2026-07-23 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -8,6 +8,20 @@ icon: material/access-point-network
 
 [OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等网络审查观测工具的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## OONI Probe 6.2.0
+
+> 2026-08-13 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.2.0){target="_blank"}
+
+- 量测引擎升至 OONI Probe CLI v3.30.0，是 6.x 系列首次更动引擎版本，先前各版皆停在 v3.29.0。
+- Android 版新增 app 内语言切换，与桌面版在 6.1.1 已有的功能对齐。
+- 强化离线处理与重试机制。量测提交遇到无法解析的报告会妥善处理，写文件改为原子操作。
+- 匿名凭证（anonymous credentials）新增管理界面与重置功能。
+- Passport 升至 0.1.5，支持 proxy 与超时设定。
+- macOS 与 iOS 的 secure storage 补上错误处理与重试机制。
+- 新增未读完成结果的计数查询索引。
+- 依赖项更新，Kotlin 升至 2.4.10，Android Gradle Plugin 升至 9.1.1。
+- 翻译更新。
+
 ## OONI Probe 6.1.1
 
 > 2026-07-07 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.10.1
+
+> 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}
+
+- 紧急安全更新，修补 Linux 内核与 expat XML 库的重大漏洞。
+- 内核升至 6.12.100，修补 CVE-2026-64560。此漏洞可让 Tails 内的 Tor Browser 取得管理员权限，访问的恶意网站若成功利用，可能完整接管 Tails 并进行去匿名化。攻击难度高，具备政府或商业黑客团队等级的资源才办得到，目前尚未发现实际被利用案例。
+- expat XML 库升至 2.8.2，修补 DSA-6404-1 这组漏洞。使用 expat 的应用程序（LibreOffice、Audacity、Git 等）被诱导开启恶意文件时，可能被用来取得管理员权限，后续同样可能导致接管与去匿名化。目前尚未发现实际被利用案例。
+- 移除未使用的 firmware，USB image 与自动升级文件各缩小 70 MB。
+- 自动升级改用 zstd 压缩加快启动，与 Tails 7.0 起 USB image 的做法一致。
+- 此版为安全专用发布，沿用 7.10 的软件组合。可从 Tails 7.0 以后版本自动升级。
+
 ## Tails 7.10
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 15.0.20
+
+> 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
+
+- 以 Firefox 安全修补为主的小版本。
+- Firefox 基底 rebase 至 140.14.0esr（tor-browser#45204），桌面版与 Android 版 GeckoView 同步升至 140.14.0esr。
+- 从 Firefox 154 backport 安全修补（tor-browser#45219）。
+- libevent 升至 2.1.13（tor-browser-build#41839）。
+- 构建工具链的 Go 升至 1.25.13（Windows、Linux、Android）。
+- 更新构建流程的 torbrowser.gpg keyring，加入新子密钥并调整主密钥到期日（tor-browser-build#41850）。
+
 ## Tor Browser 16.0a9（Alpha 测试通道）
 
 > 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -8,6 +8,20 @@ icon: material/access-point-network
 
 [OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## OONI Probe 6.2.0
+
+> 2026-08-13 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.2.0){target="_blank"}
+
+- 量測引擎升至 OONI Probe CLI v3.30.0，是 6.x 系列首次更動引擎版本，先前各版皆停在 v3.29.0。
+- Android 版新增 app 內語言切換，與桌面版在 6.1.1 已有的功能對齊。
+- 強化離線處理與重試機制。量測提交遇到無法解析的報告會妥善處理，寫檔改為原子操作。
+- 匿名憑證（anonymous credentials）新增管理介面與重設功能。
+- Passport 升至 0.1.5，支援 proxy 與逾時設定。
+- macOS 與 iOS 的 secure storage 補上錯誤處理與重試機制。
+- 新增未讀完成結果的計數查詢索引。
+- 依賴項目更新，Kotlin 升至 2.4.10，Android Gradle Plugin 升至 9.1.1。
+- 翻譯更新。
+
 ## OONI Probe 6.1.1
 
 > 2026-07-07 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.10.1
+
+> 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}
+
+- 緊急安全更新，修補 Linux 核心與 expat XML 函式庫的重大漏洞。
+- 核心升至 6.12.100，修補 CVE-2026-64560。此漏洞可讓 Tails 內的 Tor Browser 取得管理員權限，造訪的惡意網站若成功利用，可能完整接管 Tails 並進行去匿名化。攻擊難度高，具備政府或商業駭客團隊等級的資源才辦得到，目前尚未發現實際被利用案例。
+- expat XML 函式庫升至 2.8.2，修補 DSA-6404-1 這組漏洞。使用 expat 的應用程式（LibreOffice、Audacity、Git 等）被誘導開啟惡意檔案時，可能被用來取得管理員權限，後續同樣可能導致接管與去匿名化。目前尚未發現實際被利用案例。
+- 移除未使用的 firmware，USB image 與自動升級檔各縮小 70 MB。
+- 自動升級改用 zstd 壓縮加快啟動，與 Tails 7.0 起 USB image 的做法一致。
+- 此版為安全專用釋出，沿用 7.10 的軟體組合。可從 Tails 7.0 以後版本自動升級。
+
 ## Tails 7.10
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.20
+
+> 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
+
+- 以 Firefox 安全修補為主的小版本。
+- Firefox 基底 rebase 至 140.14.0esr（tor-browser#45204），桌面版與 Android 版 GeckoView 同步升至 140.14.0esr。
+- 從 Firefox 154 backport 安全修補（tor-browser#45219）。
+- libevent 升至 2.1.13（tor-browser-build#41839）。
+- 建置工具鏈的 Go 升至 1.25.13（Windows、Linux、Android）。
+- 更新建置流程的 torbrowser.gpg keyring，加入新子金鑰並調整主金鑰到期日（tor-browser-build#41850）。
+
 ## Tor Browser 16.0a9（Alpha 測試通道）
 
 > 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

例行對照上游 release notes，補齊 `docs/*/changelog/` 從 7 月下旬到 8 月中缺的三個版本，三語系同步新增。

相關 Issue / Related issue：無

| 軟體 | 版本 | 發布日 | 上游 |
|---|---|---|---|
| Tor Browser | 15.0.20 | 2026-08-18 | [公告](https://blog.torproject.org/new-release-tor-browser-15020/) |
| Tails | 7.10.1 | 2026-08-05 | [公告](https://tails.net/news/version_7.10.1/) |
| OONI Probe | 6.2.0 | 2026-08-13 | [公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.2.0) |

重點：

- **Tor Browser 15.0.20** 是以 Firefox 安全修補為主的小版本，rebase 至 140.14.0esr 並 backport Firefox 154 的修補。
- **Tails 7.10.1** 是緊急安全釋出，修補核心的 CVE-2026-64560 與 expat 的 DSA-6404-1，兩者都可能被用來取得管理員權限並進一步去匿名化。條目保留上游「攻擊難度高、尚未發現實際被利用」的說明，寫法比照既有的 7.9.1 與 7.8.1。
- **OONI Probe 6.2.0** 的量測引擎升至 CLI v3.30.0。6.0.0 到 6.1.1 五個版本都停在 v3.29.0，這是 6.x 系列首次更動引擎版本，對做觀測的人是有意義的訊號，所以在條目裡標了出來。

**Arti** 上游 CHANGELOG 頂端仍是已收錄的 2.5.1，**Tor Browser Alpha** 最新仍是已收錄的 16.0a9，兩者沒有新版可補。

## 改動範圍 / Scope

- 語系 / Language：zh-TW、zh-CN、en
- 分類 / Category：changelog
- 對讀者的影響 / Reader impact：純內容新增，9 個檔案共 108 行。沒有動 nav、沒有新檔案、沒有新的站內相對連結，不會有連結壞掉或 URL 變更。

## 自我檢查 / Self-check

- [x] 檔名全小寫、用連字號分隔，slug 以英文為主。（沿用既有檔案，未新增檔案）
- [x] front matter 齊全（title、description；blog 另含 date、slug、categories、authors）。（沿用既有 front matter，未更動）
- [x] 內部連結用相對路徑，沒有寫成 `/docs/zh-TW/...` 絕對路徑。（本次只新增上游外部連結）
- [x] 標點符合社群規範：沒有用 `——`、`；`、全形「／」，避免「不是...而是...」這類寫法。
- [x] 連續「」引號之間有加「、」。（本次條目沒有連續引號）
- [x] 圖片放在 `assets/images/`，有 alt 文字與授權標示。（本次無圖片）
- [x] 文末有「相關閱讀」之類的橫向連結（2 到 4 篇）。（changelog 是累積式列表頁，沿用既有頁面結構）

## 翻譯（如適用）/ Translation (if applicable)

- [x] 內容以 zh-TW 為來源同步，沒有自行更動事實。
- [x] zh-CN 已調整為中國用語；en 已補上在地脈絡。（en 沿用英文站既有的分號與句式慣例，zh-CN 用內核、显卡、软件、依赖项等用語）

## 安全核心內容（如適用）/ Security-core content (if applicable)

- [ ] 本 PR 改到 tools、scenarios、advanced 的工具操作或 OPSEC 內容。（未改到，只動 changelog）

## 本機驗證

- `python3 tools/test_docs_style_lint.py`：76 個案例全過。
- `python3 tools/docs_style_lint.py <9 個變更檔>`：0 error、0 warn，exit 0。

沒有跑完整 `mkdocs build`，因為這次是純內容新增，建置面沒有可壞的東西。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
