### PR TITLE
ci(build-docs): 為連網步驟設 timeout，卡住的 run 不再佔死 concurrency

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,21 @@ jobs:
       run:
         working-directory: ./docs
     steps:
+      # 每個會連網的步驟各自設 timeout-minutes，把建置的上界壓在正常耗時（約 5 分鐘）
+      # 的數倍以內。2026-08-18 有一次 `apt-get update` 卡了兩小時，workflow 當時沒有
+      # 任何上界，那個 run 就一直佔著 build-docs-s3 這組 concurrency，期間所有發布都
+      # 排隊卡死，最後靠人工察覺才取消。GitHub 預設的 360 分鐘等於沒有保護。
+      #
+      # 刻意不用 job 層的 timeout-minutes：job 層逾時可能落在 `Clean the all files`
+      # 與 `Upload to S3` 之間，那正是上面 concurrency 註解要避開的狀況，會留下一個
+      # 空的 bucket。逐步設定的話，逾時只會發生在碰 S3 之前，最壞是這次沒部署成功，
+      # 站上維持上一版。
+      #
+      # 碰 S3 的兩步與其後的 Cloudflare 清除不設上界，理由同上，寧可讓它們跑完。
+      # 純本機運算的步驟（Test cache purge script、Show packages、Verify onion output
+      # 等）也不設，它們沒有卡住的來源，設了只是雜訊。
       - name: Checkout
+        timeout-minutes: 10
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -54,10 +68,13 @@ jobs:
         run: sh ./replace_sitename_anoni_onion.sh
 
       - name: Update libs
+        timeout-minutes: 5
         run: sudo apt-get update
       - name: Install ca
+        timeout-minutes: 5
         run: sudo apt-get install ca-certificates
       - name: Set up Python
+        timeout-minutes: 10
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -68,8 +85,10 @@ jobs:
         run: python3 ../tools/test_cf_purge.py
 
       - name: Install uv
+        timeout-minutes: 10
         uses: astral-sh/setup-uv@v8.1.0
       - name: Sync Packages
+        timeout-minutes: 10
         run: uv sync --group=dev
       - name: Show packages
         run: uv tree
@@ -91,6 +110,7 @@ jobs:
       # 依 variant 分開存，最後再留一層不分 variant 的 fallback：鏡像的是第三方外部
       # 資產，兩個變體抓到的內容其實一樣，新增的 onion 格不必從零開始重抓一輪。
       - name: Cache privacy plugin external assets
+        timeout-minutes: 10
         uses: actions/cache@v6
         with:
           path: docs/.cache/plugin/privacy
@@ -100,18 +120,23 @@ jobs:
             mkdocs-privacy-
 
       - name: Install mkdocs-material social dependencies
+        timeout-minutes: 10
         run: sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       # zh-TW 只建一份，就在根路徑。曾經另外跑 run_zh-tw.sh 建一棵 /docs/zh-tw/，
       # 內容與根路徑逐位元組相同，只為了讓語言選單有對稱的網址。兩棵樹各自
       # self-canonical 又各自進 sitemap，等於自己製造重複內容。選單改填 /docs/ 之後
       # 那棵樹沒有存在理由。舊網址由 Cloudflare Redirect Rule 301 導回 /docs/。
       - name: Build Docs (/)
+        timeout-minutes: 20
         run: source ./.venv/bin/activate; sh ./run.sh;
       - name: Build Docs (/zh-cn)
+        timeout-minutes: 20
         run: source ./.venv/bin/activate; sh ./run_zh-cn.sh;
       - name: Build Docs (/en)
+        timeout-minutes: 20
         run: source ./.venv/bin/activate; sh ./run_en.sh;
       - name: Replace OG images
+        timeout-minutes: 10
         run: |
           # output 結構已改為依年份 blog/YYYY/MM/
           for base in ./output ./output/en; do


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

`build_docs.yml` 沒有任何時間上界，套用的是 GitHub 預設的 360 分鐘。2026-08-18 發布 #257 時踩到：先前一個 run（[32162140539](https://github.com/anoni-net/docs/actions/runs/32162140539)）在 `sudo apt-get update` 卡了兩個多小時，兩格都停在同一步。因為 `concurrency.cancel-in-progress` 是 `false`，它一直佔著 `build-docs-s3`，期間任何發布都只能排隊，最後靠人工察覺才手動取消。正常一次建置約 5 分鐘。

改成逐步設 `timeout-minutes`，只綁會連網、且位於任何 S3 操作之前的 12 個步驟。

相關 Issue / Related issue：無

### 為什麼不用 job 層的 timeout-minutes

這是這個 PR 唯一需要討論的取捨。job 層一行就能解決，但它的逾時可能落在 `Clean the all files`（`aws s3 rm --recursive`）與 `Upload to S3`（`aws s3 sync`）之間，那正是現有 concurrency 註解花了一段在避開的狀況：

> 用 false 而非 true：run 被中途取消有機會停在 `s3 rm` 之後、`s3 sync` 之前，那會留下一個空的 bucket。排隊比取消安全。

job 層 timeout 造成的中止跟取消是同一回事，會把那個已經被排除的風險再放回來。逐步設定則保證逾時只發生在碰 S3 之前，最壞的結果是這次沒部署成功，站上維持上一版。

### 上界怎麼分配

| 步驟 | 上界 | 步驟 | 上界 |
|---|---|---|---|
| Checkout | 10 分 | Cache privacy plugin external assets | 10 分 |
| Update libs | 5 分 | Install mkdocs-material social dependencies | 10 分 |
| Install ca | 5 分 | Build Docs (/) | 20 分 |
| Set up Python | 10 分 | Build Docs (/zh-cn) | 20 分 |
| Install uv | 10 分 | Build Docs (/en) | 20 分 |
| Sync Packages | 10 分 | Replace OG images | 10 分 |

沒設上界的是三類：碰 S3 的 `Clean the all files` 與 `Upload to S3`，其後的 `Purge Cloudflare cache`，以及純本機運算的 `Rewrite URLs for onion`、`Test cache purge script`、`Show packages`、`Inject PWA build version`、`Onion robots.txt`、`Drop service worker from onion build`、`Verify onion output`。

建置步驟給到 20 分是因為 privacy 外掛在快取未命中時要對十幾個外部主機重抓資產，那條路徑本來就慢。單一步驟卡住的話，最久 20 分鐘就會被砍掉，對比原本的 360 分鐘。

## 改動範圍 / Scope

- 語系 / Language：不適用（只動 `.github/workflows/`）
- 分類 / Category：不適用
- 對讀者的影響 / Reader impact：無。不改任何 docs 內容、產物或部署行為，只在建置卡住時提早失敗。

## 已知的殘留缺口

`Cache privacy plugin external assets` 的 post-step（快取寫回）不受 `timeout-minutes` 保護，那是 `actions/cache` 的 post 階段。不過它跑在 S3 上傳之後，真的卡住也只會延後下一個排隊的 run，S3 內容是一致的。

更根本的做法是把部署從「`s3 rm --recursive` 再 `s3 sync`」換成單次 `s3 sync --delete`，那樣就沒有空窗期，取消與逾時都變安全，`cancel-in-progress` 也能改回 `true`。那是另一個題目，範圍比這個 PR 大，先不動。

## 自我檢查 / Self-check

不適用，本 PR 未改動 docs 內容。已用 `yaml.safe_load` 驗證檔案仍可解析，並逐步確認 `timeout-minutes` 的落點與 job 層未被設定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
