### PR TITLE
ci(build-docs): 繞開 azure apt mirror，逾時不再吃光整步的時間

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -67,12 +67,29 @@ jobs:
         if: matrix.variant == 'onion'
         run: sh ./replace_sitename_anoni_onion.sh
 
+      # runner 的 apt sources 走內建的 mirrorlist（/etc/apt/apt-mirrors.txt），第一順位
+      # 是 azure.archive.ubuntu.com。2026-08-19 的發布連兩次卡死在這一步：那台 mirror
+      # 連不上，apt 對每個 index 檔重試到預設上限才 fallback 到 archive.ubuntu.com，
+      # 光重試就吃掉四分半，剩下的時間抓不完，兩次都撞上 5 分鐘的 timeout。第三次重跑
+      # 才過，clearnet 因此比 onion 晚了快 20 分鐘上線。
+      #
+      # 兩層處理。先把 mirrorlist 裡的 azure 換成 archive.ubuntu.com，不再依賴 apt 自己
+      # 的 fallback。這步只是 apt-get update 加 ca-certificates，archive.ubuntu.com 抓
+      # InRelease 也就十幾秒，跨區慢一點無所謂。再壓低重試次數與單次連線逾時，讓萬一
+      # archive 也出狀況時能快速失敗，而不是把 timeout 耗光。
+      #
+      # mirrorlist 的路徑是 runner 映像的實作細節，未來可能改。用 if 包住，檔案不在就
+      # 略過，行為退回現況而不是讓整步失敗。
       - name: Update libs
         timeout-minutes: 5
-        run: sudo apt-get update
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+          fi
+          sudo apt-get -o Acquire::Retries=1 -o Acquire::http::Timeout=15 update
       - name: Install ca
         timeout-minutes: 5
-        run: sudo apt-get install ca-certificates
+        run: sudo apt-get -o Acquire::Retries=1 -o Acquire::http::Timeout=15 install ca-certificates
       - name: Set up Python
         timeout-minutes: 10
         uses: actions/setup-python@v6


### PR DESCRIPTION
## 問題

2026-08-19 發布 Signal Proxy 那頁（#259）時，`build_docs.yml` 的 clearnet 那格連兩次卡死在第一步 `Update libs`：

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
...（反覆重試約四分半）
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease      ← 07:30:39 才 fallback
##[error]The action 'Update libs' has timed out after 5 minutes.   ← 07:35:13
```

runner 內建的 mirrorlist 第一順位是 `azure.archive.ubuntu.com`，那台當時連不上。apt 對每個 index 檔重試到預設上限才 fallback 到 `archive.ubuntu.com`，光重試就吃掉四分半，剩下不到 30 秒抓不完，兩次都撞上 #258 設的 5 分鐘 timeout。第三次重跑才過，clearnet 比 onion 晚了快 20 分鐘上線。

`Update libs` 是第一步，失敗時後面全部 skipped，所以沒有碰到 S3，站上維持上一版，沒有出現 #258 註解裡提的空窗。這部分的設計是有效的。

## 改法

兩層處理：

1. 先把 mirrorlist 裡的 azure 換成 `archive.ubuntu.com`，不再依賴 apt 自己的 fallback。這步只是 `apt-get update` 加 `ca-certificates`，`archive.ubuntu.com` 抓 InRelease 也就十幾秒（上面 log 的 `Hit:2` 不到一秒），跨區慢一點無所謂。
2. 加 `Acquire::Retries=1` 與 `Acquire::http::Timeout=15`，讓萬一 `archive` 也出狀況時快速失敗，而不是把 5 分鐘 timeout 耗光。

mirrorlist 的路徑是 runner 映像的實作細節，未來可能改，所以用 `if [ -f ... ]` 包住。檔案不在就略過，行為退回現況而不是讓整步失敗。

## 驗證限制

`build_docs.yml` 只在 push to `docs` 或 `workflow_dispatch` 觸發，PR 不會跑它，而手動觸發會實際部署到 S3，所以合併前沒辦法安全驗證。實際效果要等下次發布。

風險可控的理由：最壞情況是 sed 沒對到（mirrorlist 格式與預期不同），那時 apt 照原樣跑，等同現況；`Acquire` 那兩個參數在 mirror 正常時不會被觸發。YAML 語法已用 `yaml.safe_load` 驗過。

## 另一個可以考慮的方向

`Update libs` 與 `Install ca` 這兩步是這個 job 唯二會碰 apt 的地方，而 `ca-certificates` 在 ubuntu-24.04 runner 映像裡本來就有。如果確認沒有其他理由需要它，整組拿掉可以直接消滅這個故障點。這次沒動，因為不確定當初加的原因，留給你判斷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
