### PR TITLE
fix(pwa): 修離線時拿不到快取的網址形狀，停止每次部署清空讀者的離線內容

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ CC BY-NC-SA 4.0（禁止商業使用）。清單見根目錄 [`NOTICE`](./NOTICE
 | 文件編輯標準 | `docs_style_lint.py`、`test_docs_style_lint.py` | 把貢獻者百科「寫作風格規範」可機器判斷的部分做成檢查。三語系都掃，中英各一組規則（破折號與分號在英文屬正常用法，不套中文那組）。純標準庫，無外部相依。細節見 [`tools/README.md`](./tools/README.md) |
 | 部署 | `cf_purge.py`、`test_cf_purge.py` | 建置完把產物映射回網址，逐批清除 Cloudflare 快取（每批 30 條）|
 | 地球儀資料 | `gen_*.py`、`publish_games_data.sh` | 產生 `docs/zh-TW/games/tor-network/` 的靜態 JSON。`snapshot.json`、`torusers.json`、`seacable.json` 會持續變動，由 `publish_games_data.sh` 在正式機重生並檢查後發布到 assets，其餘幾份變動以季或年計，跟文件站一起發布即可 |
-| 地球儀版面檢查 | `check_*.mjs` | headless Chrome 跑的互動與版面檢查，由 `games-checks.yml` 在 PR 觸發 |
+| 地球儀版面檢查 | `check_double_tap.mjs`、`check_focus.mjs`、`check_pinch_release.mjs`、`check_sub_gauge.mjs`、`fix_trunk_land.mjs`、`shoot_games.mjs` | headless Chrome 跑的互動與版面檢查，由 `games-checks.yml` 在 PR 觸發 |
+| PWA 離線 | `check_precache.mjs`、`test_sw_offline.mjs` | 前者比對預快取清單與 `docs/output` 的實際檔案，並驗索引頁連出去的網址形狀命中得了快取的 key（需先建置）。後者把 `sw.js` 的離線函式抽出來單元測試，不需要建置。兩支都沒進 CI，改動 `docs/zh-TW/sw.js` 時手動跑 |
 
 ## 開發環境設置
 

--- a/docs/en/manifest.webmanifest
+++ b/docs/en/manifest.webmanifest
@@ -5,7 +5,7 @@
   "description": "Taiwan-anchored volunteer observatory tracking networked freedom across the Sinophone Asia-Pacific region — OONI measurements, Tor relay monitoring, and on-the-ground community context.",
   "lang": "en",
   "start_url": ".",
-  "scope": ".",
+  "scope": "..",
   "display": "standalone",
   "theme_color": "#00aeff",
   "background_color": "#ffffff",

--- a/docs/zh-CN/manifest.webmanifest
+++ b/docs/zh-CN/manifest.webmanifest
@@ -5,7 +5,7 @@
   "description": "匿名网络、Tor、Tails、OONI、网络自由、网络审查、ASNs 观测范围、检测列表、本地推广与翻译",
   "lang": "zh-CN",
   "start_url": ".",
-  "scope": ".",
+  "scope": "..",
   "display": "standalone",
   "theme_color": "#00aeff",
   "background_color": "#ffffff",

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -14,6 +14,13 @@
  * 寫成 "/docs/"。規格上 id 相對 origin 解析，結果是 https://anoni.net/docs/。
  * en 與 zh-cn 各自有獨立的 manifest 與 id。
  *
+ * manifest 的 scope：zh-TW 寫 "."（解析成 /docs/），en 與 zh-cn 寫 ".."（退一層，同樣
+ * 是 /docs/）。JSON 沒地方寫註解，理由記在這裡：三件互動作品只建置一份在根路徑
+ * /docs/games/，en 與 zh-cn 用 ?lang= 連過去共用同一份。那兩份 scope 若寫 "."，就只
+ * 涵蓋自己的語系前綴（/docs/en/），讀者在已安裝的 app 裡點進作品會離開 scope，
+ * Android Chrome 會掛出網址列，看起來像掉出 app。用相對值而不是寫死 "/docs/"，
+ * 本地 mkdocs serve 在 "/" 底下跑的時候一樣解析得出有效的 scope。
+ *
  * 注意：theme 資產的 hash 檔名需與 overrides/base.html 同步，
  * 升級 mkdocs-material 時要一併更新。
  */
@@ -22,8 +29,14 @@ const VERSION = "__BUILD_VERSION__";
 const PRECACHE = "anoni-docs-precache-" + VERSION;
 // runtime 拆兩個。原本導覽頁與圖片、字型共用同一個 200 筆上限，
 // 圖多的頁面逛幾輪就會把讀者想留著離線看的頁面擠掉。
-const RUNTIME_PAGES = "anoni-docs-pages-" + VERSION;
-const RUNTIME_ASSETS = "anoni-docs-assets-" + VERSION;
+//
+// 這兩個名稱刻意不帶 VERSION。VERSION 是分鐘級時間戳，每次部署必定改變，而
+// activate 會刪掉所有不在保留名單裡的快取，等於讀者累積的離線頁面每次部署都
+// 被清空一次，接著又要把整份預快取重下載一遍。頁面的新鮮度由 network-first
+// 維持，不需要靠換快取名稱來換版。PRECACHE 保留版本後綴，那批是 hash 檔名的
+// app shell，換版後舊的確實該整批丟掉。
+const RUNTIME_PAGES = "anoni-docs-pages";
+const RUNTIME_ASSETS = "anoni-docs-assets";
 const PAGES_MAX_ENTRIES = 120;
 const ASSETS_MAX_ENTRIES = 200;
 
@@ -221,6 +234,11 @@ const CORE_PAGES_EN = [
 // 數字用 tools/check_precache.mjs 量的，那支讀的是 apparent size，也就是實際要傳輸的
 // 位元組。不要用 du 量，這台的檔案系統會共用 extent，du report 出來只有一半。
 //
+// 上面那組數字是作品加進來當時量的。2026-08 重量一次，整份預快取已經到 25.05 MB，
+// 三件作品的 2.33 MB 佔比降到 9.3%。變大的原因是三個語系各存一份完整章節，而 en
+// 那份在 2026-08 補齊之後跟 zh 差不多厚了。要縮的話該從「只預快取讀者當下的語系」
+// 著手，砍作品這一批省不到多少。
+//
 // 身分敏感度：照 CORE_PAGES_ZH 那條判準（讀者是不是特定受威脅身分）檢查過。這三件
 // 是教學性質的視覺化，跟已經在預快取裡的 tools/what-is-tor/ 同一類，不指向特定身分，
 // 所以可以放。
@@ -300,9 +318,41 @@ self.addEventListener("install", (event) => {
   );
 });
 
+// 一次性遷移：把帶版本後綴的舊 runtime 快取搬進不帶版本的新快取。
+//
+// 這次改動之前每次部署都換快取名稱，activate 會把讀者累積的離線頁面整批刪掉。修法
+// 如果照舊直接刪，等於在升級的當下再清空一次，所以先搬過來。頁面與資產都要搬：舊頁面
+// 引用的是舊 hash 的 CSS 與 JS，只搬頁面的話離線開起來會沒有樣式。
+//
+// 讀者都升過一輪之後（大約兩三次部署）這段就不會再命中任何東西，可以移除。
+async function migrateLegacyRuntime() {
+  const keys = await caches.keys();
+  for (const [legacyPrefix, target] of [
+    ["anoni-docs-pages-", RUNTIME_PAGES],
+    ["anoni-docs-assets-", RUNTIME_ASSETS],
+  ]) {
+    const legacyKeys = keys.filter((key) => key.startsWith(legacyPrefix));
+    if (!legacyKeys.length) continue;
+    const cache = await caches.open(target);
+    for (const key of legacyKeys) {
+      const legacy = await caches.open(key);
+      for (const request of await legacy.keys()) {
+        // 新快取已經有的就不覆蓋，那份比較新
+        if (await cache.match(request)) continue;
+        const response = await legacy.match(request);
+        if (response) await cache.put(request, response);
+      }
+      await caches.delete(key);
+    }
+  }
+  await trimCache(RUNTIME_PAGES, PAGES_MAX_ENTRIES);
+  await trimCache(RUNTIME_ASSETS, ASSETS_MAX_ENTRIES);
+}
+
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
+      await migrateLegacyRuntime();
       const keys = await caches.keys();
       await Promise.all(
         keys
@@ -316,12 +366,42 @@ self.addEventListener("activate", (event) => {
   );
 });
 
-function offlinePathFor(pathname) {
-  const rel = pathname.slice(SCOPE_PATH.length);
+// 同一份 HTML 會被連成不同形狀的網址。互動作品的索引頁，zh-TW 連的是
+// games/x/play/，en 與 zh-cn 連的是 games/x/play/index.html?lang=en，指的是同一個
+// 檔案。Cache Storage 比對的是完整網址字串，形狀差一點就 miss，而預快取一份頁面
+// 只能存一種形狀。離線時依序試這幾種，讓三個語系都命中同一份。
+function cacheKeyCandidates(pathname) {
+  if (pathname.endsWith("/index.html")) {
+    return [pathname, pathname.slice(0, -"index.html".length)];
+  }
+  if (pathname.endsWith("/")) {
+    return [pathname, pathname + "index.html"];
+  }
+  return [pathname];
+}
+
+// 離線時替一個導覽請求找出對應的快取。ignoreSearch 讓帶 ?lang= 或分享參數的網址
+// 也命中，站上的 query 一律只由 client 端 JS 讀取，同一個路徑回傳的 HTML 是同一份。
+async function matchCachedPage(request) {
+  const url = new URL(request.url);
+  for (const pathname of cacheKeyCandidates(url.pathname)) {
+    const hit = await caches.match(url.origin + pathname, { ignoreSearch: true });
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+function offlinePathFor(url) {
+  const rel = url.pathname.slice(SCOPE_PATH.length);
   // 只列有前綴的兩語，zh-TW 落到最後的預設值（根路徑的 offline 頁）。
   for (const prefix of ["zh-cn/", "en/"]) {
     if (rel.startsWith(prefix)) return SCOPE_PATH + prefix + "offline/";
   }
+  // 路徑上沒有語系前綴時才看 query。三件互動作品只建置一份在根路徑，語系靠 ?lang=
+  // 傳，只看路徑的話英文讀者離線點進作品會掉到中文的離線頁。前綴比 query 可靠，
+  // 所以擺在後面補位。
+  const lang = url.searchParams.get("lang");
+  if (lang === "en" || lang === "zh-cn") return SCOPE_PATH + lang + "/offline/";
   return SCOPE_PATH + "offline/";
 }
 
@@ -353,9 +433,9 @@ async function networkFirst(request, event) {
     }
     return response;
   } catch (err) {
-    const cached = await caches.match(request);
+    const cached = await matchCachedPage(request);
     if (cached) return cached;
-    const offline = await caches.match(offlinePathFor(new URL(request.url).pathname));
+    const offline = await caches.match(offlinePathFor(new URL(request.url)));
     if (offline) return offline;
     throw err;
   }

--- a/tools/check_precache.mjs
+++ b/tools/check_precache.mjs
@@ -21,7 +21,7 @@
  * URL 對檔案的規則跟靜態站一樣：結尾是 / 的找 index.html，其餘直接找該檔。
  *
  * 用法：
- *   cd docs && sh run.sh && sh run_zh-tw.sh && sh run_zh-cn.sh && sh run_en.sh
+ *   cd docs && sh run.sh && sh run_zh-cn.sh && sh run_en.sh
  *   node tools/check_precache.mjs
  * 找不到 docs/output 時跳過並回 0（沒建置過就不該擋人）。
  */
@@ -57,9 +57,10 @@ const harness = `
   ${grab(/^const GAME_APPS = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_BY_PREFIX = \{[\s\S]*?\n\};/m)}
   ${grab(/^function precacheUrls\(\) \{[\s\S]*?\n\}/m)}
-  return { urls: precacheUrls(), games: GAME_APPS.length };
+  ${grab(/^function cacheKeyCandidates\(pathname\) \{[\s\S]*?\n\}/m)}
+  return { urls: precacheUrls(), games: GAME_APPS.length, cacheKeyCandidates };
 `;
-const { urls, games } = new Function(harness)();
+const { urls, games, cacheKeyCandidates } = new Function(harness)();
 
 /** URL 換成 docs/output 底下的實際檔案路徑 */
 function resolve(url) {
@@ -86,12 +87,47 @@ const gameBytes = urls
   .reduce((a, u) => a + (fs.existsSync(resolve(u)) ? fs.statSync(resolve(u)).size : 0), 0);
 console.log(`  其中三件互動作品 ${mb(gameBytes)}`);
 
+// 索引頁連出去的網址形狀，要能命中預快取的 key
+//
+// 預快取存的是 games/x/play/index.html，而 zh-TW 的互動作品索引頁連的是
+// games/x/play/，en 與 zh-cn 連的是 games/x/play/index.html?lang=en。Cache Storage
+// 比對的是完整網址字串，形狀不同就是不同的 key。這種錯配用上面那道「檔案存不存在」
+// 驗不出來，兩種形狀都指得到同一個檔案，只有離線的讀者會發現作品打不開。
+// sw.js 的 cacheKeyCandidates 負責在離線時補上另一種形狀，這裡驗它真的補得到。
+const cachedKeys = new Set(urls);
+const INDEX_PAGES = [
+  ['games/index.html', '/docs/games/'],
+  ['en/games/index.html', '/docs/en/games/'],
+  ['zh-cn/games/index.html', '/docs/zh-cn/games/'],
+];
+const unreachable = [];
+for (const [file, base] of INDEX_PAGES) {
+  const indexFile = path.join(OUT, file);
+  if (!fs.existsSync(indexFile)) continue;
+  const html = fs.readFileSync(indexFile, 'utf8');
+  const hrefs = new Set(
+    [...html.matchAll(/href="([^"]*\/play\/[^"]*)"/g)].map((m) => m[1])
+  );
+  for (const href of hrefs) {
+    const { pathname } = new URL(href, 'https://anoni.net' + base);
+    if (!cacheKeyCandidates(pathname).some((c) => cachedKeys.has(c))) {
+      unreachable.push(`${base} 連到 ${pathname}`);
+    }
+  }
+}
+
 if (missing.length) {
   console.error(`\n✗ ${missing.length} 個 URL 在 docs/output 裡找不到對應檔案：`);
   for (const u of missing.slice(0, 20)) console.error('  ' + u);
   if (missing.length > 20) console.error(`  ⋯ 另有 ${missing.length - 20} 個`);
   console.error('\nsw.js 的 install 用 allSettled 容忍失敗，所以這些會被靜默跳過，');
   console.error('線上看起來正常，只有離線的人會遇到破圖或空白。');
-  process.exit(1);
 }
-console.log('\n預快取清單裡的每個 URL 都對得到檔案。');
+if (unreachable.length) {
+  console.error(`\n✗ ${unreachable.length} 個索引頁連出去的網址對不到預快取的 key：`);
+  for (const u of unreachable) console.error('  ' + u);
+  console.error('\n檔案本身存在，線上一切正常，只有離線的讀者會打不開。');
+  console.error('修法是讓 GAME_APPS 與索引頁的連結形狀一致，或補進 cacheKeyCandidates。');
+}
+if (missing.length || unreachable.length) process.exit(1);
+console.log('\n預快取清單裡的每個 URL 都對得到檔案，索引頁連出去的網址也都命中。');

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * sw.js 離線路徑的單元測試。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * 這幾個函式只在「讀者斷線」時才會執行，線上跑的永遠是 network-first 那一條，
+ * 所以寫壞了在瀏覽器上點來點去看不出來。要人工驗得先關網路、清快取、逐語系點
+ * 一輪，成本高到不會有人每次改都做，而回報這類問題的人本來就連不上網。
+ *
+ * 三件互動作品的網址形狀是最容易踩的一處：預快取存的 key 是 games/x/play/index.html，
+ * zh-TW 的索引頁連的是 games/x/play/，en 與 zh-cn 連的是 play/index.html?lang=en。
+ * Cache Storage 比對完整網址字串，三種形狀各是一個 key，指的卻是同一個檔案。
+ *
+ * migrateLegacyRuntime 則是唯一會動到讀者既有資料的一段，搬錯就是把人家存好的
+ * 離線內容弄丟，值得有測試守著。
+ *
+ * === 怎麼驗 ===
+ *
+ * 跟 check_precache.mjs 同一套做法：把函式從 sw.js 原地抽出來執行，不重寫一份
+ * 邏輯，那樣只會驗到自己抄得對不對。Cache Storage 用最小替身，只實作這些函式
+ * 真正用到的 open/match/put/keys/delete。
+ *
+ * 用法：
+ *   node tools/test_sw_offline.mjs
+ * 不需要建置產物，也沒有外部相依。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SW = path.join(HERE, '..', 'docs', 'zh-TW', 'sw.js');
+const src = fs.readFileSync(SW, 'utf8');
+
+const grab = (re) => {
+  const m = src.match(re);
+  if (!m) throw new Error(`sw.js 裡找不到 ${re}`);
+  return m[0];
+};
+
+const ORIGIN = 'https://anoni.net';
+const SCOPE_PATH = '/docs/';
+
+// Cache Storage 會把字串 request 解析成絕對網址再當 key，替身照做，否則
+// matchCachedPage 拿 url.origin 組出來的絕對網址會對不上測試存進去的相對路徑。
+const urlOf = (request) =>
+  new URL(typeof request === 'string' ? request : request.url, ORIGIN).href;
+const normalize = (href, ignoreSearch) => (ignoreSearch ? href.split('?')[0] : href);
+
+class FakeCache {
+  constructor() {
+    this.store = new Map();
+  }
+  async put(request, response) {
+    this.store.set(urlOf(request), response);
+  }
+  async match(request, opts = {}) {
+    const want = normalize(urlOf(request), opts.ignoreSearch);
+    for (const [key, value] of this.store) {
+      if (normalize(key, opts.ignoreSearch) === want) return value;
+    }
+    return undefined;
+  }
+  async keys() {
+    // 真的 Cache.keys() 回的是 Request，這裡只需要 url 這個欄位
+    return [...this.store.keys()].map((url) => ({ url }));
+  }
+  async delete(request) {
+    return this.store.delete(urlOf(request));
+  }
+}
+
+class FakeCacheStorage {
+  constructor() {
+    this.named = new Map();
+  }
+  async open(name) {
+    if (!this.named.has(name)) this.named.set(name, new FakeCache());
+    return this.named.get(name);
+  }
+  async keys() {
+    return [...this.named.keys()];
+  }
+  async has(name) {
+    return this.named.has(name);
+  }
+  async delete(name) {
+    return this.named.delete(name);
+  }
+  async match(request, opts) {
+    for (const cache of this.named.values()) {
+      const hit = await cache.match(request, opts);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+}
+
+const harness = `
+  ${grab(/^const RUNTIME_PAGES = .*$/m)}
+  ${grab(/^const RUNTIME_ASSETS = .*$/m)}
+  ${grab(/^const PAGES_MAX_ENTRIES = .*$/m)}
+  ${grab(/^const ASSETS_MAX_ENTRIES = .*$/m)}
+  ${grab(/^function cacheKeyCandidates\(pathname\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function matchCachedPage\(request\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^function offlinePathFor\(url\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function trimCache\(cacheName, maxEntries\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function migrateLegacyRuntime\(\) \{[\s\S]*?\n\}/m)}
+  return {
+    RUNTIME_PAGES, RUNTIME_ASSETS, PAGES_MAX_ENTRIES,
+    cacheKeyCandidates, matchCachedPage, offlinePathFor, migrateLegacyRuntime,
+  };
+`;
+
+/** 每個測試拿一組乾淨的快取，避免互相污染 */
+const load = () => {
+  const caches = new FakeCacheStorage();
+  const sw = new Function('caches', 'SCOPE_PATH', harness)(caches, SCOPE_PATH);
+  return { sw, caches };
+};
+
+const req = (pathname) => ({ url: ORIGIN + pathname });
+const u = (pathname) => new URL(pathname, ORIGIN);
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test('cacheKeyCandidates 補上另一種網址形狀', ({ sw }) => {
+  assert.deepEqual(sw.cacheKeyCandidates('/docs/games/tor-network/play/'), [
+    '/docs/games/tor-network/play/',
+    '/docs/games/tor-network/play/index.html',
+  ]);
+  assert.deepEqual(sw.cacheKeyCandidates('/docs/games/tor-network/play/index.html'), [
+    '/docs/games/tor-network/play/index.html',
+    '/docs/games/tor-network/play/',
+  ]);
+  // 一般檔案沒有第二種形狀
+  assert.deepEqual(sw.cacheKeyCandidates('/docs/games/vendor/three.core.min.js'), [
+    '/docs/games/vendor/three.core.min.js',
+  ]);
+});
+
+test('三個語系連出去的形狀都命中同一份預快取', async ({ sw, caches }) => {
+  const precache = await caches.open('anoni-docs-precache-202601010000');
+  await precache.put('/docs/games/tor-network/play/index.html', 'GLOBE');
+
+  // zh-TW 的索引頁連目錄式網址
+  assert.equal(await sw.matchCachedPage(req('/docs/games/tor-network/play/')), 'GLOBE');
+  // en 與 zh-cn 連的是 index.html 加 ?lang=
+  assert.equal(
+    await sw.matchCachedPage(req('/docs/games/tor-network/play/index.html?lang=en')),
+    'GLOBE'
+  );
+  assert.equal(
+    await sw.matchCachedPage(req('/docs/games/tor-network/play/index.html?lang=zh-cn')),
+    'GLOBE'
+  );
+  // 沒快取過的頁面仍然要 miss，才輪得到離線頁接手
+  assert.equal(await sw.matchCachedPage(req('/docs/basics/metadata/')), undefined);
+});
+
+test('分享網址帶的參數不影響命中', async ({ sw, caches }) => {
+  const pages = await caches.open('anoni-docs-pages');
+  await pages.put('/docs/tools/what-is-tor/', 'TOR');
+  assert.equal(
+    await sw.matchCachedPage(req('/docs/tools/what-is-tor/?utm_source=mastodon')),
+    'TOR'
+  );
+});
+
+test('離線頁依語系前綴挑', ({ sw }) => {
+  assert.equal(sw.offlinePathFor(u('/docs/tools/what-is-tor/')), '/docs/offline/');
+  assert.equal(sw.offlinePathFor(u('/docs/en/tools/what-is-tor/')), '/docs/en/offline/');
+  assert.equal(sw.offlinePathFor(u('/docs/zh-cn/tools/what-is-tor/')), '/docs/zh-cn/offline/');
+});
+
+test('作品在根路徑，離線頁改看 ?lang=', ({ sw }) => {
+  assert.equal(
+    sw.offlinePathFor(u('/docs/games/tor-network/play/index.html?lang=en')),
+    '/docs/en/offline/'
+  );
+  assert.equal(
+    sw.offlinePathFor(u('/docs/games/tor-network/play/index.html?lang=zh-cn')),
+    '/docs/zh-cn/offline/'
+  );
+  // 沒帶 lang 就是 zh-TW
+  assert.equal(sw.offlinePathFor(u('/docs/games/tor-network/play/')), '/docs/offline/');
+});
+
+test('路徑上的語系前綴比 query 優先', ({ sw }) => {
+  // 前綴是站台建出來的，query 誰都能加。兩邊打架時信前綴。
+  assert.equal(sw.offlinePathFor(u('/docs/en/tools/what-is-tor/?lang=zh-cn')), '/docs/en/offline/');
+});
+
+test('舊的帶版本快取搬進不帶版本的新快取', async ({ sw, caches }) => {
+  const legacyPages = await caches.open('anoni-docs-pages-202601010000');
+  await legacyPages.put('/docs/basics/metadata/', 'OLD-META');
+  await legacyPages.put('/docs/tools/what-is-tor/', 'OLD-TOR');
+  const legacyAssets = await caches.open('anoni-docs-assets-202601010000');
+  await legacyAssets.put('/docs/assets/stylesheets/main.abc.min.css', 'OLD-CSS');
+
+  // 新快取已經有的那一份比較新，不該被舊的蓋掉
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/basics/metadata/', 'NEW-META');
+
+  await sw.migrateLegacyRuntime();
+
+  const migratedPages = await caches.open(sw.RUNTIME_PAGES);
+  assert.equal(await migratedPages.match('/docs/basics/metadata/'), 'NEW-META');
+  assert.equal(await migratedPages.match('/docs/tools/what-is-tor/'), 'OLD-TOR');
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  assert.equal(await assets.match('/docs/assets/stylesheets/main.abc.min.css'), 'OLD-CSS');
+  // 搬完要刪掉，否則下一次 activate 的清除迴圈才刪，等於白搬
+  assert.equal(await caches.has('anoni-docs-pages-202601010000'), false);
+  assert.equal(await caches.has('anoni-docs-assets-202601010000'), false);
+});
+
+test('遷移不會把自己當成舊快取刪掉', async ({ sw, caches }) => {
+  // RUNTIME_PAGES 是 anoni-docs-pages，舊的是 anoni-docs-pages-<版本>，
+  // 名稱只差一個連字號，判斷寫鬆一點就會把讀者的離線內容整份刪掉
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/basics/metadata/', 'KEEP');
+  await sw.migrateLegacyRuntime();
+  assert.equal(await caches.has(sw.RUNTIME_PAGES), true);
+  // 重新 open，不能拿上面那個參考來驗。整份被刪掉又重建成空的時，舊參考照樣
+  // 讀得到內容，斷言會綠得很沒道理。
+  const survived = await caches.open(sw.RUNTIME_PAGES);
+  assert.equal(await survived.match('/docs/basics/metadata/'), 'KEEP');
+});
+
+test('搬進來超過上限時會裁到上限', async ({ sw, caches }) => {
+  const legacy = await caches.open('anoni-docs-pages-202601010000');
+  for (let i = 0; i < sw.PAGES_MAX_ENTRIES + 10; i++) {
+    await legacy.put(`/docs/p${i}/`, `P${i}`);
+  }
+  await sw.migrateLegacyRuntime();
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  assert.equal((await pages.keys()).length, sw.PAGES_MAX_ENTRIES);
+});
+
+for (const [name, fn] of tests) {
+  try {
+    await fn(load());
+    passed++;
+    console.log('  ✓ ' + name);
+  } catch (err) {
+    failed++;
+    console.error('  ✗ ' + name);
+    console.error('    ' + String(err.message).split('\n').join('\n    '));
+  }
+}
+
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## 問題

三件互動作品的 2.33 MB 預快取，三個語系離線時都打不開。資產（`.js`、`.json`）有命中，最外層的 HTML 沒有，所以整頁起不來。

Cache Storage 比對的是完整網址字串，預快取存的 key 是 `games/x/play/index.html`，而各語系索引頁連出去的形狀不同：

| 語系 | 索引頁連出去的網址 | 快取裡的 key | 結果 |
|---|---|---|---|
| zh-TW | `games/x/play/` | `.../play/index.html` | miss |
| en | `.../play/index.html?lang=en` | `.../play/index.html` | miss |
| zh-CN | `.../play/index.html?lang=zh-cn` | `.../play/index.html` | miss |

`sw.js` 註解裡寫的「工作坊沒 wifi、教學現場網路很差」那個情境是壞的。

另外三件相關的問題：

- `offlinePathFor` 只看路徑前綴，而作品只建置一份在根路徑、語系靠 `?lang=` 傳，所以英文讀者離線點進作品會掉到中文的離線頁
- `RUNTIME_PAGES` 與 `RUNTIME_ASSETS` 的名稱帶 `VERSION`，而 `VERSION` 是分鐘級時間戳，每次部署必定改變。`activate` 會刪掉所有不在保留名單裡的快取，等於讀者累積的離線頁面每次部署都被清空一次，接著又要把整份預快取重下載一遍
- `en` 與 `zh-CN` 的 manifest `scope` 是 `"."`，只涵蓋自己的語系前綴。讀者在已安裝的 app 裡點進根路徑的作品會離開 scope，Android Chrome 會掛出網址列，看起來像掉出 app

## 修法

新增 `cacheKeyCandidates` 與 `matchCachedPage`，離線 fallback 依序試目錄式與 `index.html` 兩種形狀，並開 `ignoreSearch`，讓帶 `?lang=` 或分享參數的網址也命中。站上的 query 一律只由 client 端 JS 讀取，同一個路徑回傳的 HTML 是同一份，忽略 query 是安全的。

`offlinePathFor` 補讀 `?lang=`。路徑前綴仍然優先，query 只在路徑上沒有語系前綴時補位。

runtime 快取名稱拿掉版本後綴。頁面的新鮮度由 network-first 維持，不需要靠換快取名稱來換版。`PRECACHE` 保留版本後綴，那批是 hash 檔名的 app shell，換版後舊的確實該整批丟掉。同時加 `migrateLegacyRuntime` 把舊的帶版本快取搬進新快取，避免修法本身在升級當下再清空一次。頁面與資產都搬，舊頁面引用的是舊 hash 的 CSS 與 JS，只搬頁面的話離線開起來會沒有樣式。

`en` 與 `zh-CN` 的 manifest `scope` 從 `"."` 改成 `".."`，兩者都解析成 `/docs/`。用相對值而不寫死 `/docs/`，本地 `mkdocs serve` 在 `/` 底下跑時一樣解析得出有效的 scope。JSON 沒地方寫註解，理由記在 `sw.js` 頂部。

## 測試

新增 `tools/test_sw_offline.mjs`，把這批離線函式從 `sw.js` 原地抽出來單元測試，做法跟 `check_precache.mjs` 一致，不重寫一份邏輯。Cache Storage 用最小替身。不需要建置產物，也沒有外部相依。

```
$ node tools/test_sw_offline.mjs
  ✓ cacheKeyCandidates 補上另一種網址形狀
  ✓ 三個語系連出去的形狀都命中同一份預快取
  ✓ 分享網址帶的參數不影響命中
  ✓ 離線頁依語系前綴挑
  ✓ 作品在根路徑，離線頁改看 ?lang=
  ✓ 路徑上的語系前綴比 query 優先
  ✓ 舊的帶版本快取搬進不帶版本的新快取
  ✓ 遷移不會把自己當成舊快取刪掉
  ✓ 搬進來超過上限時會裁到上限

9 通過，0 失敗
```

`check_precache.mjs` 補第二道檢查，比對各語系索引頁實際連出去的網址形狀命中得了預快取的 key。原本那道只驗「檔案存不存在」，這類錯配兩種形狀都指得到同一個檔案，驗不出來。

```
$ node tools/check_precache.mjs
  預快取 183 個 URL，其中作品本體 28 個
  合計 25.05 MB（不含 runtime 快取）
  其中三件互動作品 2.33 MB

預快取清單裡的每個 URL 都對得到檔案，索引頁連出去的網址也都命中。
```

兩支都做了反向驗證確認會紅：拿掉 `cacheKeyCandidates` 的目錄式候選，`check_precache` 抓出 zh-TW 那三個連結；把遷移的前綴判斷寫鬆一個連字號（`anoni-docs-pages` 而非 `anoni-docs-pages-`），測試抓到它會把新快取自己刪掉。

## 順帶

- `GAME_APPS` 的成本註記補上現況。整份預快取實測已達 25.05 MB，作品那 2.33 MB 佔比降到 9.3%。變大的原因是三個語系各存一份完整章節，而 en 那份在 2026-08 補齊之後厚度跟 zh 差不多了
- `check_precache.mjs` 用法註解裡的 `run_zh-tw.sh` 不存在，zh-TW 是 `run.sh` 建的
- `CLAUDE.md` 的 tools 表格新增「PWA 離線」一列。原本 `check_*.mjs` 那列歸在「地球儀版面檢查」，而 `check_precache.mjs` 不是版面檢查

## 待決定

`check_precache.mjs` 與 `test_sw_offline.mjs` 都沒進 CI，改 `sw.js` 時要手動跑。`test_sw_offline.mjs` 不需要建置產物，加進 PR workflow 成本很低。`check_precache.mjs` 需要建置產物，比較適合掛在 `build_docs.yml`，但那會擋部署。這個 PR 沒動 CI。

## 後續

下一步是把預快取從三語系全下改成只下讀者當下的語系，走 client 端 `postMessage` 告知 `document.documentElement.lang`。`sw.js` 的 scope 固定在 `/docs/`，三語系共用同一個 registration，所以語系判斷沒辦法從 SW 自己的 scope 取得。同一批還有換版提示（需要先移除 `install` 裡的 `skipWaiting`）與明確的語言選擇。

🤖 Generated with [Claude Code](https://claude.com/claude-code)