### PR TITLE
fix(docs): figcaption 裡的 markdown 連結沒有 render，補上 markdown="span"

### DIFF
--- a/docs/en/blog/posts/2026-financial-companies-as-censors.md
+++ b/docs/en/blog/posts/2026-financial-companies-as-censors.md
@@ -20,7 +20,7 @@ description: "A Sinophone Asia-Pacific reading of EFF's Transaction Denied: Taiw
             alt="A piggy bank with its mouth taped shut, representing payment rails severed by financial intermediaries"
             style="border-radius: 10px;">
     </a>
-    <figcaption>Image from EFF Deeplinks article [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} (EFF Financial Censorship banner library), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}.</figcaption>
+    <figcaption markdown="span">Image from EFF Deeplinks article [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} (EFF Financial Censorship banner library), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}.</figcaption>
 </figure>
 
 On **9 May 2017**, the cross-border electronic payment service **PayPal** closed all domestic transaction functions in Taiwan. Two PayPal Taiwan accounts could no longer send money to each other. Cross-border transfers kept working. The streamer economy took the worst hit. Twitch Cheer, YouTube Super Chat, StreamLabs, and NightDev — tools that processed local audience tips through PayPal — went dark on the same day. Small organizations and independent media that relied on PayPal for domestic flows lost a payment rail overnight[^8].

--- a/docs/en/blog/posts/2026-grapheneos-android-17.md
+++ b/docs/en/blog/posts/2026-grapheneos-android-17.md
@@ -19,7 +19,7 @@ description: "An anoni.net take on Android 17 and GrapheneOS: Google's AOSP sque
             alt="Android 17 and GrapheneOS: who decides what runs on the phone you bought"
             style="border-radius: 5px;">
     </a>
-    <figcaption>Image: a smartphone wrapped in a chain and padlock, standing in for a device locked down by outside rules. Photo by Towfiqu barbhuiya, via [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"} (Pexels License).</figcaption>
+    <figcaption markdown="span">Image: a smartphone wrapped in a chain and padlock, standing in for a device locked down by outside rules. Photo by Towfiqu barbhuiya, via [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"} (Pexels License).</figcaption>
 </figure>
 
 You paid for the phone, but what it can run and what it can install is increasingly **not yours to decide**. That question stays invisible until an app refuses to open because it "detected a non-stock OS," or an open-source OS you rely on gets harder to maintain because the hardware data behind it stops being public. [Android 17](https://source.android.com/docs/whatsnew/android-17-release){target="_blank"} landed on **2026-06-16**, and it pushed that question one step further.

--- a/docs/en/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/en/blog/posts/2026-victory-702-has-expired.md
@@ -20,7 +20,7 @@ description: "A Sinophone Asia-Pacific read of the Section 702 lapse: what warra
             alt="EFF's NSA eagle graphic, reworking the NSA seal into an eagle plugging its talons into telecom lines, representing warrantless mass surveillance"
             style="border-radius: 10px;">
     </a>
-    <figcaption>Image: EFF designer Hugh D'Andrade's "NSA eagle," which reworks the NSA seal into an eagle plugging its talons into the nation's telecom lines. From [EFF's NSA spying work](https://www.eff.org/nsa-spying){target="_blank"}, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img].</figcaption>
+    <figcaption markdown="span">Image: EFF designer Hugh D'Andrade's "NSA eagle," which reworks the NSA seal into an eagle plugging its talons into the nation's telecom lines. From [EFF's NSA spying work](https://www.eff.org/nsa-spying){target="_blank"}, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img].</figcaption>
 </figure>
 
 !!! info ""

--- a/docs/en/blog/posts/tianjian-digital-privacy.md
+++ b/docs/en/blog/posts/tianjian-digital-privacy.md
@@ -16,7 +16,7 @@ description: "Tian Jian's two-session series on digital security and privacy for
 
 <figure markdown="span">
   ![Poster for the digital security and privacy series](https://assets.anoni.net/blog/tianjian-digital-privacy.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
-  <figcaption>Series poster by Tian Jian. Source: [TJ Field School event page](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
+  <figcaption markdown="span">Series poster by Tian Jian. Source: [TJ Field School event page](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
 </figure>
 
 Tian Jian's learning platform TJ Field School is running a two-session series on digital security and privacy. Toomore from our community gave the first session on 12 August, and Mashbean takes the second on 26 August. Registration is still open.

--- a/docs/en/regional/ooni-asn-coverage.md
+++ b/docs/en/regional/ooni-asn-coverage.md
@@ -21,7 +21,7 @@ The internet is a mesh of interconnected Autonomous Systems (AS). Each AS is a g
             alt="How ASNs interconnect on the real network, diagram from cloudflare.com"
             title="How ASNs interconnect on the real network, diagram from cloudflare.com">
     </a>
-    <figcaption>How ASNs interconnect on the real network ([image source](https://www.cloudflare.com/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}).</figcaption>
+    <figcaption markdown="span">How ASNs interconnect on the real network ([image source](https://www.cloudflare.com/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}).</figcaption>
 </figure>
 
 For OONI measurement, the ASN is the smallest useful unit of "which network did we see this censorship on". The same website may be unreachable on one carrier and fine on another, and you cannot tell those apart without breaking the data down by ASN. That is why OONI analysis keeps asking how many distinct ASNs a region's measurements come from. The higher that share, the better the data reflects the region's actual connectivity.

--- a/docs/zh-CN/blog/posts/2025-probe-security-without-identification.md
+++ b/docs/zh-CN/blog/posts/2025-probe-security-without-identification.md
@@ -27,7 +27,7 @@ description: "OONI 预计实施匿名凭证以减缓虚假观测数据对观测�
             title="Security without identification: transaction systems to make big brother obsolete"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <figcaption>在他那篇具有开创性的论文《[没有身份识别的安全性：使老大哥过时的交易系统](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 构想了一个用户可以使用单一数字钱包匿名与多个组织互动的未来，即使这些组织互相勾结。</figcaption>
+    <figcaption markdown="span">在他那篇具有开创性的论文《[没有身份识别的安全性：使老大哥过时的交易系统](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 构想了一个用户可以使用单一数字钱包匿名与多个组织互动的未来，即使这些组织互相勾结。</figcaption>
 </figure>
 
 为了提升 OONI 观测数据的可信度，并防止故意或无意上传的错误测量结果对 OONI 数据库的影响，我们正在考虑在 OONI Probe 中设计和实施匿名凭证。在这篇文章中，我们提供了匿名凭证的现有文献回顾。这是为了让对密码学领域不太熟悉但又好奇的读者能够深入了解其所依据的协议。

--- a/docs/zh-CN/blog/posts/2026-financial-companies-as-censors.md
+++ b/docs/zh-CN/blog/posts/2026-financial-companies-as-censors.md
@@ -20,7 +20,7 @@ description: "2017 年 5 月 9 日 PayPal 关闭台湾境内交易，2026 年的
             alt="被胶带封口的存钱猪，象征被金融中介切断的支付管道"
             style="border-radius: 10px;">
     </a>
-    <figcaption>图片来自 EFF Deeplinks 文章 [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} 的社交卡片（EFF Financial Censorship banner 图库），授权为 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。</figcaption>
+    <figcaption markdown="span">图片来自 EFF Deeplinks 文章 [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} 的社交卡片（EFF Financial Censorship banner 图库），授权为 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。</figcaption>
 </figure>
 
 2017 年 5 月 9 日，美国的跨境电子支付服务 PayPal 全数关闭台湾境内交易功能，两个 PayPal Taiwan 账号之间不能再收付款，跨境收付款则维持运作。受冲击最大的是刚起步的实况产业，Twitch Cheer、YouTube Super Chat、StreamLabs、NightDev 这些依赖 PayPal 处理本地观众赞助的工具集体中断，小型组织与独立媒体的本地金流也跟着受影响[^9]。

--- a/docs/zh-CN/blog/posts/2026-grapheneos-android-17.md
+++ b/docs/zh-CN/blog/posts/2026-grapheneos-android-17.md
@@ -19,7 +19,7 @@ description: "Android 17 上线后 GrapheneOS 的处境：Google 收紧 AOSP、a
             alt="Android 17 上线后的 GrapheneOS：谁决定手机上能执行什么系统"
             style="border-radius: 5px;">
     </a>
-    <figcaption>图片：智能手机被锁链缠绕，象征装置被外部规则锁住。摄影 Towfiqu barbhuiya，来源 [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"}（Pexels License）。</figcaption>
+    <figcaption markdown="span">图片：智能手机被锁链缠绕，象征装置被外部规则锁住。摄影 Towfiqu barbhuiya，来源 [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"}（Pexels License）。</figcaption>
 </figure>
 
 手机是你花钱买的，但它能装什么、能执行什么系统，越来越不是你能决定的。这个问题平常不会浮上台面，直到你想换一套更保护隐私的系统，却发现某些 app 因为「侦测到非原厂系统」而拒绝执行，或是你信任的开源系统因为得不到硬件资料而越来越难维护。Android 17 在 2026 年 6 月 16 日上线[^1]，把这个问题又往前推了一步。

--- a/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
@@ -20,7 +20,7 @@ description: "FISA Section 702 让美国情报机构不需令状就能收集境�
             alt="EFF 的 NSA eagle 图，把 NSA 标志改画成一只老鹰用爪子接上电信线路，象征无令状的大规模监控"
             style="border-radius: 10px;">
     </a>
-    <figcaption>图片为 EFF 设计师 Hugh D'Andrade 绘制的「NSA eagle」，把 NSA 标志改画成老鹰用爪子接上电信线路，象征无令状的大规模监控。出自 [EFF 的 NSA 监控专题](https://www.eff.org/nsa-spying){target="_blank"}，授权为 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
+    <figcaption markdown="span">图片为 EFF 设计师 Hugh D'Andrade 绘制的「NSA eagle」，把 NSA 标志改画成老鹰用爪子接上电信线路，象征无令状的大规模监控。出自 [EFF 的 NSA 监控专题](https://www.eff.org/nsa-spying){target="_blank"}，授权为 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
 </figure>
 
 你寄一封信到 Gmail、用 iMessage 跟在美国的朋友聊天、用 WhatsApp 联络海外的家人，这些通信只要有一端落在美国的服务或网络上，本来就可能被美国情报机构在不需令状的情况下收集。授权这件事的法律叫 FISA Section 702（《外国情报监控法》第 702 条）。2026 年 6 月 12 日午夜，这条授权在美国国会的僵局中到期[^1]。

--- a/docs/zh-CN/blog/posts/tianjian-digital-privacy.md
+++ b/docs/zh-CN/blog/posts/tianjian-digital-privacy.md
@@ -16,7 +16,7 @@ description: "《田间》的「数位安全与隐私保护系列」两场线上
 
 <figure markdown="span">
   ![数位安全与隐私保护系列活动主视觉](https://assets.anoni.net/blog/tianjian-digital-privacy.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
-  <figcaption>活动主视觉由《田间》制作，来源：[在田间学活动页面](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
+  <figcaption markdown="span">活动主视觉由《田间》制作，来源：[在田间学活动页面](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
 </figure>
 
 《田间》在「在田间学」开了「数位安全与隐私保护系列」，两场免费线上课程。8/12 的第一场由我们社区的 Toomore 分享，8/26 的第二场由黄豆泥（Mashbean）接续，现在还可以报名。

--- a/docs/zh-CN/taiwan/ooni-asn-coverage.md
+++ b/docs/zh-CN/taiwan/ooni-asn-coverage.md
@@ -16,7 +16,7 @@ icon: material/access-point-network
             title="ASNs 在实际网络上串联在一起，图示来源：https://www.cloudflare.com/zh-cn/learning/network-layer/what-is-an-autonomous-system/"
         >
     </a>
-    <figcaption>ASNs 在实际网络上串联在一起（[图示来源](https://www.cloudflare.com/zh-cn/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}）。</figcaption>
+    <figcaption markdown="span">ASNs 在实际网络上串联在一起（[图示来源](https://www.cloudflare.com/zh-cn/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}）。</figcaption>
 </figure>
 
 大家每日使用的网络可以简单地理解为一个由许多互相连接的设备与系统组成的整体，这些设备包括电脑、移动设备、服务器、路由器及交换器等，主要功能是让数据可以在彼此之间进行交换与传输。

--- a/docs/zh-TW/blog/posts/2025-probe-security-without-identification.md
+++ b/docs/zh-TW/blog/posts/2025-probe-security-without-identification.md
@@ -27,7 +27,7 @@ description: "OONI 預計實作匿名憑證減緩假觀測資料影響觀測資�
             title="Security without identification: transaction systems to make big brother obsolete"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <figcaption>在他那篇具有開創性的論文《[沒有身份識別的安全性：使老大哥過時的交易系統](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 構想了一個使用者可以使用單一數位錢包匿名與多個組織互動的未來，即使這些組織互相勾結。 </figcaption>
+    <figcaption markdown="span">在他那篇具有開創性的論文《[沒有身份識別的安全性：使老大哥過時的交易系統](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 構想了一個使用者可以使用單一數位錢包匿名與多個組織互動的未來，即使這些組織互相勾結。 </figcaption>
 </figure>
 
 為了提升 OONI 觀測資料的可信度，並防止故意或無意上傳的錯誤測量結果對 OONI 資料庫的影響，我們正在考慮在 OONI Probe 中設計和實作匿名憑證。在這篇文章中，我們提供了匿名憑證的現有文獻回顧。這是為了讓對密碼學領域不太熟悉但又好奇的讀者，能深入了解其所依據的協議。

--- a/docs/zh-TW/blog/posts/2026-financial-companies-as-censors.md
+++ b/docs/zh-TW/blog/posts/2026-financial-companies-as-censors.md
@@ -20,7 +20,7 @@ description: "2017 年 5 月 9 日 PayPal 關閉台灣境內交易，2026 年的
             alt="被膠帶封口的存錢豬，象徵被金融中介切斷的支付管道"
             style="border-radius: 10px;">
     </a>
-    <figcaption>圖片來自 EFF Deeplinks 文章 [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} 的社交卡片（EFF Financial Censorship banner 圖庫），授權為 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。</figcaption>
+    <figcaption markdown="span">圖片來自 EFF Deeplinks 文章 [Former EFF Activism Director's New Book, Transaction Denied, Explores What Happens When Financial Companies Act like Censors](https://www.eff.org/deeplinks/2026/04/former-eff-activism-directors-new-book-transaction-denied-explores-what-happens){target="_blank"} 的社交卡片（EFF Financial Censorship banner 圖庫），授權為 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。</figcaption>
 </figure>
 
 2017 年 5 月 9 日，美國的跨境電子支付服務 PayPal 全數關閉台灣境內交易功能，兩個 PayPal Taiwan 帳號之間不能再收付款，跨境收付款則維持運作。受衝擊最大的是剛起步的實況產業，Twitch Cheer、YouTube Super Chat、StreamLabs、NightDev 這些依賴 PayPal 處理本地觀眾贊助的工具集體中斷，小型組織與獨立媒體的本地金流也跟著受影響[^8]。

--- a/docs/zh-TW/blog/posts/2026-grapheneos-android-17.md
+++ b/docs/zh-TW/blog/posts/2026-grapheneos-android-17.md
@@ -19,7 +19,7 @@ description: "Android 17 上線後 GrapheneOS 的處境：Google 收緊 AOSP、a
             alt="Android 17 上線後的 GrapheneOS：誰決定手機上能執行什麼系統"
             style="border-radius: 5px;">
     </a>
-    <figcaption>圖片：智慧型手機被鎖鏈纏繞，象徵裝置被外部規則鎖住。攝影 Towfiqu barbhuiya，來源 [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"}（Pexels License）。</figcaption>
+    <figcaption markdown="span">圖片：智慧型手機被鎖鏈纏繞，象徵裝置被外部規則鎖住。攝影 Towfiqu barbhuiya，來源 [Pexels](https://www.pexels.com/photo/close-up-of-a-smart-phone-with-a-lock-11391947/){target="_blank"}（Pexels License）。</figcaption>
 </figure>
 
 手機是你花錢買的，但它能裝什麼、能執行什麼系統，越來越不是你能決定的。這個問題平常不會浮上檯面，直到你想換一套更保護隱私的系統，卻發現某些 app 因為「偵測到非原廠系統」而拒絕執行，或是你信任的開源系統因為得不到硬體資料而越來越難維護。Android 17 在 2026 年 6 月 16 日上線[^1]，把這個問題又往前推了一步。

--- a/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
@@ -20,7 +20,7 @@ description: "FISA Section 702 讓美國情報機構不需令狀就能蒐集境�
             alt="EFF 的 NSA eagle 圖，把 NSA 標誌改畫成一隻老鷹用爪子接上電信線路，象徵無令狀的大規模監控"
             style="border-radius: 10px;">
     </a>
-    <figcaption>圖片為 EFF 設計師 Hugh D'Andrade 繪製的「NSA eagle」，把 NSA 標誌改畫成老鷹用爪子接上電信線路，象徵無令狀的大規模監控。出自 [EFF 的 NSA 監控專題](https://www.eff.org/nsa-spying){target="_blank"}，授權為 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
+    <figcaption markdown="span">圖片為 EFF 設計師 Hugh D'Andrade 繪製的「NSA eagle」，把 NSA 標誌改畫成老鷹用爪子接上電信線路，象徵無令狀的大規模監控。出自 [EFF 的 NSA 監控專題](https://www.eff.org/nsa-spying){target="_blank"}，授權為 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
 </figure>
 
 你寄一封信到 Gmail、用 iMessage 跟在美國的朋友聊天、用 WhatsApp 聯絡海外的家人，這些通訊只要有一端落在美國的服務或網路上，原本就可能被美國情報機構在不需令狀的情況下蒐集。提供授權的法律叫 FISA Section 702（《外國情報監控法》第 702 條）。2026 年 6 月 12 日午夜，該授權在美國國會的僵局中到期[^1]。

--- a/docs/zh-TW/blog/posts/tianjian-digital-privacy.md
+++ b/docs/zh-TW/blog/posts/tianjian-digital-privacy.md
@@ -16,7 +16,7 @@ description: "《田間》的「數位安全與隱私保護系列」兩場線上
 
 <figure markdown="span">
   ![數位安全與隱私保護系列活動主視覺](https://assets.anoni.net/blog/tianjian-digital-privacy.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
-  <figcaption>活動主視覺由《田間》製作，來源：[在田間學活動頁面](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
+  <figcaption markdown="span">活動主視覺由《田間》製作，來源：[在田間學活動頁面](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
 </figure>
 
 《田間》在「在田間學」開了「數位安全與隱私保護系列」，兩場免費線上課程。8/12 的第一場由我們社群的 Toomore 分享，8/26 的第二場由黃豆泥（Mashbean）接續，現在還可以報名。

--- a/docs/zh-TW/taiwan/ooni-asn-coverage.md
+++ b/docs/zh-TW/taiwan/ooni-asn-coverage.md
@@ -19,7 +19,7 @@ icon: material/access-point-network
             alt="ASN 在實際網路上串連在一起，圖示來源：cloudflare.com"
             title="ASN 在實際網路上串連在一起，圖示來源：cloudflare.com">
     </a>
-    <figcaption>ASN 在實際網路上串連在一起（[圖片來源](https://www.cloudflare.com/zh-tw/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}）。</figcaption>
+    <figcaption markdown="span">ASN 在實際網路上串連在一起（[圖片來源](https://www.cloudflare.com/zh-tw/learning/network-layer/what-is-an-autonomous-system/){target="_blank"}）。</figcaption>
 </figure>
 
 對 OONI 觀測來說，ASN 是「在哪一家網路上看到審查」的最小單位。同一個網站可能在中華電信看不到、在台灣大哥大看得到，這種差異需要先以 ASN 為單位才能區分清楚。所以 OONI 分析常常會問「這個地區的測量資料有多少不同的 ASN 來源」，比例越高，越能反映該區域的整體連線環境。


### PR DESCRIPTION
## 問題

`<figure markdown="span">` 底下的 `<figcaption>` 沒有自己標 markdown 屬性，md_in_html 就不會處理它的內容，裡面的 `[文字](網址){target="_blank"}` 原樣輸出成純文字。線上實例（修正前）：

```
<figcaption>活動主視覺由《田間》製作，來源：[在田間學活動頁面](https://tian-jian.org/tj-field-school/event/digital-privacy/){target="_blank"}</figcaption>
```

## 修法

figcaption 補上 `markdown="span"`。`docs/zh-TW/reports/interseclab-madlink/index.md` 早就是這樣寫，屬站內既有的正確寫法，其餘檔案跟著補齊。

修正後 render：

```
<figcaption>活動主視覺由《田間》製作，來源：<a href="https://tian-jian.org/tj-field-school/event/digital-privacy/" target="_blank">在田間學活動頁面</a></figcaption>
```

## 範圍

17 個檔案，每檔 1 處，三語系。除了這次新發的 `tianjian-digital-privacy`，也涵蓋既有的 `2025-probe-security-without-identification`、`2026-financial-companies-as-censors`、`2026-grapheneos-android-17`、`2026-victory-702-has-expired` 與 `ooni-asn-coverage`，同一個問題全站都存在。

只加一個屬性，沒有動任何文字內容。lint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)