### PR TITLE
fix(pwa): 首次造訪離線閱讀頁時卡在「讀取中」

### DIFF
--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -101,6 +101,7 @@
   const STRINGS = {
     "zh-TW": {
       loading: "讀取中",
+      preparing: "離線功能還在準備，裝置上的狀態稍後才會顯示。",
       noSupport:
         "這個瀏覽器沒有提供離線儲存，或者停用了 Service Worker（Tor Browser 屬於後者，onion 版本也不啟用）。這一頁其他段落的說明仍然適用。",
       noIndex: "讀不到頁面清單，可能是目前離線且這份清單還沒被存下來。恢復連線後重新整理即可。",
@@ -129,6 +130,7 @@
     },
     zh: {
       loading: "读取中",
+      preparing: "离线功能还在准备，设备上的状态稍后才会显示。",
       noSupport:
         "这个浏览器没有提供离线存储，或者停用了 Service Worker（Tor Browser 属于后者，onion 版本也不启用）。这一页其他段落的说明仍然适用。",
       noIndex: "读不到页面清单，可能是当前离线且这份清单还没有被存下来。恢复连接后刷新即可。",
@@ -157,6 +159,7 @@
     },
     en: {
       loading: "Loading",
+      preparing: "Offline support is still starting up. What is on this device will show shortly.",
       noSupport:
         "This browser has no offline storage available, or Service Workers are disabled (Tor Browser is the latter case, and the onion version does not enable them either). The rest of this page still applies.",
       noIndex: "The page list could not be loaded. You may be offline and it has not been stored yet. Reload once you are back online.",
@@ -215,10 +218,32 @@
     return;
   }
 
+  // service worker 準備好了沒。
+  //
+  // 不能直接用 navigator.serviceWorker.ready：首次造訪時 install 要把整個語系的核心
+  // 章節抓完（約十 MB）才會 activate，ready 也才 resolve，行動網路上那是好幾分鐘。
+  // 這一頁的清單不需要等那個，所以拆成兩段，索引先畫、狀態晚點補。
+  //
+  // 先讓出一輪再問有沒有 registration：base.html 的註冊碼在 body 尾端，比這支晚執行，
+  // 太早問會拿到 undefined。問得到才等 ready，問不到就是這個環境不註冊（onion 版與
+  // 停用 Service Worker 的瀏覽器），沒必要一直等下去。
+  let readyPromise = null;
+  function whenReady() {
+    if (!readyPromise) {
+      readyPromise = new Promise((resolve) => setTimeout(resolve, 1200))
+        .then(() => navigator.serviceWorker.getRegistration())
+        .then((registration) => {
+          if (!registration) throw new Error("no-service-worker-registration");
+          return navigator.serviceWorker.ready;
+        });
+    }
+    return readyPromise;
+  }
+
   // 一次請求一個 MessageChannel。下載類的指令會在同一個 port 上多次回報進度，
   // 最後一則不是 progress，那時才算結束。
   function ask(message, onProgress) {
-    return navigator.serviceWorker.ready.then(
+    return whenReady().then(
       (registration) =>
         new Promise((resolve, reject) => {
           const worker = registration.active;
@@ -255,6 +280,10 @@
     remove: new Set(),
     // 展開中的章節。勾一個項目就整頁重畫，沒記著的話會全部收合回去
     open: new Set(),
+    // service worker 那半回來了沒。沒回來之前清單照樣可以看、可以勾，
+    // 只是不知道裝置上已經有哪些。
+    swReady: false,
+    swMissing: false,
   };
 
   function refreshStatus() {
@@ -290,6 +319,14 @@
 
   function renderStatus() {
     const status = el("p", "ol-status");
+    if (state.swMissing) {
+      status.textContent = t.noSupport;
+      return status;
+    }
+    if (!state.swReady) {
+      status.textContent = t.preparing;
+      return status;
+    }
     status.appendChild(
       document.createTextNode(fill("savedCount", { n: state.saved.size }))
     );
@@ -336,13 +373,15 @@
     if (!open) return wrapper;
 
     const body = el("div", "ol-body");
-    body.appendChild(
-      button(t.selectAll, null, () => {
+    if (!state.swMissing) {
+      body.appendChild(
+        button(t.selectAll, null, () => {
         const wanted = section.pages.some((page) => !willBeStored(page.url));
-        for (const page of section.pages) setWanted(page.url, wanted);
-        render();
-      })
-    );
+          for (const page of section.pages) setWanted(page.url, wanted);
+          render();
+        })
+      );
+    }
 
     const list = el("ul", "ol-pages");
     for (const page of section.pages) {
@@ -352,7 +391,7 @@
       box.type = "checkbox";
       box.checked = willBeStored(page.url);
       // 站台自動存的那批由上面的開關統一管，個別勾選沒有意義
-      box.disabled = state.precached.has(page.url);
+      box.disabled = state.swMissing || state.precached.has(page.url);
       box.addEventListener("change", () => {
         setWanted(page.url, box.checked);
         render();
@@ -412,6 +451,8 @@
     root.appendChild(renderStatus());
     if (message) root.appendChild(el("p", "ol-message", message));
 
+    if (state.swMissing) return renderSections();
+
     const autoLabel = el("label", "ol-auto");
     const autoBox = document.createElement("input");
     autoBox.type = "checkbox";
@@ -451,18 +492,20 @@
     );
     root.appendChild(actions);
 
+    renderSections();
+    if (state.add.size || state.remove.size) root.appendChild(renderApply());
+  }
+
+  function renderSections() {
     if (!state.index) {
       root.appendChild(el("p", null, t.noIndex));
       return;
     }
-
     // 頁數多的排前面。讀者要找的多半是章節，零星的單頁擺後面不礙事。
     const sections = state.index.sections
       .slice()
       .sort((a, b) => b.pages.length - a.pages.length);
     for (const section of sections) root.appendChild(renderSection(section));
-
-    if (state.add.size || state.remove.size) root.appendChild(renderApply());
   }
 
   // 動作跑起來之後停用按鈕、顯示進度，做完重讀狀態再整頁重畫
@@ -484,15 +527,23 @@
 
   note(t.loading);
 
-  Promise.all([
-    refreshStatus(),
-    fetch(indexUrl, { credentials: "same-origin" })
-      .then((response) => (response.ok ? response.json() : null))
-      .catch(() => null),
-  ])
-    .then((results) => {
-      state.index = results[1];
+  // 索引不經過 service worker，來了就先把清單畫出來
+  fetch(indexUrl, { credentials: "same-origin" })
+    .then((response) => (response.ok ? response.json() : null))
+    .catch(() => null)
+    .then((index) => {
+      state.index = index;
+      render();
+    });
+
+  whenReady()
+    .then(refreshStatus)
+    .then(() => {
+      state.swReady = true;
       render();
     })
-    .catch(() => note(t.noSupport));
+    .catch(() => {
+      state.swMissing = true;
+      render();
+    });
 })();


### PR DESCRIPTION
推 #268 上線之後，對正式站截圖驗證時發現的。

## 問題

管理頁原本等 `Promise.all([狀態查詢, 索引])`，而狀態查詢走 `navigator.serviceWorker.ready`。

首次造訪時 `install` 要把整個語系的核心章節抓完（約 10 MB）才會 `activate`，`ready` 也才 resolve。行動網路上那是好幾分鐘，這段時間畫面就停在「讀取中」三個字。而頁面清單來自 `offline-index.json`，根本不需要等那個。

## 修法

拆成兩段。索引一到就把章節清單畫出來，service worker 那半晚點補：

```js
fetch(indexUrl)...then((index) => { state.index = index; render(); });

whenReady().then(refreshStatus).then(() => { state.swReady = true; render(); })
           .catch(() => { state.swMissing = true; render(); });
```

狀態列在補上之前說明「離線功能還在準備，裝置上的狀態稍後才會顯示」，不顯示假的「已存 0 頁」。

## 順帶：沒有 service worker 的環境

原本 `ready` 永遠不 resolve，畫面會一直停在準備中。改成先讓出一輪再問 `getRegistration()`：

```js
new Promise((resolve) => setTimeout(resolve, 1200))
  .then(() => navigator.serviceWorker.getRegistration())
  .then((registration) => {
    if (!registration) throw new Error("no-service-worker-registration");
    return navigator.serviceWorker.ready;
  });
```

讓出一輪是必要的，`base.html` 的註冊碼在 `{% block scripts %}`（body 尾端），比內容區的這支晚執行，太早問會拿到 `undefined`。

問不到就確定這個環境不註冊，顯示說明並把清單降級成唯讀，讀者仍然看得到站上有哪些內容。onion 版與停用 Service Worker 的瀏覽器走這一條。

## 驗證方式也換了

headless 的 `--virtual-time-budget` 不會等 service worker 在 `install` 裡發的 fetch，截出來永遠停在準備中，看起來像沒修好。改用 CDP 以真實時間觀察：

```
 3s: 你自己選存的 0 頁、站台自動存的 42 頁 | 本站在這台裝置上佔用 11.2 MB，可用空間還有 10.0 GB
 6s: （同上）
24s: （同上）
```

狀態三秒內就補上了。降級那條路用不在 `base.html` 白名單的 hostname（`127.0.0.2`）確認：

```
這個瀏覽器沒有提供離線儲存，或者停用了 Service Worker（Tor Browser 屬於後者，onion 版本也不啟用）。這一頁其他段落的說明仍然適用。 |  | ▸ | 近期公告
```

說明出現，清單仍在。

三支測試沒動到邏輯，仍然全過（26 / 6 / offline_index）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)