### PR TITLE
fix(pwa): 離線閱讀頁的章節清單改照 nav 的分組與順序

### DIFF
--- a/docs/hooks/offline_index.py
+++ b/docs/hooks/offline_index.py
@@ -33,16 +33,60 @@ SKIP_SEGMENTS = ("/page/", "/archive/", "/category/")
 
 # 收集在模組層級。mkdocs 一次執行只建一個語系，三語系是三個 process，不會互相污染。
 _pages = []
+# nav 樹走過一遍得到的章節順序。管理頁照這個排，讀者在側邊欄看到什麼順序，
+# 在這裡就看到什麼順序。
+_order = []
 
 
-def _top_section(page):
-    """走到 nav 的頂層章節，回傳它的標題。不在 nav 裡的頁面回 None。"""
+def _nav_path(page):
+    """這一頁在 nav 上的章節路徑，由外而內。不在 nav 裡的頁面回空 list。"""
     node = getattr(page, "parent", None)
-    if node is None:
-        return None
-    while getattr(node, "parent", None) is not None:
-        node = node.parent
-    return getattr(node, "title", None)
+    path = []
+    while node is not None:
+        title = getattr(node, "title", None)
+        if title:
+            path.append(title)
+        node = getattr(node, "parent", None)
+    path.reverse()
+    return path
+
+
+def _nav_titles(page):
+    """回傳 (頂層章節, 第二層章節)。
+
+    nav 最深有三層（指南 > 工具 > 連線層：Tor 工具家族）。管理頁只取到第二層，
+    第三層的頁面併回它所屬的第二層章節。全展開會變成三十組，其中好幾組只有兩三頁，
+    那份清單比現在更難看起。取兩層之後對得上側邊欄折起來時的樣子。
+    """
+    path = _nav_path(page)
+    if not path:
+        return None, None
+    return path[0], (path[1] if len(path) > 1 else path[0])
+
+
+def _key(group, section):
+    return (group or "") + "|" + (section or "")
+
+
+def on_nav(nav, config, **kwargs):
+    """記下 nav 的章節順序。
+
+    不能靠頁面被處理的先後：mkdocs 是照檔案路徑的字母序跑 on_post_page，那個順序
+    跟讀者在側邊欄看到的完全對不上（「進階」會排在「概念」前面，零星的單頁散在
+    中間）。這裡走一次 nav 樹，拿到的才是側邊欄的順序。
+    """
+    _order.clear()
+
+    def walk(items, path):
+        for item in items:
+            if getattr(item, "is_section", False):
+                walk(item.children, path + [item.title])
+            elif getattr(item, "is_page", False):
+                key = _key(path[0] if path else None, path[1] if len(path) > 1 else (path[0] if path else None))
+                if key not in _order:
+                    _order.append(key)
+
+    walk(nav.items, [])
 
 
 def on_post_page(output, page, config, **kwargs):
@@ -51,15 +95,13 @@ def on_post_page(output, page, config, **kwargs):
         return output
     if any(segment in "/" + url for segment in SKIP_SEGMENTS):
         return output
+    group, section = _nav_titles(page)
     _pages.append(
         {
             "url": url,
             "title": page.title,
-            "section": _top_section(page),
-            # URL 第一段。章節的 index 頁（tools/）與底下的內容（tools/x/）要落在
-            # 同一組，所以先去掉結尾的斜線再切。首頁的 url 是空字串，自成一組。
-            # 這個 key 在三個語系之間是穩定的，不受翻譯影響。
-            "key": url.rstrip("/").split("/")[0],
+            "group": group,
+            "section": section,
             "bytes": len(output.encode("utf-8")),
         }
     )
@@ -71,30 +113,45 @@ def on_post_build(config, **kwargs):
         log.warning("offline_index: 沒有收集到任何頁面，不產生 %s", OUTPUT_NAME)
         return
 
-    # 依 key 分組，保留第一次出現的順序，也就是 nav 的順序
+    # 依 nav 的章節分組。用 (頂層, 所屬章節) 當依據而不是 URL 的第一段：站台的
+    # 「關於我們」底下是 about/、contact.md 與 help/ 三個不同目錄，照 URL 分會變成
+    # 三組各一頁，散在清單裡不知道從何看起，而在側邊欄上它們本來就是同一節。
     groups = {}
     for entry in _pages:
+        key = _key(entry["group"], entry["section"])
         group = groups.setdefault(
-            entry["key"],
-            {"key": entry["key"], "title": None, "nav_title": None, "pages": []},
+            key,
+            {
+                "key": key,
+                "group": entry["group"] or "",
+                "title": entry["section"] or "",
+                "pages": [],
+            },
         )
-        # 章節的 index 頁標題最貼切。nav 的頂層標題在這個站分不出組（tools、
-        # basics、scenarios 在 nav 上都掛在「指南」底下），只當備援。
-        if entry["url"].rstrip("/") == entry["key"]:
-            group["title"] = entry["title"]
-        if group["nav_title"] is None and entry["section"]:
-            group["nav_title"] = entry["section"]
         group["pages"].append(
             {"url": entry["url"], "title": entry["title"], "bytes": entry["bytes"]}
         )
 
-    sections = []
+    # nav 走過的先排。nav 上沒有的插回同一個頂層章節的尾巴，不要一律丟到最後：
+    # blog 外掛的文章結構在 on_nav 之後才建，一律附在後面的話「近期公告」會離它的
+    # 「資訊更新」隔著整個社群與活動參與，讀者不會知道那兩者是同一節。
+    ordered = [groups.pop(key) for key in _order if key in groups]
     for group in groups.values():
+        at = len(ordered)
+        for index, existing in enumerate(ordered):
+            if existing["group"] == group["group"]:
+                at = index + 1
+        ordered.insert(at, group)
+
+    sections = []
+    for group in ordered:
         sections.append(
             {
                 "key": group["key"],
-                # index 頁、nav 標題、key 依序當備援，管理頁至少還分得出組
-                "title": group["title"] or group["nav_title"] or group["key"] or "",
+                # nav 上的名稱優先。整份索引就是側邊欄的投影，名稱不一致的話
+                # 讀者得自己在兩邊之間對照。
+                "title": group["title"] or group["group"] or group["pages"][0]["title"],
+                "group": group["group"],
                 "bytes": sum(page["bytes"] for page in group["pages"]),
                 "pages": group["pages"],
             }

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -46,6 +46,13 @@
     #offline-library .ol-actions {
       display: flex; flex-wrap: wrap; gap: .4rem; margin: 0 0 1.2rem;
     }
+    #offline-library .ol-group {
+      margin: 1.4rem 0 .1rem; font-weight: 700; font-size: .72rem;
+      opacity: .7; letter-spacing: .04em;
+    }
+    #offline-library .ol-group:first-of-type { margin-top: .6rem; }
+    /* 頂層章節底下只有一組時不掛標題，改用留白分隔，否則它會看起來像上一組的一部分 */
+    #offline-library .ol-section--gap { margin-top: 1.4rem; }
     #offline-library .ol-section {
       border-bottom: .05rem solid var(--md-default-fg-color--lightest);
     }
@@ -125,6 +132,7 @@
       removed: "已移除 {n} 頁。",
       selectAll: "整章勾選",
       pages: "{n} 頁",
+      overview: "總覽",
       badgeAuto: "站台已存",
       progress: "{done} / {total}",
     },
@@ -154,6 +162,7 @@
       removed: "已移除 {n} 页。",
       selectAll: "整章勾选",
       pages: "{n} 页",
+      overview: "总览",
       badgeAuto: "站台已存",
       progress: "{done} / {total}",
     },
@@ -183,6 +192,7 @@
       removed: "{n} pages removed.",
       selectAll: "Select whole section",
       pages: "{n} pages",
+      overview: "Overview",
       badgeAuto: "stored by the site",
       progress: "{done} / {total}",
     },
@@ -349,7 +359,7 @@
     return status;
   }
 
-  function renderSection(section) {
+  function renderSection(section, label) {
     const stored = section.pages.filter((page) => isStored(page.url)).length;
     const wrapper = el("div", "ol-section");
     const open = state.open.has(section.key);
@@ -363,7 +373,7 @@
     // 展開指示自己畫。material 的箭頭是 summary::after，這裡沒有 summary 可用，
     // 而 ::before/::after 在 md-typeset 底下容易被 theme 的規則波及。
     toggle.appendChild(el("span", "ol-mark", open ? "▾" : "▸"));
-    toggle.appendChild(el("span", "ol-name", section.title));
+    toggle.appendChild(el("span", "ol-name", label));
     toggle.appendChild(
       el("span", "ol-meta", fill("pages", { n: section.pages.length }) + "・" + size(section.bytes))
     );
@@ -501,11 +511,38 @@
       root.appendChild(el("p", null, t.noIndex));
       return;
     }
-    // 頁數多的排前面。讀者要找的多半是章節，零星的單頁擺後面不礙事。
-    const sections = state.index.sections
-      .slice()
-      .sort((a, b) => b.pages.length - a.pages.length);
-    for (const section of sections) root.appendChild(renderSection(section));
+    // 照 offline-index.json 給的順序，那是 nav 的順序，不另外排。原本按頁數排，
+    // 結果是「近期公告」七十篇擺最上面、指南的章節散在中間，跟讀者在側邊欄記得的
+    // 位置完全對不上，一打開不知道從何看起。
+    const sections = state.index.sections;
+    const perGroup = {};
+    for (const section of sections) {
+      const group = section.group || "";
+      perGroup[group] = (perGroup[group] || 0) + 1;
+    }
+
+    let lastGroup = null;
+    let first = true;
+    for (const section of sections) {
+      const group = section.group || "";
+      const changed = group !== lastGroup;
+      // 一個頂層章節底下只有一組時不另外掛標題，兩行寫同一個名字沒有意義
+      const titled = group && perGroup[group] > 1;
+      if (titled && changed) root.appendChild(el("p", "ol-group", group));
+
+      // 只有一頁又跟頂層同名的，那是這一節的總覽頁，照原名列會跟頂層標題重複
+      const label =
+        titled && section.title === group && section.pages.length === 1
+          ? t.overview
+          : section.title;
+      const node = renderSection(section, label);
+      // 沒有標題可以分隔時改用留白，不然它會看起來像上一組的最後一項
+      if (changed && !titled && !first) node.classList.add("ol-section--gap");
+      root.appendChild(node);
+
+      lastGroup = group;
+      first = false;
+    }
   }
 
   // 動作跑起來之後停用按鈕、顯示進度，做完重讀狀態再整頁重畫

--- a/tools/test_offline_index.py
+++ b/tools/test_offline_index.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """offline_index hook 的回歸測試。
 
-這支 hook 決定「離線內容管理頁上列出哪些東西」。錯了不會讓建置變紅燈：漏掉章節
-就是讀者在管理頁上找不到那些頁面（而管理頁存在的理由正是讓讀者拿到預設不下載的
-那幾頁），多列聚合頁則是讓人下載到一堆重複的摘要，還把估算的大小灌水。
+這支 hook 決定「離線內容管理頁上列出哪些東西、照什麼順序」。錯了不會讓建置變紅燈：
+漏掉章節就是讀者在管理頁上找不到那些頁面（而管理頁存在的理由正是讓讀者拿到預設
+不下載的那幾頁），順序亂掉則是整份清單跟側邊欄對不起來，打開不知道從何看起。
 
-分組規則改動時，請一併在這裡補上對應案例。不跑 mkdocs，只測純邏輯。
+分組與排序規則改動時，請一併在這裡補上對應案例。不跑 mkdocs，只測純邏輯。
 """
 
 from __future__ import annotations
@@ -32,121 +32,162 @@ def check(label: str, got, want) -> None:
         failures.append(f"{label}\n    got:  {got!r}\n    want: {want!r}")
 
 
-class FakeSection:
-    def __init__(self, title, parent=None):
-        self.title = title
-        self.parent = parent
-
-
 class FakePage:
-    def __init__(self, url, title, parent=None):
+    is_section = False
+    is_page = True
+
+    def __init__(self, url, title):
         self.url = url
         self.title = title
-        self.parent = parent
+        self.parent = None
 
 
-def build(pages, html="x"):
-    """把一串 (url, title, parent) 餵過 hook，回傳寫出來的 JSON。"""
+class FakeSection:
+    is_section = True
+    is_page = False
+
+    def __init__(self, title, children):
+        self.title = title
+        self.children = list(children)
+        self.parent = None
+        for child in self.children:
+            child.parent = self
+
+
+class FakeNav:
+    def __init__(self, items):
+        self.items = list(items)
+
+
+def build(nav, pages, html="x"):
+    """跑一輪 hook，回傳寫出來的 JSON。
+
+    pages 是 mkdocs 實際處理頁面的順序，跟 nav 的順序不同（mkdocs 照檔案路徑的
+    字母序跑），測試刻意傳打亂的順序，驗輸出仍照 nav。
+    """
     offline_index._pages.clear()
+    offline_index._order.clear()
+    offline_index.on_nav(nav, None)
     for page in pages:
         offline_index.on_post_page(html, page, None)
     with tempfile.TemporaryDirectory() as tmp:
-        config = {"site_dir": tmp, "theme": {"language": "zh-TW"}}
-        offline_index.on_post_build(config)
+        offline_index.on_post_build({"site_dir": tmp, "theme": {"language": "zh-TW"}})
         target = pathlib.Path(tmp) / offline_index.OUTPUT_NAME
-        if not target.exists():
-            return None
-        return json.loads(target.read_text(encoding="utf-8"))
+        return json.loads(target.read_text(encoding="utf-8")) if target.exists() else None
 
 
-def keys_of(index):
-    return [section["key"] for section in index["sections"]]
+def titles(index):
+    return [(s["group"], s["title"], len(s["pages"])) for s in index["sections"]]
 
 
-def section_by_key(index, key):
-    for section in index["sections"]:
-        if section["key"] == key:
-            return section
-    # 找不到時回一份空的而不是 None。分組壞掉時整個 key 會消失，直接取欄位會讓
-    # 這支腳本崩在 TypeError 上，看不到是哪一項對不起來。
-    return {"key": key, "title": None, "bytes": 0, "pages": []}
+# --- 順序照 nav，不是照頁面被處理的先後 ---
 
+home = FakePage("", "首頁")
+guides_index = FakePage("guides/", "指南")
+basics_index = FakePage("basics/", "概念層")
+basics_page = FakePage("basics/metadata/", "Metadata")
+tools_index = FakePage("tools/", "工具層")
+tools_deep = FakePage("tools/what-is-tor/", "什麼是 Tor")
+about = FakePage("about/", "關於我們")
+contact = FakePage("contact/", "持續關注")
 
-# --- 分組 key ---
+nav = FakeNav([
+    home,
+    FakeSection("指南", [
+        guides_index,
+        FakeSection("概念", [basics_index, basics_page]),
+        # 第三層：nav 上「工具」底下還有「連線層」這種子分組
+        FakeSection("工具", [tools_index, FakeSection("連線層", [tools_deep])]),
+    ]),
+    FakeSection("關於我們", [about, contact]),
+])
 
-index = build(
-    [
-        FakePage("", "首頁"),
-        FakePage("about/", "關於我們"),
-        FakePage("tools/", "工具層"),
-        FakePage("tools/what-is-tor/", "什麼是 Tor"),
-        FakePage("blog/2026/04/x/", "某篇文章"),
-    ]
+# 刻意用字母序餵進去，那是 mkdocs 實際的處理順序
+index = build(nav, [about, basics_index, basics_page, contact, guides_index, home, tools_index, tools_deep])
+check(
+    "順序照 nav 而不是字母序",
+    titles(index),
+    [("", "首頁", 1), ("指南", "指南", 1), ("指南", "概念", 2), ("指南", "工具", 2), ("關於我們", "關於我們", 2)],
 )
-# 章節的 index 頁（tools/）與底下的內容（tools/x/）要落在同一組
-check("key 分組", keys_of(index), ["", "about", "tools", "blog"])
-check("index 頁與內容同組", len(section_by_key(index, "tools")["pages"]), 2)
-check("首頁自成一組", len(section_by_key(index, "")["pages"]), 1)
 
-# --- 章節標題 ---
+# 第三層的頁面併回第二層。全展開會變成三十組，其中好幾組只有兩三頁。
+check("第三層併回第二層", [p["url"] for p in index["sections"][3]["pages"]], ["tools/", "tools/what-is-tor/"])
 
-# nav 的頂層標題在這個站分不出組（tools、basics、scenarios 都掛在「指南」底下），
-# 所以標題優先取該章節 index 頁的標題
-guides = FakeSection("指南")
-index = build(
-    [
-        FakePage("tools/", "工具層", parent=guides),
-        FakePage("tools/what-is-tor/", "什麼是 Tor", parent=guides),
-        FakePage("basics/", "概念層", parent=guides),
-    ]
+# 站台的「關於我們」底下是 about/ 與 contact.md 兩個不同目錄，照 URL 分會變成
+# 兩組各一頁，在側邊欄上它們本來就是同一節
+check("同一節的不同目錄合併", len(index["sections"][4]["pages"]), 2)
+
+# --- nav 上沒有的插回同一個頂層的尾巴 ---
+
+posts_index = FakePage("blog/", "資訊更新")
+changelog = FakePage("changelog/", "軟體更新日誌")
+community = FakePage("community/", "社群")
+# blog 外掛的文章在 on_nav 之後才進 nav，hook 走 nav 時看不到
+article = FakePage("blog/2026/04/x/", "某篇文章")
+article.parent = FakeSection("近期公告", [])
+article.parent.parent = FakeSection("資訊更新", [])
+
+nav2 = FakeNav([
+    FakeSection("資訊更新", [posts_index, FakeSection("軟體更新日誌", [changelog])]),
+    FakeSection("社群", [community]),
+])
+index2 = build(nav2, [article, changelog, community, posts_index])
+# 一律附在最後的話，「近期公告」會離它的「資訊更新」隔著整個社群
+check(
+    "nav 上沒有的插回同一個頂層的尾巴",
+    titles(index2),
+    [("資訊更新", "資訊更新", 1), ("資訊更新", "軟體更新日誌", 1), ("資訊更新", "近期公告", 1), ("社群", "社群", 1)],
 )
-check("章節標題取 index 頁", section_by_key(index, "tools")["title"], "工具層")
-check("同一個 nav 標題也分得開", section_by_key(index, "basics")["title"], "概念層")
-
-# 沒有 index 頁時退回 nav 的頂層標題
-nested = FakeSection("在地脈絡", parent=None)
-child = FakeSection("子章節", parent=nested)
-index = build([FakePage("taiwan/pdpa-2025/", "個資法", parent=child)])
-check("沒有 index 頁時用 nav 頂層標題", section_by_key(index, "taiwan")["title"], "在地脈絡")
-
-# 兩者都沒有時退回 key，管理頁至少還分得出組
-index = build([FakePage("reports/x/", "某份報告")])
-check("都沒有時退回 key", section_by_key(index, "reports")["title"], "reports")
 
 # --- 排除 ---
 
-index = build(
-    [
-        FakePage("blog/2026/04/x/", "某篇文章"),
-        FakePage("blog/page/2/", "第 2 頁"),
-        FakePage("blog/archive/2025/", "2025 年"),
-        FakePage("blog/category/updates/", "更新"),
-        FakePage("offline/", "離線閱讀"),
-        FakePage("404.html", "找不到"),
-    ]
-)
+post = FakePage("blog/2026/04/x/", "某篇文章")
+section = FakeSection("資訊更新", [post])
+skipped = [
+    FakePage("blog/page/2/", "第 2 頁"),
+    FakePage("blog/archive/2025/", "2025 年"),
+    FakePage("blog/category/updates/", "更新"),
+    FakePage("offline/", "離線閱讀"),
+    FakePage("404.html", "找不到"),
+]
+for page in skipped:
+    page.parent = section
+index3 = build(FakeNav([section]), [post] + skipped)
 # 聚合頁的內容都在個別文章裡，讓讀者勾只會下載到一堆重複的摘要
-check("只留真正的文章", [page["url"] for page in section_by_key(index, "blog")["pages"]], ["blog/2026/04/x/"])
-check("管理頁與 404 不列", keys_of(index), ["blog"])
+check("只留真正的文章", [p["url"] for p in index3["sections"][0]["pages"]], ["blog/2026/04/x/"])
+check("管理頁與 404 不列", len(index3["sections"]), 1)
 
 # --- 大小 ---
 
-index = build([FakePage("tools/", "工具層"), FakePage("tools/x/", "某頁")], html="12345")
-check("章節大小是頁面加總", section_by_key(index, "tools")["bytes"], 10)
-check("單頁大小是 HTML 位元組數", section_by_key(index, "tools")["pages"][0]["bytes"], 5)
+a = FakePage("tools/", "工具層")
+b = FakePage("tools/x/", "某頁")
+index4 = build(FakeNav([FakeSection("工具", [a, b])]), [a, b], html="12345")
+check("章節大小是頁面加總", index4["sections"][0]["bytes"], 10)
+check("單頁大小是 HTML 位元組數", index4["sections"][0]["pages"][0]["bytes"], 5)
 
 # 中文是多位元組，算的要是位元組不是字元數
-index = build([FakePage("tools/", "工具層")], html="中文")
-check("中文算位元組", section_by_key(index, "tools")["bytes"], 6)
+c = FakePage("tools/", "工具層")
+index5 = build(FakeNav([FakeSection("工具", [c])]), [c], html="中文")
+check("中文算位元組", index5["sections"][0]["bytes"], 6)
+
+# --- 不在 nav 裡的頁面 ---
+
+orphan = FakePage("strays/x/", "孤兒頁")
+index6 = build(FakeNav([]), [orphan])
+# 標題退回頁面自己的標題，至少列得出來
+check("不在 nav 裡的頁面照樣收錄", titles(index6), [("", "孤兒頁", 1)])
 
 # --- 全空 ---
 
-check("沒有任何頁面時不產生檔案", build([]), None)
+check("沒有任何頁面時不產生檔案", build(FakeNav([]), []), None)
 
 # --- 語系 ---
 
+d = FakePage("tools/", "Tools")
 offline_index._pages.clear()
-offline_index.on_post_page("x", FakePage("tools/", "Tools"), None)
+offline_index._order.clear()
+offline_index.on_nav(FakeNav([FakeSection("Guides", [d])]), None)
+offline_index.on_post_page("x", d, None)
 with tempfile.TemporaryDirectory() as tmp:
     offline_index.on_post_build({"site_dir": tmp, "theme": {"language": "en"}})
     written = json.loads((pathlib.Path(tmp) / offline_index.OUTPUT_NAME).read_text(encoding="utf-8"))


### PR DESCRIPTION
使用者回報：離線閱讀頁的列表「看起來很亂，也不知道怎麼看起」，希望能跟 nav 類似。

## 原本亂在哪

清單按頁數多寡排序，所以「近期公告」七十篇擺在最上面，指南的六個章節散在中間，零星的單頁（首頁、持續關注、關於我們、緊急求救、匿名網路工作坊）各自成組混在裡面。那個順序跟讀者在側邊欄記得的位置完全無關。

分組依據是 URL 的第一段，所以站台的「關於我們」被拆成 `about`、`contact`、`help` 三組各一頁，而在側邊欄上它們本來就是同一節。

## 改成什麼

```
▸ 首頁                    1 頁 · 192 KB   1/1

指南
▸ 總覽                    1 頁 · 175 KB   1/1
▸ 概念                   10 頁 · 1.9 MB   6/10
▸ 工具                   20 頁 · 3.9 MB   15/20
▸ 場景                   11 頁 · 2.2 MB   3/11
▸ 進階                    6 頁 · 1.1 MB   6/6
▸ 報告                   17 頁 · 3.3 MB   0/17

在地脈絡
▸ 總覽 / 連線層的在地觀測 / 法規與制度

▸ 互動                    4 頁 · 738 KB   1/4

資訊更新
▸ 總覽 / 軟體更新日誌 / 近期公告

社群
▸ 總覽 / 加入社群 / 文件與開發 / 架設節點 / 讀懂觀測資料 / 2026 主題
...
```

順序與名稱都跟側邊欄一樣。三個語系各 23 組，各自照自己的 nav（en 的 About 排在最前面，因為 `mkdocs_en.yml` 的 nav 順序不同）。

## 實作

分組依據改成 nav 的 (頂層章節, 第二層章節)。

順序改由 `on_nav` 走一次 nav 樹決定。不能靠頁面被處理的先後 — mkdocs 是照檔案路徑的字母序跑 `on_post_page`，那樣「進階」會排在「概念」前面。blog 外掛的文章在 `on_nav` 之後才進 nav，那一類插回同一個頂層章節的尾巴，不然「近期公告」會離「資訊更新」隔著整個社群與活動參與。

nav 最深有三層（指南 > 工具 > 連線層：Tor 工具家族），只取到第二層，第三層的頁面併回所屬章節。全展開是 30 組，其中好幾組只有兩三頁，比原本更難看起；取兩層之後對得上側邊欄折起來的樣子。

管理頁的呈現規則：

- 照索引給的順序排，不另外排序
- 頂層章節掛一個小標題
- 只有一頁又跟頂層同名的（各節的 index 頁）顯示成「總覽」
- 頂層底下只有一組時不掛標題，兩行寫同一個名字沒有意義，改用留白分隔，否則它會看起來像上一組的最後一項（「互動」原本會被吸進「在地脈絡」）

## 測試

`test_offline_index.py` 依新規則重寫：用假的 nav 樹餵進 `on_nav`，頁面刻意用字母序傳入，驗輸出仍照 nav。

```
  順序照 nav 而不是字母序
  第三層併回第二層
  同一節的不同目錄合併
  nav 上沒有的插回同一個頂層的尾巴
  只留真正的文章 / 管理頁與 404 不列
  章節大小是頁面加總 / 中文算位元組
  不在 nav 裡的頁面照樣收錄
```

反向驗證確認會紅：拿掉 nav 排序（3 項失敗）、把層級取到第三層（3 項失敗，`工具` 會裂成 `工具` 與 `連線層`）。

另外兩支測試與 `check_precache.mjs` 不受影響，仍全過（32 / 6，預快取三語系各約 10~11.5 MB）。版面用 headless Chrome 實際渲染確認過，包含「互動」那組的留白分隔。

🤖 Generated with [Claude Code](https://claude.com/claude-code)