### PR TITLE
fix(pwa): 離線閱讀頁誤判成「這個瀏覽器沒有離線儲存」

### DIFF
--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -280,6 +280,10 @@
       #}
       <script>
         (function () {
+          // 這個環境到底會不會註冊 service worker，只有這裡知道。離線內容管理頁
+          // 靠這個旗標判斷要不要等，不然它只能空等到超時，才對著一個根本不會註冊的
+          // 瀏覽器說「這裡沒有離線儲存」。
+          window.__anoniServiceWorker = false;
           if (!("serviceWorker" in navigator)) return;
 
           var script, options;
@@ -293,6 +297,7 @@
           } else {
             return;
           }
+          window.__anoniServiceWorker = true;
 
           // 換版提示的文案。document.documentElement.lang 在 zh-CN 版是 "zh"
           // （mkdocs_cn.yml 的 theme.language），對不到 zh-CN 這個代碼。

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -228,24 +228,40 @@
     return;
   }
 
-  // service worker 準備好了沒。
+  // 等 registration 出現。
+  //
+  // 不能只等一小段固定時間就下判斷。Chrome 會把 register() 排到頁面 load 之後才真的
+  // 跑，而這一頁要載完 material 的 bundle 與字型，正式站實測 getRegistration() 到
+  // 十二秒才回得出東西。等太短就會對著一個好好的瀏覽器說「這裡沒有離線儲存」。
+  //
+  // 反過來，真的不註冊的環境（onion 版、IPFS gateway、停用 Service Worker 的瀏覽器）
+  // 由 base.html 把 window.__anoniServiceWorker 設成 false，看到就直接放棄，不用空等。
+  // 那支在 body 尾端，比這支晚執行，所以第一輪拿到 undefined 是正常的，繼續等就是。
+  function waitForRegistration() {
+    const deadline = Date.now() + 30000;
+    const attempt = () => {
+      if (window.__anoniServiceWorker === false) return Promise.resolve(null);
+      return navigator.serviceWorker.getRegistration().then((registration) => {
+        if (registration) return registration;
+        if (Date.now() > deadline) return null;
+        return new Promise((resolve) => setTimeout(resolve, 500)).then(attempt);
+      });
+    };
+    return attempt();
+  }
+
+  // service worker 可以收指令了沒。
   //
   // 不能直接用 navigator.serviceWorker.ready：首次造訪時 install 要把整個語系的核心
   // 章節抓完（約十 MB）才會 activate，ready 也才 resolve，行動網路上那是好幾分鐘。
   // 這一頁的清單不需要等那個，所以拆成兩段，索引先畫、狀態晚點補。
-  //
-  // 先讓出一輪再問有沒有 registration：base.html 的註冊碼在 body 尾端，比這支晚執行，
-  // 太早問會拿到 undefined。問得到才等 ready，問不到就是這個環境不註冊（onion 版與
-  // 停用 Service Worker 的瀏覽器），沒必要一直等下去。
   let readyPromise = null;
   function whenReady() {
     if (!readyPromise) {
-      readyPromise = new Promise((resolve) => setTimeout(resolve, 1200))
-        .then(() => navigator.serviceWorker.getRegistration())
-        .then((registration) => {
-          if (!registration) throw new Error("no-service-worker-registration");
-          return navigator.serviceWorker.ready;
-        });
+      readyPromise = waitForRegistration().then((registration) => {
+        if (!registration) throw new Error("no-service-worker-registration");
+        return navigator.serviceWorker.ready;
+      });
     }
     return readyPromise;
   }


### PR DESCRIPTION
推 #271 上線後截圖驗證時發現的。這是 #269 引入的問題。

## 症狀

正式站的離線閱讀頁顯示「這個瀏覽器沒有提供離線儲存，或者停用了 Service Worker」，章節清單的已存比例全部是 `0 / N`，勾選框也停用，等於整頁功能都被關掉。而那個瀏覽器是有 service worker 的。

## 原因

#269 用「等 1200 毫秒再問 `getRegistration()`」判斷這個環境有沒有 service worker。那個延遲太短。Chrome 會把 `register()` 排到頁面 load 之後才真的跑，而這一頁要載完 material 的 bundle 與字型：

```
  500ms  registration=undefined
 1500ms  registration=false
 3000ms  registration=false
 6000ms  registration=false
12000ms  registration=true      ← 正式站實測
```

本機測不出來，因為資源都在 localhost，兩秒內就註冊好了。

## 修法

輪詢等 registration 出現，上限三十秒：

```js
function waitForRegistration() {
  const deadline = Date.now() + 30000;
  const attempt = () => {
    if (window.__anoniServiceWorker === false) return Promise.resolve(null);
    return navigator.serviceWorker.getRegistration().then((registration) => {
      if (registration) return registration;
      if (Date.now() > deadline) return null;
      return new Promise((resolve) => setTimeout(resolve, 500)).then(attempt);
    });
  };
  return attempt();
}
```

真的不註冊的環境不靠等待判斷。`base.html` 是唯一知道要不要註冊的地方（hostname 白名單），讓它把結論寫進 `window.__anoniServiceWorker`，管理頁看到 `false` 就直接放棄，不用空等三十秒。那支在 body 尾端比管理頁的程式晚執行，所以第一輪拿到 `undefined` 是正常的，繼續等就是。

## 驗證

兩種環境都用 CDP 實測：

```
=== localhost（會註冊）===
 2s  旗標=true   狀態=你自己選存的 0 頁、站台自動存的 42 頁
18s  旗標=true   狀態=你自己選存的 0 頁、站台自動存的 42 頁

=== 127.0.0.2（不在白名單，不註冊）===
 2s  旗標=false  狀態=這個瀏覽器沒有提供離線儲存，或者停用了 Service Worker
18s  旗標=false  狀態=這個瀏覽器沒有提供離線儲存，或者停用了 Service Worker
```

三支測試不受影響，仍全過（32 / 6 / offline_index）。

合併部署後我會再對正式站確認一次，那裡的註冊延遲才是真實情況。

🤖 Generated with [Claude Code](https://claude.com/claude-code)