### PR TITLE
ci: tools/ 的四支測試進 CI

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,59 @@
+# tools/ 底下那幾支測試的 CI。全部零外部相依，不需要建置產物，跑完不到十秒。
+#
+# 為什麼值得掛上來：這幾支守的都是「只在特定情境才會出錯、平常看不出來」的行為，
+# 而那正是抽樣測試守不住的一類。實際踩過的：
+#
+#   - service worker 的離線 fallback 整條鏈沒有測試，結果「清除所有離線內容」把
+#     離線提示頁一起清掉，之後任何沒快取的網址在離線時都掉到瀏覽器的錯誤畫面
+#   - 預快取清單與索引頁連出去的網址形狀對不上，線上一切正常，只有離線的人打不開
+#   - 離線內容管理頁的分組與排序改動，錯了是整份清單跟側邊欄對不起來
+#   - 部署後要清哪些網址，漏清是訪客看到舊內容，多清是波及 zone 內其他服務
+#
+# tools/test_docs_style_lint.py 不在這裡，它由 docs-style-lint.yml 跑，那支 workflow
+# 本來就要先確認規則沒壞掉才有資格擋 PR。
+name: tools-tests
+
+on:
+  pull_request:
+    paths:
+      - "tools/**"
+      - "docs/zh-TW/sw.js"
+      - "docs/overrides/base.html"
+      - "docs/hooks/**"
+      - ".github/workflows/tools-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # service worker 的離線行為：網址形狀、語系、預快取範圍、library 與清除
+      - name: sw.js 離線路徑
+        run: node tools/test_sw_offline.mjs
+
+      # 語言偏好只在預設語系的首頁套用，其餘一律不動
+      - name: 語言偏好導向規則
+        run: node tools/test_lang_preference.mjs
+
+      # 離線內容管理頁的章節分組與排序，照 nav 而不是檔案的字母序
+      - name: 離線內容索引
+        run: python3 tools/test_offline_index.py
+
+      # 部署後要清除的 Cloudflare 快取網址
+      - name: Cloudflare 快取清除映射
+        run: python3 tools/test_cf_purge.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,10 @@ CC BY-NC-SA 4.0（禁止商業使用）。清單見根目錄 [`NOTICE`](./NOTICE
 |------|------|------|
 | 離線內容索引 | `docs/hooks/offline_index.py` | mkdocs hook，建置時產出各語系的 `offline-index.json`（有哪些頁面、屬於哪個章節、多大）。離線內容管理頁 `docs/<lang>/offline.md` 用它列出可勾選的清單，介面在 `docs/zh-TW/js/offline-library.js`（另兩語是 symlink）|
 | 文件編輯標準 | `docs_style_lint.py`、`test_docs_style_lint.py` | 把貢獻者百科「寫作風格規範」可機器判斷的部分做成檢查。三語系都掃，中英各一組規則（破折號與分號在英文屬正常用法，不套中文那組）。純標準庫，無外部相依。細節見 [`tools/README.md`](./tools/README.md) |
-| 部署 | `cf_purge.py`、`test_cf_purge.py` | 建置完把產物映射回網址，逐批清除 Cloudflare 快取（每批 30 條）|
+| 部署 | `cf_purge.py`、`test_cf_purge.py` | 建置完把產物映射回網址，逐批清除 Cloudflare 快取（每批 30 條）。測試由 [`tools-tests.yml`](./.github/workflows/tools-tests.yml) 在 PR 觸發 |
 | 地球儀資料 | `gen_*.py`、`publish_games_data.sh` | 產生 `docs/zh-TW/games/tor-network/` 的靜態 JSON。`snapshot.json`、`torusers.json`、`seacable.json` 會持續變動，由 `publish_games_data.sh` 在正式機重生並檢查後發布到 assets，其餘幾份變動以季或年計，跟文件站一起發布即可 |
 | 地球儀版面檢查 | `check_double_tap.mjs`、`check_focus.mjs`、`check_pinch_release.mjs`、`check_sub_gauge.mjs`、`fix_trunk_land.mjs`、`shoot_games.mjs` | headless Chrome 跑的互動與版面檢查，由 `games-checks.yml` 在 PR 觸發 |
-| PWA 與離線 | `check_precache.mjs`、`test_sw_offline.mjs`、`test_lang_preference.mjs`、`test_offline_index.py` | `check_precache.mjs` 比對預快取清單與 `docs/output` 的實際檔案，並驗索引頁連出去的網址形狀命中得了快取的 key（需先建置）。其餘三支把函式從 `docs/zh-TW/sw.js`、`docs/overrides/base.html` 與 `docs/hooks/offline_index.py` 原地抽出來單元測試，不需要建置。四支都沒進 CI，改動那幾個檔案時手動跑 |
+| PWA 與離線 | `check_precache.mjs`、`test_sw_offline.mjs`、`test_lang_preference.mjs`、`test_offline_index.py` | `check_precache.mjs` 比對預快取清單與 `docs/output` 的實際檔案，並驗索引頁連出去的網址形狀命中得了快取的 key（需先建置）。其餘三支把函式從 `docs/zh-TW/sw.js`、`docs/overrides/base.html` 與 `docs/hooks/offline_index.py` 原地抽出來單元測試，不需要建置。由 [`tools-tests.yml`](./.github/workflows/tools-tests.yml) 在 PR 觸發，`check_precache.mjs` 需要建置產物所以沒進 CI，改 `docs/zh-TW/sw.js` 時手動跑一次 |
 
 ## 開發環境設置
 
@@ -259,6 +259,12 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
   - 只掃這次 PR 變更的檔案，避免舊文的遺留違規擋住新貢獻
   - 這個 job 會擋 merge。error 級規則讓 linter 回 exit 1，job 就紅；warn 級規則仍只以 annotation 標在變更行上，不影響 exit code
   - 待辦：repo 設定尚未把這個 check 列為 branch protection 必過，所以目前擋得住 PR 的紅燈，擋不住有權限的人直接合併
+
+- **tools-tests.yml**: 跑 `tools/` 底下那幾支零相依的測試
+  - 觸發路徑：`tools/**`、`docs/zh-TW/sw.js`、`docs/overrides/base.html`、`docs/hooks/**`
+  - 內容：`test_sw_offline.mjs`（service worker 的離線行為）、`test_lang_preference.mjs`（語言偏好導向）、`test_offline_index.py`（離線內容索引的分組與排序）、`test_cf_purge.py`（快取清除映射）
+  - 不需要建置產物，跑完不到十秒。`test_docs_style_lint.py` 不在這裡，由 `docs-style-lint.yml` 跑
+  - `check_precache.mjs` 需要 `docs/output`，沒進 CI，改 `sw.js` 時手動跑一次
 
 - **games-checks.yml**: 「Tor 中繼地球儀」的互動與版面檢查（headless Chrome）
   - 觸發路徑：`docs/zh-TW/games/tor-network/**`、`tools/check_*.mjs`


### PR DESCRIPTION
這幾輪一直掛著的技術債。

## 為什麼值得掛上來

這幾支守的都是「只在特定情境才會出錯、平常看不出來」的行為，而那正是抽樣測試守不住的一類。這一輪實際踩過的：

- **service worker 的離線 fallback 整條鏈沒有測試**，結果「清除所有離線內容」把離線提示頁一起清掉，之後任何沒快取的網址在離線時都掉到瀏覽器的錯誤畫面（#270）
- **預快取清單與索引頁連出去的網址形狀對不上**，線上一切正常，只有離線的人打不開（#263）
- **離線內容管理頁的分組與排序**，錯了是整份清單跟側邊欄對不起來（#271）

## 內容

| 測試 | 守什麼 |
|---|---|
| `test_sw_offline.mjs` | service worker 的離線行為：網址形狀、語系、預快取範圍、library 與清除（32 項）|
| `test_lang_preference.mjs` | 語言偏好只在預設語系的首頁套用，其餘一律不動（6 項）|
| `test_offline_index.py` | 離線內容索引的章節分組與排序，照 nav 而不是檔案的字母序 |
| `test_cf_purge.py` | 部署後要清除的 Cloudflare 快取網址映射 |

四支都是零外部相依、不需要建置產物，跑完不到十秒。

觸發路徑除了 `tools/**` 本身，還包含被它們原地抽出函式的那三個來源檔：`docs/zh-TW/sw.js`、`docs/overrides/base.html`、`docs/hooks/**`。

## 沒放進來的兩支

`test_docs_style_lint.py` 由 `docs-style-lint.yml` 跑，那支 workflow 本來就要先確認規則沒壞掉才有資格擋 PR，不重複。

`check_precache.mjs` 需要 `docs/output`，留在手動，`CLAUDE.md` 有註明改 `sw.js` 時要跑一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)