### PR TITLE
fix(pwa): 換版提示與語言選擇改成從底部浮出，不再置頂推擠版面

### DIFF
--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -60,6 +60,52 @@
         是各自獨立的檔案，樣式寫在這裡只要維護一份，跟著 base.html 的 symlink 走。
       #}
       <style>
+        /*
+          換版提示與語言選擇從底部浮出，不再插在 body 最前面。置頂那種做法有兩個
+          問題：卡片一插進來整頁內容往下推，讀者正在讀的位置就跑掉了。而讀者的
+          視線多半在內容區，捲動過之後頂端那條根本不在視野裡，等於沒出現過。
+        */
+        #__anoni-toasts {
+          position: fixed;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: 6;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: .4rem;
+          padding: .6rem;
+          padding-bottom: calc(.6rem + env(safe-area-inset-bottom, 0px));
+          /* 卡片以外的地方要點得穿，不然底部整條都擋住內容 */
+          pointer-events: none;
+        }
+        .anoni-toast {
+          pointer-events: auto;
+          box-sizing: border-box;
+          width: 100%;
+          max-width: 34rem;
+          padding: .55rem .8rem;
+          border: .05rem solid var(--md-default-fg-color--lighter);
+          border-radius: .2rem;
+          background: var(--md-default-bg-color);
+          color: var(--md-default-fg-color);
+          /* z3 而不是 z2。卡片是白底浮在白底內容上，陰影淡一點就分不出邊界 */
+          box-shadow: var(--md-shadow-z3);
+          font-size: .7rem;
+          line-height: 1.7;
+          animation: anoni-toast-in .28s ease-out;
+        }
+        .anoni-toast p {
+          margin: 0;
+        }
+        @keyframes anoni-toast-in {
+          from { transform: translateY(130%); opacity: 0; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .anoni-toast { animation: none; }
+        }
         .anoni-banner-action {
           background: none;
           border: 0;
@@ -271,6 +317,28 @@
         {{ script | script_tag }}
       {% endfor %}
       {#
+        底部浮出卡片的共用容器。換版提示與語言選擇各自在獨立的 IIFE 裡，這支掛在
+        window 上讓兩邊都用得到，也讓兩張卡片同時出現時能疊在一起而不是互相蓋掉。
+      #}
+      <script>
+        window.__anoniToast = function (card) {
+          var host = document.getElementById("__anoni-toasts");
+          if (!host) {
+            host = document.createElement("div");
+            host.id = "__anoni-toasts";
+            document.body.appendChild(host);
+          }
+          card.className = card.className
+            ? "anoni-toast " + card.className
+            : "anoni-toast";
+          host.appendChild(card);
+          return function () {
+            card.remove();
+            if (!host.childElementCount) host.remove();
+          };
+        };
+      </script>
+      {#
         PWA: service worker 只在 clearnet 註冊。Tor Browser 停用 SW、IPFS gateway hostname
         不符，皆自動跳過。
 
@@ -335,10 +403,7 @@
 
             var banner = document.createElement("aside");
             banner.id = "__sw-update";
-            banner.className = "md-banner";
-
-            var inner = document.createElement("div");
-            inner.className = "md-banner__inner md-grid md-typeset";
+            var dismiss;
 
             var line = document.createElement("p");
             line.appendChild(document.createTextNode(t.text));
@@ -352,12 +417,11 @@
               } catch (err) {
                 // 存不進去就只是這次關掉，換頁會再出現
               }
-              banner.remove();
+              dismiss();
             }));
 
-            inner.appendChild(line);
-            banner.appendChild(inner);
-            document.body.insertBefore(banner, document.body.firstChild);
+            banner.appendChild(line);
+            dismiss = window.__anoniToast(banner);
           }
 
           navigator.serviceWorker.register(script, options).then(function (registration) {
@@ -494,9 +558,7 @@
 
           // 沒有偏好，問一次。選項與順序跟著 extra.alternate 走，跟 header 的切換器同一份。
           var banner = document.createElement("aside");
-          banner.className = "md-banner";
-          var inner = document.createElement("div");
-          inner.className = "md-banner__inner md-grid md-typeset";
+          var dismiss;
           var line = document.createElement("p");
           line.appendChild(document.createTextNode(t.ask));
 
@@ -512,7 +574,7 @@
           links.forEach(function (link) {
             line.appendChild(action(link.name, function () {
               writePref(link.lang);
-              if (current && link.lang === current.lang) banner.remove();
+              if (current && link.lang === current.lang) dismiss();
               else location.assign(link.href);
             }));
           });
@@ -523,12 +585,11 @@
             } catch (err) {
               // 記不住就下次再問
             }
-            banner.remove();
+            dismiss();
           }));
 
-          inner.appendChild(line);
-          banner.appendChild(inner);
-          document.body.insertBefore(banner, document.body.firstChild);
+          banner.appendChild(line);
+          dismiss = window.__anoniToast(banner);
         })();
       </script>
     {% endblock %}


### PR DESCRIPTION
使用者回報：更新提示與語言詢問都置頂在最上面，有時候沒看到它跳出，而且會強制移動版面。

## 兩個問題

置頂的卡片是 `document.body.insertBefore(banner, document.body.firstChild)` 插進去的，所以：

1. **推擠版面** — 卡片一插進來整頁內容往下推，讀者正在讀的位置就跑掉了
2. **看不到** — 讀者的視線多半在內容區，捲動過之後頂端那一條根本不在視野裡

## 改成底部浮出

`position: fixed; bottom: 0` 不佔文檔流，內容不會位移，而底部在多數閱讀姿勢下都在視線邊緣，看得到也不擋正文。

兩段 script（換版提示、語言選擇）各自在獨立的 IIFE 裡，共用的容器掛在 `window.__anoniToast`：

```js
window.__anoniToast = function (card) {
  // ...建立或取用 #__anoni-toasts 容器
  host.appendChild(card);
  return function () { card.remove(); if (!host.childElementCount) host.remove(); };
};
```

兩張卡片同時出現時會疊在一起而不是互相蓋掉。容器本身 `pointer-events: none`，只有卡片本體接得到點擊，底部整條不會擋住內容。

其他細節：

- 卡片從下方滑入（`translateY(130%)` → `0`），`prefers-reduced-motion` 的讀者不套用
- iOS 的底部安全區用 `env(safe-area-inset-bottom)` 讓開
- 陰影用 `--md-shadow-z3` 而不是 z2，卡片是白底浮在白底內容上，淡一點就分不出邊界

## 驗證

```
語言選擇卡片 = 選擇你的閱讀語言 臺灣正體（zh-TW）簡體中文（zh-CN）English (en-US) 稍後
容器位置    = fixed bottom=0px 距視窗底 0px
有沒有推擠   = h1 距頂 98px（跟沒有卡片時一樣）
兩張並存    = 2 張（垂直堆疊）
```

截圖確認過視覺。三支測試不受影響（6 / 32 / offline_index）。

換版提示與語言選擇用同一個 helper，語言選擇驗證過就證明機制正常；換版提示的觸發邏輯沒動，只換了呈現方式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)