### PR TITLE
ci: 三個 workflow 加路徑限定，asn_coverage 那兩支補 timeout 與並行取消

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,9 +1,22 @@
 name: BuildDocs
 
+# paths 列的是「會改變產物的東西」。docs/ 之外還有兩處：repo 根目錄的
+# BECOME_ANONI*.md 由 pymdownx.snippets 嵌進文件（base_path 含 ".."），
+# tools/cf_purge.py 與它的測試是部署最後一步在跑的。
+#
+# 漏列會變成推了 docs 分支卻沒有建置，站上維持舊內容而沒有任何錯誤訊息。新增
+# 這一類 docs/ 之外的相依時要一併補進來。真的遇到沒觸發，從 Actions 頁面用
+# workflow_dispatch 手動跑一次就好。
 on:
   push:
     branches:
       - "docs"
+    paths:
+      - "docs/**"
+      - "BECOME_ANONI*.md"
+      - "tools/cf_purge.py"
+      - "tools/test_cf_purge.py"
+      - ".github/workflows/build_docs.yml"
   workflow_dispatch:
 
 # 最後兩步是先 `aws s3 rm --recursive` 清空該 prefix，再 `s3 sync` 上傳。兩個 run

--- a/.github/workflows/check-ripe.yml
+++ b/.github/workflows/check-ripe.yml
@@ -1,14 +1,28 @@
 name: RIPE ASN name lists
+# 這支跑的是 asn_coverage/ripe.py 的資料抓取，跟 docs/ 的內容無關。原本任何 main 的 push 都觸發，
+# 2026-08-19 一天下來被 docs 的 PR 觸發 18 次，每次四個 job，把並行額度佔滿，
+# 連 BuildDocs 都排不進去。改成只在 asn_coverage/ 真的變動時跑，每日 cron 照舊。
 on:
   push:
     branches:
       - main
+    paths:
+      - "asn_coverage/**"
+      - ".github/workflows/check-ripe.yml"
   workflow_dispatch:
   schedule:
     - cron: "20 0 * * *"
 
+# 同一分支的新 push 取消還在跑的，不要疊在一起
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_list:
+    # 沒有這一行時 job 會用預設的六小時上限。2026-08-19 有六個 run 卡在
+    # apt-get update（runner 的 apt mirror 沒有回應），一路佔著 runner 不放。
+    timeout-minutes: 30
     strategy:
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
@@ -20,10 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Update libs
-        run: sudo apt-get update
+      # runner image 本來就帶著 ca-certificates，這一步只是保險。失敗不該擋住整個
+      # job，2026-08-19 卡死的六個 run 全部都停在這裡。
       - name: Install certificates
-        run: sudo apt-get install ca-certificates
+        timeout-minutes: 5
+        continue-on-error: true
+        run: |
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y ca-certificates
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/lookback-ooni.yml
+++ b/.github/workflows/lookback-ooni.yml
@@ -1,14 +1,28 @@
 name: Lookback OONI Data
+# 這支跑的是 asn_coverage/ooni.py 的資料抓取，跟 docs/ 的內容無關。原本任何 main 的 push 都觸發，
+# 2026-08-19 一天下來被 docs 的 PR 觸發 18 次，每次四個 job，把並行額度佔滿，
+# 連 BuildDocs 都排不進去。改成只在 asn_coverage/ 真的變動時跑，每日 cron 照舊。
 on:
   push:
     branches:
       - main
+    paths:
+      - "asn_coverage/**"
+      - ".github/workflows/lookback-ooni.yml"
   workflow_dispatch:
   schedule:
     - cron: "20 0 * * *"
 
+# 同一分支的新 push 取消還在跑的，不要疊在一起
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_list:
+    # 沒有這一行時 job 會用預設的六小時上限。2026-08-19 有六個 run 卡在
+    # apt-get update（runner 的 apt mirror 沒有回應），一路佔著 runner 不放。
+    timeout-minutes: 30
     strategy:
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
@@ -20,10 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Update libs
-        run: sudo apt-get update
+      # runner image 本來就帶著 ca-certificates，這一步只是保險。失敗不該擋住整個
+      # job，2026-08-19 卡死的六個 run 全部都停在這裡。
       - name: Install certificates
-        run: sudo apt-get install ca-certificates
+        timeout-minutes: 5
+        continue-on-error: true
+        run: |
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y ca-certificates
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,8 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 使用 GitHub Actions 自動建置與部署：
 
 - **build_docs.yml**: 建置多語系文件並發布
-  - 觸發條件: push to `docs` branch 或手動觸發
+  - 觸發條件: push to `docs` branch 且變更落在會改變產物的路徑（`docs/**`、根目錄的 `BECOME_ANONI*.md`、`tools/cf_purge.py` 與其測試、workflow 自己），或手動觸發
+  - 只動 `tools/` 其他檔案或 CI 設定時推 `docs` 不會建置，那是刻意的，產物沒有變。真的需要重跑從 Actions 頁面用 `workflow_dispatch`
   - 建置所有語言版本（zh-TW, zh-CN, en）
   - 處理 Open Graph 圖片
   - 清理並上傳至 S3：clearnet 產物在 `docs/`，onion 產物在同一個 bucket 的 `docs-onion/`
@@ -265,6 +266,11 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
   - 內容：`test_sw_offline.mjs`（service worker 的離線行為）、`test_lang_preference.mjs`（語言偏好導向）、`test_offline_index.py`（離線內容索引的分組與排序）、`test_cf_purge.py`（快取清除映射）
   - 不需要建置產物，跑完不到十秒。`test_docs_style_lint.py` 不在這裡，由 `docs-style-lint.yml` 跑
   - `check_precache.mjs` 需要 `docs/output`，沒進 CI，改 `sw.js` 時手動跑一次
+
+- **check-ripe.yml** 與 **lookback-ooni.yml**: `asn_coverage/` 的資料抓取
+  - 觸發路徑：`asn_coverage/**` 與各自的 workflow。原本任何 main 的 push 都觸發，2026-08-19 一天被 docs 的 PR 觸發 18 次，每次四個 job（2 OS × 2 Python），把並行額度佔滿，連 BuildDocs 都排不進去
+  - `timeout-minutes: 30` 與 `concurrency` 的 `cancel-in-progress`。同一天有六個 run 卡在 `apt-get update`（runner 的 apt mirror 沒有回應），沒有 timeout 就會佔著 runner 到預設的六小時
+  - 憑證那一步改成 `continue-on-error`，runner image 本來就帶 ca-certificates，那一步失敗不該擋住整個 job
 
 - **games-checks.yml**: 「Tor 中繼地球儀」的互動與版面檢查（headless Chrome）
   - 觸發路徑：`docs/zh-TW/games/tor-network/**`、`tools/check_*.mjs`


### PR DESCRIPTION
今天 Actions 塞死的處置。

## 發生什麼

六個 run 卡在第 3 步 `sudo apt-get update`（runner 的 apt mirror 沒有回應），十八個 job 佔著並行額度，BuildDocs 排不進去，推出去的部署一直沒上線。

```
→ 3. Update libs        in_progress   ← 卡了 79 分鐘
  4. Install certificates  pending
  ...
```

三件事湊在一起：

1. **`check-ripe` 與 `lookback-ooni` 跑的是 `asn_coverage/` 的資料抓取，卻設成任何 main 的 push 都觸發**。今天光是 docs 的 PR 就觸發 18 次，每次四個 job（2 OS × 2 Python）
2. **沒有 `timeout-minutes`**，卡住的 job 會佔著 runner 到預設的六小時
3. **沒有 `concurrency`**，新的 push 不會取消還在跑的，只會疊上去

## 改動

| workflow | 改了什麼 |
|---|---|
| `check-ripe.yml`、`lookback-ooni.yml` | push 觸發限定 `asn_coverage/**` 與自己，每日 cron 照舊；加 `timeout-minutes: 30` 與 `concurrency` 的 `cancel-in-progress`；憑證那步改 `continue-on-error` |
| `build_docs.yml` | push 觸發限定會改變產物的路徑 |

憑證那一步值得說明：runner image 本來就帶 `ca-certificates`，那一步只是保險，失敗不該擋住整個 job — 而今天卡死的六個 run 全部停在那裡。

## build_docs 的 paths 要小心

除了 `docs/**`，還要列兩處 `docs/` 之外的相依：

- 根目錄的 `BECOME_ANONI*.md`，由 `pymdownx.snippets` 嵌進文件（`base_path` 含 `".."`）
- `tools/cf_purge.py` 與其測試，部署最後一步在跑的

漏列會變成推了 `docs` 分支卻沒有建置，站上維持舊內容而沒有任何錯誤訊息 — 正是 `CLAUDE.md` 特別提醒過的那個坑的新變體。workflow 裡留了註解提醒新增這類相依時要一併補，真的沒觸發時 `workflow_dispatch` 還在。

## 已經做的處置

卡住的六個 run 與兩個重複的 `tools-tests` 已經取消，佇列消化中，BuildDocs 已經開始跑。那兩個排程 workflow 的 cron 明天照常。

`CLAUDE.md` 的 CI/CD 段落跟著更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)