### PR TITLE
perf(pwa): 完整章節等讀者確定語言再下，首次造訪先給 0.5 MB 底線

### DIFF
--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -477,7 +477,21 @@
             // lang 屬性是 "zh" 這件事。
             navigator.serviceWorker.ready.then(function (ready) {
               if (ready.active) {
-                ready.active.postMessage({ type: "PRECACHE_LANG", url: location.href });
+                // 讀者選過閱讀語言了沒。service worker 讀不到 localStorage，這件事
+                // 只有這裡說得出來，而它決定了要現在下整個語系還是先等一等。key 跟
+                // 下面那段語言偏好的 PREF_KEY 是同一個，兩段是各自獨立的 IIFE，
+                // 改動時要一起改。
+                var settled = false;
+                try {
+                  settled = !!localStorage.getItem("anoni-docs-lang");
+                } catch (err) {
+                  // 隱私模式或擋掉 storage 的環境讀不到，當作還沒選
+                }
+                ready.active.postMessage({
+                  type: "PRECACHE_LANG",
+                  url: location.href,
+                  settled: settled,
+                });
               }
             });
 

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -349,11 +349,42 @@ function essentialUrlsFor(prefix) {
 // 後清空，下次重跑一輪也只是白查一次，不會抓重複的東西。
 const precachedPrefixes = new Set();
 
+// 讀者在某個語系底下導覽過幾次。存進 Cache Storage 的理由跟 AUTO_PRECACHE_URL 一樣：
+// SW 讀不到 localStorage，而這個數字要跨 SW 重啟與跨部署留著。
+const VISITS_URL = "/__anoni-settings/visits/";
+
+async function noteVisit(prefix) {
+  const cache = await caches.open(SETTINGS);
+  const url = VISITS_URL + (prefix || "root");
+  const hit = await cache.match(url);
+  const count = hit ? parseInt(await hit.text(), 10) || 0 : 0;
+  await cache.put(url, new Response(String(count + 1)));
+  return count + 1;
+}
+
+// 這台裝置上一版有沒有存過這個語系的完整章節。
+//
+// 換版時用得到：讀者按下更新，activate 會清掉舊的 PRECACHE，如果新的 install 只抓了
+// 底線那一批，讀者原本存著的四十幾頁會憑空消失一段時間。上一版有的，這一版照樣補齊。
+async function hadFullPrecache(prefix) {
+  const pages = CORE_PAGES_BY_PREFIX[prefix] || CORE_PAGES_ZH;
+  // 挑一個不在底線那批裡的頁面當探針，有它就代表上一版下的是完整章節
+  const probe = SCOPE_PATH + prefix + pages.find((page) => page !== "offline/");
+  for (const name of await caches.keys()) {
+    if (!name.startsWith("anoni-docs-precache-")) continue;
+    if (await (await caches.open(name)).match(probe)) return true;
+  }
+  return false;
+}
+
 // 補齊某個語系的預快取。已經在快取裡的跳過，所以換語系時只會抓新的那一份，作品
 // 本體與抓過的東西不重來。
-async function precacheFor(prefix) {
-  // 讀者關掉自動存或清空過內容時只補底線那一批，不抓完整章節
-  const full = await autoPrecacheEnabled();
+//
+// wantFull 由呼叫端決定要不要下完整章節，見 installPrecache 與 precacheOnNavigation。
+// 這裡只再 AND 上一個條件：讀者關掉自動存或清空過內容時，一律只補底線那一批。
+async function precacheFor(prefix, wantFull) {
+  if (precachedPrefixes.has(prefix + " full")) return;
+  const full = wantFull && (await autoPrecacheEnabled());
   const done = prefix + (full ? " full" : " essential");
   if (precachedPrefixes.has(done)) return;
   precachedPrefixes.add(done);
@@ -402,16 +433,40 @@ async function guessLangPrefix() {
   return null;
 }
 
+// install 階段要抓的那一批。抽成具名函式是為了能在 Node 裡驗，事件回呼裡的
+// 匿名 async 函式測不到，見 tools/test_sw_offline.mjs。
+//
+// 上一版已經有完整章節的裝置照樣補齊。那是換版，讀者按下更新之後 activate 會清掉
+// 舊的 PRECACHE，只抓底線那批的話他存著的四十幾頁會憑空少掉一段時間，斷網就什麼
+// 都沒有。沒有的就是首次安裝，先抓底線，等讀者確定要讀哪個語言再下整份。
+async function installPrecache() {
+  const prefix = await guessLangPrefix();
+  if (prefix === null) return null;
+  await precacheFor(prefix, await hadFullPrecache(prefix));
+  return prefix;
+}
+
+// 一次導覽觸發的預快取。
+//
+// 完整那一批要等讀者確定了要讀哪個語言才下。首次造訪時 install 幾乎是立刻開跑，
+// 而底部那張語言卡片要等 DOM 與 script 跑完才浮出來，讀者按下「English」的那幾秒，
+// 網站已經在下 zh-TW 的四十幾頁了，接著又下一份 en，兩份並存到下次部署才清掉。
+// 從搜尋引擎落在內頁的讀者更是從頭到尾沒被問過，十 MB 就這樣進了他的行動網路帳單。
+//
+// 兩個條件任一成立就算讀者確定了：client 說他選過閱讀語言，或者他在同一個語系底下
+// 翻到了第二頁。看一頁就走的人只會用掉底線那 0.5 MB。
+//
+// 計數刻意不放在 precacheFor 裡。install 也會呼叫那一支，算進去的話首次造訪光是
+// install 加上第一次導覽就湊滿兩次，門檻等於不存在。
+async function precacheOnNavigation(prefix, settled) {
+  await precacheFor(prefix, settled || (await noteVisit(prefix)) >= 2);
+}
+
 self.addEventListener("install", (event) => {
-  event.waitUntil(
-    (async () => {
-      const prefix = await guessLangPrefix();
-      if (prefix !== null) await precacheFor(prefix);
-      // 這裡刻意不呼叫 skipWaiting。原本一裝好就搶著接管，讀者正在讀的分頁會在毫無
-      // 徵兆的情況下換掉腳下的 SW，而 activate 又會清掉不在保留名單裡的快取。改成
-      // 停在 waiting，等讀者在換版提示上按下更新，收到 SKIP_WAITING 才接管。
-    })()
-  );
+  // 這裡刻意不呼叫 skipWaiting。原本一裝好就搶著接管，讀者正在讀的分頁會在毫無
+  // 徵兆的情況下換掉腳下的 SW，而 activate 又會清掉不在保留名單裡的快取。改成
+  // 停在 waiting，等讀者在換版提示上按下更新，收到 SKIP_WAITING 才接管。
+  event.waitUntil(installPrecache());
 });
 
 // === 離線內容管理 ===
@@ -592,7 +647,10 @@ self.addEventListener("message", (event) => {
   if (data.type === "PRECACHE_LANG" && typeof data.url === "string") {
     const prefix = langPrefixOf(new URL(data.url));
     if (prefix !== null) {
-      event.waitUntil(precacheFor(prefix));
+      // 已經下過整份就什麼都不用做，也不用再為了數次數寫一次 Cache Storage
+      if (!precachedPrefixes.has(prefix + " full")) {
+        event.waitUntil(precacheOnNavigation(prefix, data.settled === true));
+      }
     }
     return;
   }

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -110,9 +110,14 @@ const harness = `
   ${grab(/^function precacheUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function essentialUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const precachedPrefixes = .*$/m)}
-  ${grab(/^async function precacheFor\(prefix\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^const VISITS_URL = .*$/m)}
+  ${grab(/^async function noteVisit\(prefix\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function hadFullPrecache\(prefix\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function precacheFor\(prefix, wantFull\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function precacheOnNavigation\(prefix, settled\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function langPrefixOf\(url\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function guessLangPrefix\(\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function installPrecache\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const LIBRARY = .*$/m)}
   ${grab(/^const SETTINGS = .*$/m)}
   ${grab(/^const AUTO_PRECACHE_URL = .*$/m)}
@@ -140,6 +145,7 @@ const harness = `
     RUNTIME_PAGES, RUNTIME_ASSETS, PAGES_MAX_ENTRIES, PRECACHE, LIBRARY, SETTINGS,
     cacheKeyCandidates, matchCachedPage, offlinePathFor, migrateLegacyRuntime,
     langPrefixOf, precacheUrlsFor, essentialUrlsFor, precacheFor, guessLangPrefix,
+    noteVisit, hadFullPrecache, installPrecache, precacheOnNavigation,
     autoPrecacheEnabled, setAutoPrecache, libraryEntries, precachedEntries,
     messagePrefix, addToLibrary, removeFromLibrary, clearAllOffline,
     handleLibraryMessage, networkFirst,
@@ -323,9 +329,80 @@ test('預快取清單只含指定語系，作品本體三語共用', (load) => {
   assert.ok(en.includes('/docs/games/tor-network/play/index.html'));
 });
 
+test('首次造訪只抓底線那批，不在讀者選語言之前下整個語系', async (load) => {
+  // install 幾乎是註冊完就開跑，而底部那張語言卡片要等 DOM 與 script 跑完才浮出來。
+  // 讀者按下「English」的那幾秒，網站已經在下 zh-TW 的四十幾頁了，接著又下一份 en。
+  const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.installPrecache();
+  await sw.precacheOnNavigation('', false);
+
+  assert.deepEqual(fetched.slice().sort(), sw.essentialUrlsFor('').slice().sort());
+  assert.ok(!fetched.includes('/docs/tools/what-is-tor/'));
+  assert.ok(fetched.length < sw.precacheUrlsFor('').length);
+});
+
+test('同一個語系導覽到第二頁才下整份', async (load) => {
+  const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.installPrecache();
+  await sw.precacheOnNavigation('', false);
+  fetched.length = 0;
+
+  // 讀者點進第二頁，client 又送一次 PRECACHE_LANG
+  await sw.precacheOnNavigation('', false);
+  assert.ok(fetched.includes('/docs/tools/what-is-tor/'));
+});
+
+test('install 自己不算一次造訪，否則門檻等於不存在', async (load) => {
+  // 首次造訪是 install 加上第一次導覽兩次呼叫。計數放在 precacheFor 裡的話，
+  // 讀者還沒翻第二頁就湊滿了。
+  const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.installPrecache();
+  await sw.precacheOnNavigation('', false);
+  assert.ok(!fetched.includes('/docs/tools/what-is-tor/'));
+});
+
+test('讀者選過閱讀語言就不用再等第二頁', async (load) => {
+  const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.installPrecache();
+  await sw.precacheOnNavigation('', true);
+  assert.ok(fetched.includes('/docs/tools/what-is-tor/'));
+});
+
+test('造訪次數分語系算，換一個語系要重新累積', async (load) => {
+  const { sw } = load();
+  assert.equal(await sw.noteVisit(''), 1);
+  assert.equal(await sw.noteVisit('en/'), 1);
+  assert.equal(await sw.noteVisit(''), 2);
+});
+
+test('install 在新裝置上只補底線，在換版的裝置上照舊補完整', async (load) => {
+  // 讀者按下更新之後 activate 會清掉舊的 PRECACHE。換版也只抓底線的話，他原本
+  // 存著的四十幾頁要等再導覽兩次才回得來，中間斷網就什麼都沒有。
+  const here = ['https://anoni.net/docs/guides/'];
+
+  const fresh = load({ clients: here });
+  assert.equal(await fresh.sw.installPrecache(), '');
+  assert.ok(!fresh.fetched.includes('/docs/tools/what-is-tor/'));
+  assert.deepEqual(fresh.fetched.slice().sort(), fresh.sw.essentialUrlsFor('').slice().sort());
+
+  const upgrade = load({ clients: here });
+  await (await upgrade.caches.open('anoni-docs-precache-202601010000')).put('/docs/', 'HOME');
+  assert.equal(await upgrade.sw.hadFullPrecache(''), true);
+  assert.equal(await upgrade.sw.installPrecache(), '');
+  assert.ok(upgrade.fetched.includes('/docs/tools/what-is-tor/'));
+});
+
+test('只存過底線那批的裝置不算有完整章節', async (load) => {
+  const { sw, caches } = load();
+  const previous = await caches.open('anoni-docs-precache-202601010000');
+  for (const url of sw.essentialUrlsFor('')) await previous.put(url, 'X');
+
+  assert.equal(await sw.hadFullPrecache(''), false);
+});
+
 test('一次只抓一個語系的量', async (load) => {
   const { sw, fetched } = load();
-  await sw.precacheFor('en/');
+  await sw.precacheFor('en/', true);
   assert.equal(fetched.length, sw.precacheUrlsFor('en/').length);
   assert.ok(
     fetched.every((url) => url.startsWith('/docs/en/') || url.startsWith('/docs/games/'))
@@ -334,11 +411,11 @@ test('一次只抓一個語系的量', async (load) => {
 
 test('換語系時不重抓已經有的東西', async (load) => {
   const { sw, fetched } = load();
-  await sw.precacheFor('');
+  await sw.precacheFor('', true);
   const firstRound = fetched.length;
   fetched.length = 0;
 
-  await sw.precacheFor('en/');
+  await sw.precacheFor('en/', true);
   // 作品本體第一輪就抓過了，第二輪只補 en 自己那一份
   assert.ok(fetched.every((url) => url.startsWith('/docs/en/')));
   assert.ok(fetched.length < firstRound);
@@ -362,21 +439,21 @@ test('install 從開著的分頁推語系', async (load) => {
 
 test('同一個語系不會在每次導覽都重跑一輪', async (load) => {
   const { sw, fetched } = load();
-  await sw.precacheFor('en/');
+  await sw.precacheFor('en/', true);
   const first = fetched.length;
   assert.ok(first > 0);
 
   // client 每次頁面載入都會送 PRECACHE_LANG，這裡模擬連續幾次
   fetched.length = 0;
-  await sw.precacheFor('en/');
-  await sw.precacheFor('en/');
+  await sw.precacheFor('en/', true);
+  await sw.precacheFor('en/', true);
   assert.equal(fetched.length, 0);
 });
 
 test('個別頁面 404 不會讓整批預快取失敗', async (load) => {
   const missing = '/docs/zh-cn/tools/what-is-cryptpad/';
   const { sw, caches } = load({ notFound: [missing] });
-  await sw.precacheFor('zh-cn/');
+  await sw.precacheFor('zh-cn/', true);
   const cache = await caches.open(sw.PRECACHE);
   assert.equal(await cache.match(missing), undefined);
   // 同一批的其他頁面照樣進快取
@@ -497,7 +574,7 @@ test('網站自動存的回實際在裝置上的，不是那份硬編清單', as
   assert.ok(!essential.includes('tools/what-is-tor/'));
 
   await sw.setAutoPrecache(true);
-  await sw.precacheFor('');
+  await sw.precacheFor('', true);
   assert.ok((await sw.precachedEntries('')).includes('tools/what-is-tor/'));
 });
 
@@ -513,7 +590,7 @@ test('舊版管理頁不帶網址時退回根路徑，zh-TW 讀者不受影響',
 
 test('清除會清光所有快取，並把自動預快取關掉', async (load) => {
   const { sw, caches } = load();
-  await sw.precacheFor('');
+  await sw.precacheFor('', true);
   await sw.addToLibrary('', ['scenarios/journalist/'], false, () => {});
   const pages = await caches.open(sw.RUNTIME_PAGES);
   await pages.put('/docs/basics/metadata/', 'VISITED');
@@ -541,7 +618,7 @@ test('清除之後只補離線提示頁那一批，章節不會整包抓回來',
   // 讀者自己在管理頁把開關打開才恢復完整
   await sw.setAutoPrecache(true);
   fetched.length = 0;
-  await sw.precacheFor('');
+  await sw.precacheFor('', true);
   assert.ok(fetched.includes('/docs/tools/what-is-tor/'));
 });
 
@@ -569,7 +646,7 @@ test('關掉自動存之後，離線提示頁照樣留著', async (load) => {
 
 test('狀態查詢回得出已存的、網站存的與空間用量', async (load) => {
   const { sw } = load();
-  await sw.precacheFor('');
+  await sw.precacheFor('', true);
   await sw.addToLibrary('', ['scenarios/journalist/'], false, () => {});
 
   const replies = [];
@@ -592,7 +669,7 @@ test('狀態查詢回得出已存的、網站存的與空間用量', async (load
 
 test('狀態查詢依網址挑對語系的預設清單', async (load) => {
   const { sw } = load();
-  await sw.precacheFor('en/');
+  await sw.precacheFor('en/', true);
   const replies = [];
   await sw.handleLibraryMessage(
     { type: 'OFFLINE_STATUS', url: 'https://anoni.net/docs/en/offline/' },


### PR DESCRIPTION
> 疊在 #280 上面，base 指向 `fix/offline-links`。#280 合併之後這個 PR 的 diff 會自動收斂成只剩自己那一個 commit。

## 為什麼

首次造訪時 service worker 的 `install` 幾乎是註冊完就開跑，而底部那張語言卡片要等 DOM 與 script 跑完才浮出來。讀者按下「English」的那幾秒，網站已經在下 zh-TW 的四十幾頁，接著又下一份 en，兩份並存到下次部署 `activate` 才清掉。

從搜尋引擎落在內頁的讀者更是從頭到尾沒被問過語言（語言卡片只在首頁出現），十 MB 就這樣進了他的行動網路帳單。對一個讀者可能正處在受限網路下的網站，這個預設不太對。

## 改了什麼

完整章節等讀者確定要讀哪個語言才下。兩個條件任一成立就算確定：

- client 說他選過閱讀語言（`localStorage` 的 `anoni-docs-lang`。service worker 讀不到 localStorage，由 `base.html` 在 `PRECACHE_LANG` 裡帶過來）
- 他在同一個語系底下翻到了第二頁

在那之前只下 `essentialUrlsFor()` 那 0.5 MB，離線閱讀頁與撐得起它的 app shell 都在裡面。看一頁就走的人不會替一整個語系付流量。

**換版不受影響。** `install` 先看這台裝置上一版有沒有存過完整章節（`hadFullPrecache`），有就照舊補齊。少了這一步，讀者按下更新之後 `activate` 清掉舊的 `PRECACHE`，他存著的四十幾頁要等再導覽兩次才回得來，中間斷網就什麼都沒有。

造訪次數存在 Cache Storage，理由跟 `AUTO_PRECACHE_URL` 一樣：SW 讀不到 localStorage，而這個數字要跨 SW 重啟與跨部署留著。

## 一個實機才抓得到的坑

第一版把計數寫在 `precacheFor` 裡，單元測試全綠，瀏覽器上第一頁卻還是下了 79 項。`install` 也會呼叫那一支，所以首次造訪光是 install 加第一次導覽就湊滿兩次，門檻等於不存在。計數移到 `precacheOnNavigation`，並補一項測試守著這件事。

`install` 的決策也抽成 `installPrecache()`。事件回呼裡的匿名 async 函式測不到，反向驗證時改壞了它測試還是全綠。

## 驗證

`tools/test_sw_offline.mjs` 37 → 44。反向驗證：

| 故意改壞 | 結果 |
|---|---|
| 拿掉門檻，一律整份下 | 3 項紅 |
| `install` 不再認舊快取 | 1 項紅 |
| `hadFullPrecache` 一律說有 | 2 項紅 |

三語系建置零警告，`check_precache.mjs` 全綠。

實機（本機建置 + headless Chrome，每輪全新 profile）：

| 情境 | 第一頁 | 第二頁 |
|---|---|---|
| 沒選過語言 | 10 項 | 79 項 |
| 選過 zh-TW | 79 項 | 79 項 |
| 從內頁進來 | 10 項 | 79 項 |

開首頁等兩秒再按底部卡片的 English，按下之前 zh-TW 只有 10 項。

換版那條也跑過：存滿 79 項的裝置遇到新版本 → `install` 直接補到 79、舊的還在、新的停在 waiting → 按下更新 → 舊的被清掉、`what-is-tor` 仍讀得到。沒有空窗。

## 要你確認的取捨

只造訪一頁就關掉、之後才斷網的讀者，現在手上只有 0.5 MB 的離線閱讀頁，改動前他會有四十幾頁。我認為值得，那十 MB 本來就是在他沒同意的情況下下載的，而多數人在第一次造訪就會看第二頁。門檻定在「第二頁」而不是更高，也是為了讓這個代價盡量小。

如果你覺得對這個網站的讀者情境來說太冒險，門檻可以改成「install 就下，但先只下該語系首頁加幾個入口頁」，或是乾脆退回原本的行為。跟我說。

🤖 Generated with [Claude Code](https://claude.com/claude-code)