### PR TITLE
perf(pwa): 導覽等網路超過三秒就先給裝置上那一份

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -755,9 +755,16 @@ async function trimCache(cacheName, maxEntries) {
   }
 }
 
+// 導覽請求等網路多久，超過就先給裝置上那一份。
+//
+// 完全斷線時 fetch 立刻就失敗，這個值用不到。它是為了「連得上但很慢」與「連線被
+// 干擾」那種狀態：讀者手上明明有離線副本，卻要陪著瀏覽器一路等到它自己放棄，
+// 而那種網路正是這個網站的讀者比別人更常遇到的。
+const NAVIGATE_TIMEOUT_MS = 3000;
+
 async function networkFirst(request, event) {
-  try {
-    const response = await fetch(request);
+  // 先把網路那條發出去，不管後面走哪一條，它拿到的東西都要寫進快取
+  const network = fetch(request).then(async (response) => {
     if (response.ok) {
       const cache = await caches.open(RUNTIME_PAGES);
       await cache.put(request, response.clone());
@@ -767,13 +774,31 @@ async function networkFirst(request, event) {
       keepAlive(event, trimCache(RUNTIME_PAGES, PAGES_MAX_ENTRIES));
     }
     return response;
-  } catch (err) {
-    const cached = await matchCachedPage(request);
-    if (cached) return cached;
-    const offline = await caches.match(offlinePathFor(new URL(request.url)));
-    if (offline) return offline;
-    throw err;
+  });
+
+  const cached = await matchCachedPage(request);
+  if (!cached) {
+    // 裝置上沒有這一頁，等網路是唯一的選擇，慢也要等
+    try {
+      return await network;
+    } catch (err) {
+      const offline = await caches.match(offlinePathFor(new URL(request.url)));
+      if (offline) return offline;
+      throw err;
+    }
   }
+
+  // 有副本就跟網路賽跑。網路先到就用網路的，讀者拿到的是最新內容。
+  const raced = await Promise.race([
+    network.catch(() => null),
+    new Promise((resolve) => setTimeout(() => resolve(null), NAVIGATE_TIMEOUT_MS)),
+  ]);
+  if (raced) return raced;
+
+  // 網路太慢或失敗，先給讀者看得到的那一份。網路那邊還在跑，回來時照樣寫進快取，
+  // 下一次導覽拿到的就是新的。SW 要活到那時候，所以掛在 waitUntil 上。
+  keepAlive(event, network.catch(() => {}));
+  return cached;
 }
 
 async function staleWhileRevalidate(request, event) {

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -140,6 +140,7 @@ const harness = `
   ${grab(/^async function trimCache\(cacheName, maxEntries\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function migrateLegacyRuntime\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function keepAlive\(event, promise\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^const NAVIGATE_TIMEOUT_MS = .*$/m)}
   ${grab(/^async function networkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
   return {
     RUNTIME_PAGES, RUNTIME_ASSETS, PAGES_MAX_ENTRIES, PRECACHE, LIBRARY, SETTINGS,
@@ -148,7 +149,7 @@ const harness = `
     noteVisit, hadFullPrecache, installPrecache, precacheOnNavigation,
     autoPrecacheEnabled, setAutoPrecache, libraryEntries, precachedEntries,
     messagePrefix, addToLibrary, removeFromLibrary, clearAllOffline,
-    handleLibraryMessage, networkFirst,
+    handleLibraryMessage, networkFirst, NAVIGATE_TIMEOUT_MS,
   };
 `;
 
@@ -162,10 +163,15 @@ const load = (opts = {}) => {
   const caches = new FakeCacheStorage();
   const fetched = [];
   const net = { offline: !!opts.offline };
-  const fetchStub = async (url) => {
+  // 真的 Response 有 clone()，networkFirst 存快取時會用到
+  const makeResponse = (url, ok) => ({ ok, url, clone: () => makeResponse(url, ok) });
+  const fetchStub = async (input) => {
+    const url = typeof input === 'string' ? input : input.url;
     fetched.push(url);
     if (net.offline) throw new TypeError("Failed to fetch");
-    return { ok: !(opts.notFound || []).includes(url), url };
+    // 「連得上但很慢」。networkFirst 的逾時要比這個短才有得比。
+    if (opts.networkDelay) await new Promise((r) => setTimeout(r, opts.networkDelay));
+    return makeResponse(url, !(opts.notFound || []).includes(url));
   };
   const selfStub = {
     clients: {
@@ -173,9 +179,12 @@ const load = (opts = {}) => {
     },
   };
   const navigatorStub = { storage: { estimate: async () => ({ usage: 1024, quota: 4096 }) } };
-  const sw = new Function('caches', 'SCOPE_PATH', 'fetch', 'self', 'navigator', harness)(
-    caches, SCOPE_PATH, fetchStub, selfStub, navigatorStub
-  );
+  // NAVIGATE_TIMEOUT_MS 那個 setTimeout 由外面給。fastTimeout 讓它立刻觸發，
+  // 配上 networkDelay 就能在幾十毫秒內驗完「網路太慢」那條路。
+  const setTimeoutStub = opts.fastTimeout ? (fn) => setTimeout(fn, 0) : setTimeout;
+  const sw = new Function(
+    'caches', 'SCOPE_PATH', 'fetch', 'self', 'navigator', 'setTimeout', harness
+  )(caches, SCOPE_PATH, fetchStub, selfStub, navigatorStub, setTimeoutStub);
   return { sw, caches, fetched, net };
 };
 
@@ -685,6 +694,58 @@ test('認不得的指令會回錯誤，不會靜靜沒反應', async (load) => {
   const replies = [];
   await sw.handleLibraryMessage({ type: 'NOPE' }, { postMessage: (d) => replies.push(d) });
   assert.equal(replies[0].type, 'error');
+});
+
+test('網路太慢時先給裝置上那一份，不陪著等到瀏覽器放棄', async (load) => {
+  // 完全斷線時 fetch 立刻失敗，逾時用不到。這條是為了「連得上但很慢」與「連線被
+  // 干擾」那種狀態，而那正是這個網站的讀者比別人更常遇到的網路。
+  const { sw, caches } = load({ networkDelay: 40, fastTimeout: true });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  assert.equal(await sw.networkFirst(req('/docs/tools/what-is-tor/'), null), 'CACHED');
+});
+
+test('網路來得及就用網路那份，不會拿舊的給讀者', async (load) => {
+  const { sw, caches } = load();
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'STALE');
+
+  const response = await sw.networkFirst(req('/docs/tools/what-is-tor/'), null);
+  assert.notEqual(response, 'STALE');
+  assert.equal(response.url, ORIGIN + '/docs/tools/what-is-tor/');
+});
+
+test('先給舊的之後，網路那份回來照樣寫進快取', async (load) => {
+  // 逾時只是不讓讀者等，不是放棄這次更新。下一次導覽要拿到新的。
+  const { sw, caches } = load({ networkDelay: 40, fastTimeout: true });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  assert.equal(await sw.networkFirst(req('/docs/tools/what-is-tor/'), null), 'CACHED');
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  assert.notEqual(await pages.match('/docs/tools/what-is-tor/'), 'CACHED');
+});
+
+test('逾時之後把網路那條掛在 waitUntil 上，SW 才活得到它回來', async (load) => {
+  // 少了這一步，SW 有機會在網路那份回來之前就被瀏覽器終止，快取永遠停在舊的。
+  const { sw, caches } = load({ networkDelay: 40, fastTimeout: true });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  const kept = [];
+  const event = { waitUntil: (promise) => kept.push(promise) };
+  assert.equal(await sw.networkFirst(req('/docs/tools/what-is-tor/'), event), 'CACHED');
+  assert.equal(kept.length, 1);
+  await Promise.all(kept);
+});
+
+test('裝置上沒有的頁面照樣等網路，慢也要等', async (load) => {
+  // 快取裡什麼都沒有時逾時沒有意義，早早放棄只會把讀者丟到離線頁，
+  // 而網路其實只是慢，再等一下就回來了。
+  const { sw } = load({ networkDelay: 40, fastTimeout: true });
+  const response = await sw.networkFirst(req('/docs/tools/what-is-tor/'), null);
+  assert.equal(response.url, ORIGIN + '/docs/tools/what-is-tor/');
 });
 
 test('離線時沒快取過的頁面會落到離線頁', async (load) => {


### PR DESCRIPTION
> 疊在 #281 上面，base 指向 `fix/precache-timing`。前面兩個合併之後 diff 會收斂成只剩自己那一個 commit。

## 為什麼

`networkFirst` 原本沒有逾時，要 `fetch` 真的失敗才回快取。完全斷線時瀏覽器立刻就失敗，那條沒問題。

這個網站的讀者更常遇到的是「連得上但很慢」與「連線被干擾」。那時每一頁都在等網路自己放棄（Chrome 可以等到三十秒以上），而裝置上明明有副本。離線閱讀存了四十幾頁，在最需要它的網路狀況下卻用不到。

## 改了什麼

改成賽跑。網路那條照樣先發出去，同時查裝置上有沒有這一頁：

- 有副本才計時。三秒內網路回來就用網路的，超過就先給讀者看得到的那一份
- 網路那邊繼續跑，回來時照樣寫進快取，下一次導覽拿到的就是新的
- 那條 promise 掛在 `event.waitUntil` 上，SW 才活得到它回來
- 裝置上沒有這一頁時不計時，早早放棄只會把讀者丟到離線閱讀頁，而網路其實只是慢

逾時只是不讓讀者等，不是放棄這次更新。

## 驗證

`tools/test_sw_offline.mjs` 44 → 49。反向驗證：

| 故意改壞 | 結果 |
|---|---|
| 拿掉逾時，一律等網路 | 2 項紅 |
| 沒快取時也套逾時 | 6 項紅 |
| 拿掉 `waitUntil` | 1 項紅 |

測試替身補上 `clone()` 與可注入的 `setTimeout`，逾時那幾條在幾十毫秒內跑完，不用真的等三秒。

實機量測（本機建置 + 一支把目錄式網址延遲八秒的 server）：

| | 這個 PR | 改動前 |
|---|---|---|
| 已快取的 `what-is-tor` | 3.2s | 8.2s |
| 沒快取的 `ai-privacy` | 8.2s | 8.2s |
| 已快取的 `metadata` | 3.2s | 8.2s |

量測時 server 回應帶 `no-store`。第一次量的時候沒加，三個都是零點幾秒，那是 Chrome 自己的 HTTP cache 命中，跟 service worker 無關。

## 一個副作用

正常網路下如果某次請求剛好超過三秒，讀者會拿到裝置上那一份，可能不是最新的。下一次導覽就會是新的（網路那份在背景寫回快取了）。三秒在一般連線上很少超過，我認為這個代價可以接受，但如果你覺得剛發新文章時看到舊版本不行，這個值可以調高，或者只在 `navigator.onLine === false` 以外的情況放寬。

🤖 Generated with [Claude Code](https://claude.com/claude-code)