### PR TITLE
fix(utils): 選中的按鈕 hover 時文字看不見，輸入框在 iOS 會把整頁放大

### DIFF
--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -30,8 +30,12 @@
       border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; padding: .3rem .7rem;
     }
-    #offline-library button:hover:not(:disabled) {
+    /* 填了底色的「套用變更」不套這條，不然滑鼠放上去文字就看不見了 */
+    #offline-library button:hover:not(:disabled):not(.ol-primary) {
       border-color: var(--md-accent-fg-color); color: var(--md-accent-fg-color);
+    }
+    #offline-library .ol-primary:hover:not(:disabled) {
+      filter: brightness(1.1);
     }
     #offline-library button:disabled { opacity: .5; cursor: default; }
     #offline-library .ol-status { line-height: 1.8; margin: .4rem 0; }

--- a/docs/zh-TW/js/passphrase.js
+++ b/docs/zh-TW/js/passphrase.js
@@ -96,8 +96,15 @@
       border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; padding: .35rem .8rem;
     }
-    #passphrase-tool button:hover:not(:disabled) {
+    /* 填了底色的按鈕不套這條。accent 色的字在 primary 底上對比不夠，讀者看到的
+       是「選中之後把滑鼠放上去，字就不見了」。觸控裝置點完會停在 hover 狀態，
+       所以手機上是按一下就消失。 */
+    #passphrase-tool button:hover:not(:disabled):not([aria-pressed="true"]) {
       border-color: var(--md-accent-fg-color); color: var(--md-accent-fg-color);
+    }
+    /* 選中的按鈕改用亮度變化當回饋，文字色不動 */
+    #passphrase-tool button[aria-pressed="true"]:hover:not(:disabled) {
+      filter: brightness(1.1);
     }
     #passphrase-tool button:disabled { opacity: .5; cursor: default; }
     #passphrase-tool button[aria-pressed="true"] {

--- a/docs/zh-TW/js/qrcode.js
+++ b/docs/zh-TW/js/qrcode.js
@@ -81,7 +81,12 @@
     #qrcode-tool { margin: 1em 0; }
     #qrcode-tool textarea {
       width: 100%; box-sizing: border-box; font: inherit;
-      font-family: var(--md-code-font-family, monospace); font-size: .78rem;
+      font-family: var(--md-code-font-family, monospace);
+      /* iOS Safari 在輸入框字級小於 16px 時，一聚焦就把整頁放大，而且不會縮回去。
+         material 的 rem 基準是 20px，.78rem 只有 15.6px 剛好踩到。用 max 撐到 16px，
+         桌機上的差別看不出來。不改 viewport 的 user-scalable，那會讓需要放大的人
+         沒辦法放大。 */
+      font-size: max(16px, .78rem);
       border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; padding: .6rem; min-height: 5rem; resize: vertical;
       background: var(--md-default-bg-color); color: var(--md-default-fg-color);
@@ -94,8 +99,12 @@
       border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; padding: .35rem .8rem;
     }
-    #qrcode-tool button:hover:not(:disabled) {
+    /* 同 passphrase.js：填了底色的按鈕不套這條，不然選中之後文字會看不見 */
+    #qrcode-tool button:hover:not(:disabled):not([aria-pressed="true"]) {
       border-color: var(--md-accent-fg-color); color: var(--md-accent-fg-color);
+    }
+    #qrcode-tool button[aria-pressed="true"]:hover:not(:disabled) {
+      filter: brightness(1.1);
     }
     #qrcode-tool button:disabled { opacity: .5; cursor: default; }
     #qrcode-tool button[aria-pressed="true"] {

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -537,6 +537,17 @@ test('大小含資產，章節的部分去重', async () => {
   assert.deepEqual(sizes, ['200 KB', '150 KB']);
 });
 
+test('填了底色的按鈕不會被 hover 規則蓋掉文字色', () => {
+  // 通用 hover 把文字色換成 accent，而它的特異性比 .ol-primary 高。實際效果是
+  // 「套用變更」按下去之後滑鼠停在上面，字就跟藍底融在一起看不見了。
+  // 觸控裝置點完會停在 hover 狀態，所以手機上是按一下就消失。
+  assert.ok(
+    src.includes('button:hover:not(:disabled):not(.ol-primary)'),
+    'hover 規則要排除填了底色的按鈕'
+  );
+  assert.ok(src.includes('.ol-primary:hover'), '填色按鈕要有自己的 hover 回饋');
+});
+
 test('進度與完成訊息都在底部那條裡，不是散在頁面頂端', async () => {
   // 那條 sticky 在畫面下緣，而套用按鈕就在上面。進度畫在頁面頂端的話，讀者按完
   // 什麼都看不到。位置本身要靠實機截圖，這裡守的是「它是那條的子節點」。

--- a/tools/test_passphrase.mjs
+++ b/tools/test_passphrase.mjs
@@ -193,6 +193,16 @@ test('接的是真的亂數源，而且分布沒有明顯偏斜', () => {
   }
 });
 
+test('選中的模式按鈕不會被 hover 規則蓋掉文字色', () => {
+  // 通用 hover 把文字色換成 accent，特異性又比填色那條高。選中之後滑鼠停在上面，
+  // 字就跟藍底融在一起。觸控裝置點完會停在 hover 狀態，所以手機上是按一下就消失。
+  assert.ok(
+    src.includes('button:hover:not(:disabled):not([aria-pressed="true"])'),
+    'hover 規則要排除選中的按鈕'
+  );
+  assert.ok(src.includes('button[aria-pressed="true"]:hover'), '選中的按鈕要有自己的 hover 回饋');
+});
+
 for (const [name, fn] of tests) {
   try {
     fn();

--- a/tools/test_qrcode.mjs
+++ b/tools/test_qrcode.mjs
@@ -37,6 +37,10 @@ const VENDOR = path.join(HERE, '..', 'docs', 'zh-TW', 'utils', 'vendor', 'qrcode
 const src = fs.readFileSync(SRC, 'utf8');
 const qrcode = createRequire(import.meta.url)(VENDOR);
 
+// 掃描用的版本：剝掉註解。註解本來就在說明「不會出現哪些東西」，寫出那些名字才
+// 講得清楚，而註解裡的字不該讓自我檢查失效。跟 test_leaks.mjs 同一個做法。
+const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
 const grab = (re) => {
   const m = src.match(re);
   if (!m) throw new Error(`qrcode.js 裡找不到 ${re}`);
@@ -361,6 +365,22 @@ test('同一列連續的黑格併成一個 rect', () => {
 
 test('糾錯等級的說明數字沒有寫反', () => {
   assert.deepEqual(tool.ERROR_LEVELS, { L: 7, M: 15, Q: 25, H: 30 });
+});
+
+test('選中的等級按鈕不會被 hover 規則蓋掉文字色', () => {
+  assert.ok(
+    src.includes('button:hover:not(:disabled):not([aria-pressed="true"])'),
+    'hover 規則要排除選中的按鈕'
+  );
+  assert.ok(src.includes('button[aria-pressed="true"]:hover'));
+});
+
+test('輸入框的字級撐到 16px，iOS 才不會一聚焦就放大整頁', () => {
+  // iOS Safari 在輸入框字級小於 16px 時聚焦會自動放大，而且不會縮回去。
+  // material 的 rem 基準是 20px，.78rem 只有 15.6px 剛好踩到。
+  assert.ok(src.includes('font-size: max(16px'), '輸入框字級要用 max 撐到 16px');
+  // 不要改 viewport 的 user-scalable，那會讓需要放大的人沒辦法放大
+  assert.ok(!code.includes('user-scalable'));
 });
 
 test('留白留了規範要求的四格', () => {


### PR DESCRIPTION
兩個回報來的問題。

## 按鈕的文字不是消失，是對比掉到看不見

通用的 hover 規則把文字色換成 accent：

```css
#passphrase-tool button:hover:not(:disabled) {
  color: var(--md-accent-fg-color);
}
```

它的特異性 `(1,2,1)` 比填底色那條 `(1,1,0)` 高，所以選中的按鈕變成 **accent 藍紫的字配 primary 藍的底**。量出來 **1.4:1**，WCAG AA 要求 4.5:1。

觸控裝置點完會停在 hover 狀態，所以手機上是按一下就消失，不用滑鼠也會遇到。

**同一個 bug 在三個地方**：`passphrase` 的模式按鈕、`qrcode` 的糾錯等級按鈕，還有離線閱讀頁那顆「套用變更」。hover 規則改成排除填了底色的按鈕，那些改用 `filter: brightness(1.1)` 當回饋，文字色不動。

| | 文字 | 底色 | 對比 |
|---|---|---|---|
| 改動前 | `rgb(82, 108, 254)` | `rgb(0, 109, 153)` | 1.4 |
| 改動後 | `rgb(255, 255, 255)` | `rgb(0, 109, 153)` | 5.8 |

## iOS 的放大是字級踩到門檻

Safari 在輸入框字級**小於 16px** 時聚焦會自動放大整頁，而且不會縮回去。material 的 rem 基準是 20px，`qrcode` 那個 textarea 寫 `.78rem` 只有 15.6px，剛好踩到。

改成 `font-size: max(16px, .78rem)`，桌機上的差別看不出來。

**沒有動 viewport 的 `user-scalable`。** 那個做法能擋掉放大，但同時讓真的需要放大的人也沒辦法放大，是無障礙的反模式。測試裡有一項檢查它沒有出現。

## 驗證

三支測試各加一項。反向驗證三項全紅：

| 故意改壞 | 結果 |
|---|---|
| `passphrase` 的 hover 不排除選中的按鈕 | 1 項紅 |
| `qrcode` 輸入框字級退回 `.78rem` | 1 項紅 |
| `offline-library` 的 hover 不排除 `.ol-primary` | 1 項紅 |

實機（本機建置 + headless Chrome，用 `CSS.forcePseudoState` 強制 hover 狀態再量 computed style）：上表那兩組數字就是量出來的，輸入框的 computed `font-size` 是 `16px`。

三語系建置零警告，七支測試全綠，`check_precache` 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)