### PR TITLE
小工具索引頁的卡片順序對齊 nav

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -102,6 +102,10 @@ jobs:
       - name: QR code 讀取器
         run: node tools/test_qrread.mjs
 
+      # 小工具索引頁的卡片順序：跟 nav 不一致時沒有任何錯誤訊息，只有讀者會覺得東西換位置
+      - name: 小工具索引順序
+        run: node tools/test_utils_index_order.mjs
+
       # 圖表函式庫按需載入：放回 extra_javascript 不會有錯誤訊息，只是全站變慢
       - name: 圖表函式庫按需載入
         run: node tools/test_chart_assets.mjs

--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -28,9 +28,9 @@ The articles on this site explain how to protect yourself. This section holds th
 
     Turn onion addresses, Tor bridges and other long, easily mistyped strings into a QR code the person in front of you can read with a camera, without anything passing through a server. Downloadable as SVG for printing.
 
--   :material-eye-outline: **[What your browser gives away](leaks.md)**
+-   :material-qrcode-scan: **[QR code reader](qr-read.md)**
 
-    Lists what any site can read without asking, annotated with how Tor Browser normalises each one. Open it in a second browser to see what those defences actually do.
+    Read what is inside a QR code image without the image leaving your device. URLs get their hostname shown separately, and there is no open button.
 
 -   :material-image-off-outline: **[Photo metadata remover](strip-metadata.md)**
 
@@ -44,9 +44,9 @@ The articles on this site explain how to protect yourself. This section holds th
 
     Find zero-width characters, bidirectional controls and homoglyphs hiding in text, with positions marked and each class explained. Both document leak tracking and phishing URLs rely on these.
 
--   :material-qrcode-scan: **[QR code reader](qr-read.md)**
+-   :material-eye-outline: **[What your browser gives away](leaks.md)**
 
-    Read what is inside a QR code image without the image leaving your device. URLs get their hostname shown separately, and there is no open button.
+    Lists what any site can read without asking, annotated with how Tor Browser normalises each one. Open it in a second browser to see what those defences actually do.
 
 </div>
 

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -28,9 +28,9 @@ icon: material/tools
 
     把 onion 网址、Tor bridge 这类很长又容易打错的字符串变成 QR code，让眼前的人用相机读走，中间不经过任何服务器。可以下载成 SVG 印出来。
 
--   :material-eye-outline: **[你的浏览器透露了什么](leaks.md)**
+-   :material-qrcode-scan: **[QR code 读取器](qr-read.md)**
 
-    列出任何网站不必问你就拿得到的信息，并标出 Tor Browser 会把哪些统一掉。换个浏览器再看一次，就知道那些防护实际上做了什么。
+    读出图片里 QR code 的内容，图片不离开设备。解出来是网址时把主机独立标出来，并且不提供打开按钮。
 
 -   :material-image-off-outline: **[照片 metadata 清除器](strip-metadata.md)**
 
@@ -44,9 +44,9 @@ icon: material/tools
 
     找出文字里看不见的零宽字符、方向控制与同形字，标出位置并说明每一类是什么。文件外流追踪与钓鱼网址都靠这些东西。
 
--   :material-qrcode-scan: **[QR code 读取器](qr-read.md)**
+-   :material-eye-outline: **[你的浏览器透露了什么](leaks.md)**
 
-    读出图片里 QR code 的内容，图片不离开设备。解出来是网址时把主机独立标出来，并且不提供打开按钮。
+    列出任何网站不必问你就拿得到的信息，并标出 Tor Browser 会把哪些统一掉。换个浏览器再看一次，就知道那些防护实际上做了什么。
 
 </div>
 

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -28,9 +28,9 @@ icon: material/tools
 
     把 onion 網址、Tor bridge 這類很長又容易打錯的字串變成 QR code，讓眼前的人用相機讀走，中間不經過任何伺服器。可以下載成 SVG 印出來。
 
--   :material-eye-outline: **[你的瀏覽器透露了什麼](leaks.md)**
+-   :material-qrcode-scan: **[QR code 讀取器](qr-read.md)**
 
-    列出任何網站不必問你就拿得到的資訊，並標出 Tor Browser 會把哪些統一掉。換個瀏覽器再看一次，就知道那些防護實際上做了什麼。
+    讀出圖片裡 QR code 的內容，圖片不離開裝置。解出來是網址時把主機獨立標出來，並且不提供開啟按鈕。
 
 -   :material-image-off-outline: **[照片 metadata 清除器](strip-metadata.md)**
 
@@ -44,9 +44,9 @@ icon: material/tools
 
     找出文字裡看不見的零寬字元、方向控制與同形字，標出位置並說明每一類是什麼。文件外流追蹤與釣魚網址都靠這些東西。
 
--   :material-qrcode-scan: **[QR code 讀取器](qr-read.md)**
+-   :material-eye-outline: **[你的瀏覽器透露了什麼](leaks.md)**
 
-    讀出圖片裡 QR code 的內容，圖片不離開裝置。解出來是網址時把主機獨立標出來，並且不提供開啟按鈕。
+    列出任何網站不必問你就拿得到的資訊，並標出 Tor Browser 會把哪些統一掉。換個瀏覽器再看一次，就知道那些防護實際上做了什麼。
 
 </div>
 

--- a/tools/test_utils_index_order.mjs
+++ b/tools/test_utils_index_order.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * 小工具索引頁的卡片順序要跟 nav 一致。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * 讀者從左側目錄看到的順序，跟從索引頁卡片看到的順序，是同一區的兩個入口。兩邊不
+ * 一樣的時候沒有任何錯誤訊息，站台照樣建得起來，只有讀者會覺得東西「換位置了」。
+ *
+ * 這個不一致很容易發生：新增一個工具要改 nav（三個設定檔）跟索引頁（三個語系），
+ * 六個地方各自插入，插錯位置不會有人發現。實際上這一區短時間內就發生過兩次。
+ *
+ * 順序以 nav 為準，索引頁跟著它走。
+ *
+ * 用法：
+ *   node tools/test_utils_index_order.mjs
+ * 不需要建置產物，也沒有外部相依。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DOCS = path.join(HERE, '..', 'docs');
+const PAIRS = [
+  ['mkdocs.yml', 'zh-TW'],
+  ['mkdocs_en.yml', 'en'],
+  ['mkdocs_cn.yml', 'zh-CN'],
+];
+
+// nav 裡 utils/index.md 之後那一串就是這一區的順序
+function navOrder(configFile) {
+  const lines = fs.readFileSync(path.join(DOCS, configFile), 'utf8').split('\n');
+  const out = [];
+  let started = false;
+  for (const line of lines) {
+    const m = line.match(/^\s+- utils\/([a-z0-9-]+)\.md\s*$/);
+    if (m) {
+      if (m[1] === 'index') { started = true; continue; }
+      if (started) out.push(m[1]);
+    } else if (started && out.length) {
+      break;
+    }
+  }
+  return out;
+}
+
+// 索引頁的 grid cards 區塊裡，每張卡片連到哪一頁
+function cardOrder(lang) {
+  const text = fs.readFileSync(path.join(DOCS, lang, 'utils', 'index.md'), 'utf8');
+  const start = text.indexOf('<div class="grid cards" markdown>');
+  assert.ok(start >= 0, `${lang} 的索引頁沒有 grid cards 區塊`);
+  const body = text.slice(start, text.indexOf('</div>', start));
+  return [...body.matchAll(/^-\s+:[a-z0-9-]+:\s+\*\*\[[^\]]+\]\(([a-z0-9-]+)\.md\)\*\*/gm)].map((m) => m[1]);
+}
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test('三個語系的索引頁卡片順序都跟自己的 nav 一致', () => {
+  for (const [config, lang] of PAIRS) {
+    const nav = navOrder(config);
+    const cards = cardOrder(lang);
+    assert.deepEqual(cards, nav,
+      `${lang} 的順序對不上\n      nav  ：${nav.join('、')}\n      卡片：${cards.join('、')}`);
+  }
+});
+
+test('三個語系的 nav 順序彼此一致', () => {
+  // 語系之間排法不同，讀者切換語言時會覺得東西跑掉了
+  const [base, ...rest] = PAIRS.map(([config]) => navOrder(config));
+  for (let i = 0; i < rest.length; i += 1) {
+    assert.deepEqual(rest[i], base, `${PAIRS[i + 1][0]} 的 nav 順序跟 mkdocs.yml 不同`);
+  }
+});
+
+test('nav 裡的每一頁都有對應的檔案與卡片', () => {
+  for (const [config, lang] of PAIRS) {
+    for (const slug of navOrder(config)) {
+      const file = path.join(DOCS, lang, 'utils', slug + '.md');
+      assert.ok(fs.existsSync(file), `${lang} 的 nav 有 ${slug} 但檔案不存在`);
+    }
+    assert.ok(navOrder(config).length >= 6, `${lang} 的 nav 只有 ${navOrder(config).length} 個工具`);
+  }
+});
+
+test('索引頁沒有多出 nav 以外的卡片', () => {
+  // 多出來的卡片在左側目錄裡找不到，讀者按了之後回不去
+  for (const [config, lang] of PAIRS) {
+    const nav = new Set(navOrder(config));
+    for (const slug of cardOrder(lang)) {
+      assert.ok(nav.has(slug), `${lang} 的索引頁有 ${slug} 的卡片，但 nav 裡沒有這一頁`);
+    }
+  }
+});
+
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message.split('\n').slice(0, 5).join('\n    ')}`);
+    failed += 1;
+  }
+}
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## 問題

左側目錄與索引頁卡片是同一區的兩個入口，順序不一樣的時候讀者會覺得東西換位置了。

| | nav | 索引頁卡片 |
|---|---|---|
| 4 | QR code 讀取器 | 你的瀏覽器透露了什麼 |
| 8 | 你的瀏覽器透露了什麼 | QR code 讀取器 |

其餘六個位置本來就一致。

## 修法

順序以 nav 為準，三個語系一起改。只動排序不動內容：三個檔案各 8 行增刪。

改完的順序：威脅模型清單、密語與密碼產生器、QR code 產生器、QR code 讀取器、照片 metadata 清除器、網址清理器、隱形字元偵測、你的瀏覽器透露了什麼。

## 加了測試

這個不一致沒有任何錯誤訊息，站台照樣建得起來。而它很容易發生：新增一個工具要改六個地方（三個設定檔的 nav 加三個語系的索引頁），各自插入，插錯位置不會有人發現。

實際上這一區短時間內就發生過兩次，都是我自己加工具時插的位置跟 nav 不同。

`tools/test_utils_index_order.mjs` 4 項：

- 三個語系的索引頁卡片順序都跟自己的 nav 一致
- 三個語系的 nav 順序彼此一致（語系之間排法不同，讀者切換語言時也會覺得東西跑掉）
- nav 裡的每一頁都有對應的檔案
- 索引頁沒有多出 nav 以外的卡片（那種卡片在左側目錄裡找不到）

四處故意改壞都會紅：卡片移位、nav 換順序而卡片沒跟上、只改一個語系的 nav、索引頁少一張卡片。

## 驗證

三語系建置通過，建置產物裡的實際順序逐一比對過。既有 12 支測試與 `check_precache.mjs` 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)