### PR TITLE
補齊第三方元件的標示，並修好其他語系缺少的 pdf-lib

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -102,6 +102,10 @@ jobs:
       - name: QR code 讀取器
         run: node tools/test_qrread.mjs
 
+      # 第三方元件的標示與授權：漏掉不會有錯誤訊息，只是授權沒有被履行
+      - name: 第三方元件標示
+        run: node tools/test_vendor_attribution.mjs
+
       # 小工具索引頁的卡片順序：跟 nav 不一致時沒有任何錯誤訊息，只有讀者會覺得東西換位置
       - name: 小工具索引順序
         run: node tools/test_utils_index_order.mjs

--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -63,6 +63,23 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 The code and data behind these tools are stored along with the page. Tick this section in the [offline reading](../offline.md) list and they will open without a network afterwards.
 
+## Whose code this uses
+
+Most of the code in this section is our own, under [anoni-net/docs](https://github.com/anoni-net/docs/tree/main/docs/zh-TW/js){target="_blank"}. Four things come from elsewhere, included unmodified:
+
+| Component | Used by | Licence | Where the licence text is |
+|---|---|---|---|
+| [qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator){target="_blank"} 1.4.4 | [QR code generator](qrcode.md) | MIT | [the header at the top of the file](vendor/qrcode-generator.js) |
+| [jsQR](https://github.com/cozmo/jsQR){target="_blank"} 1.4.0 | [QR code reader](qr-read.md) | Apache-2.0 | [jsQR-LICENSE.txt](vendor/jsQR-LICENSE.txt) |
+| [pdf-lib](https://github.com/Hopding/pdf-lib){target="_blank"} 1.17.1 | The PDF part of the [file metadata remover](strip-metadata.md) | MIT | [pdf-lib-LICENSE.txt](vendor/pdf-lib-LICENSE.txt) |
+| The 7776-word list from [asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"} | [Passphrase and password generator](passphrase.md) | Word data CC-BY-4.0, code MIT | [the upstream repository](https://github.com/anoni-net/asian-diceware){target="_blank"} |
+
+The `pdf-lib.min.js` build also bundles Microsoft's tslib (Apache-2.0), whose copyright header survives in the file rather than being stripped by the minifier.
+
+Leaving these unmodified is deliberate. Editing them would forfeit the "this is the upstream file" property, leaving readers who want to check with nothing but our word for it. The files sit under `utils/vendor/` and can be diffed against upstream.
+
+Why each of these is not written from scratch is explained at the bottom of the relevant page. The shared reason is that getting them wrong does not crash anything; it produces output that looks right and is not, which is harder to notice than a failure.
+
 ## What is not here
 
 Anything that needs an external service to work stays out, because that conflicts with both rules above. For network measurement use [OONI Probe](../tools/what-is-ooni.md), which is built for the job and documents what happens to the data.

--- a/docs/en/utils/qr-read.md
+++ b/docs/en/utils/qr-read.md
@@ -79,7 +79,7 @@ QR codes carry error correction, but a blurred photo, a steep angle or too littl
 
 ## Whose code does the decoding
 
-Decoding is handled by [jsQR](https://github.com/cozmo/jsQR){target="_blank"} (Apache-2.0), placed unmodified under `utils/vendor/` with the full licence text alongside it.
+Decoding is handled by [jsQR](https://github.com/cozmo/jsQR){target="_blank"} (Apache-2.0, [full licence text](vendor/jsQR-LICENSE.txt)), placed unmodified under `utils/vendor/`. Everything third-party in this section is listed on the [tools index](index.md#whose-code-this-uses).
 
 Decoding involves locating the code, correcting perspective and applying error correction, a considerably larger job than encoding. The tests generate codes with known contents using qrcode-generator from the [generator](qrcode.md) page and read them back with jsQR, so two independent libraries check each other.
 

--- a/docs/en/utils/vendor/pdf-lib-LICENSE.txt
+++ b/docs/en/utils/vendor/pdf-lib-LICENSE.txt
@@ -1,0 +1,1 @@
+../../../zh-TW/utils/vendor/pdf-lib-LICENSE.txt

--- a/docs/en/utils/vendor/pdf-lib.min.js
+++ b/docs/en/utils/vendor/pdf-lib.min.js
@@ -1,0 +1,1 @@
+../../../zh-TW/utils/vendor/pdf-lib.min.js

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -63,6 +63,23 @@ icon: material/tools
 
 这些工具的程序与数据会跟页面一起存下来。在[离线阅读](../offline.md)的清单里勾起这一区的页面，之后没有网络也打得开。
 
+## 用了谁的程序
+
+这一区大部分的程序是自己写的，放在 [anoni-net/docs](https://github.com/anoni-net/docs/tree/main/docs/zh-TW/js){target="_blank"} 底下。有四样东西来自别人，原封不动放进来，不做任何修改：
+
+| 组件 | 用在 | 授权 | 授权文字在哪 |
+|---|---|---|---|
+| [qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator){target="_blank"} 1.4.4 | [QR code 生成器](qrcode.md) | MIT | [文件开头的标头](vendor/qrcode-generator.js) |
+| [jsQR](https://github.com/cozmo/jsQR){target="_blank"} 1.4.0 | [QR code 读取器](qr-read.md) | Apache-2.0 | [jsQR-LICENSE.txt](vendor/jsQR-LICENSE.txt) |
+| [pdf-lib](https://github.com/Hopding/pdf-lib){target="_blank"} 1.17.1 | [文件 metadata 清除器](strip-metadata.md)的 PDF 部分 | MIT | [pdf-lib-LICENSE.txt](vendor/pdf-lib-LICENSE.txt) |
+| [asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"} 的 7776 字词表 | [密语与密码生成器](passphrase.md) | 词表数据 CC-BY-4.0，程序 MIT | [上游的 repo](https://github.com/anoni-net/asian-diceware){target="_blank"} |
+
+`pdf-lib.min.js` 那一份里面还打包了微软的 tslib（Apache-2.0），它的版权标头跟着留在文件里，没有被压缩工具剥掉。
+
+不做修改是刻意的。改过就失去「这是上游那一份」的可审性，读者要验的时候只能相信我们的说法。文件都在 `utils/vendor/` 底下，可以自己跟上游的版本比对。
+
+为什么这几样不自己写，每一页最后那一节有说明。共通的理由是那些东西写错不会崩溃，只会产生看起来正常但实际上错的结果，而那比坏掉更难发现。
+
 ## 没有收进来的东西
 
 需要连到外部服务才能运作的功能不会放在这里，那跟「离线可用」与「不送出数据」两条规则冲突。网络测量请用 [OONI Probe](../tools/what-is-ooni.md)，那是设计来做这件事的工具，数据的处理方式也公开。

--- a/docs/zh-CN/utils/qr-read.md
+++ b/docs/zh-CN/utils/qr-read.md
@@ -79,7 +79,7 @@ QR code 有容错能力，但照片太模糊、角度太斜、周围留白不够
 
 ## 解码用的是谁的程序
 
-解码交给 [jsQR](https://github.com/cozmo/jsQR){target="_blank"}（Apache-2.0 授权），原封不动放在 `utils/vendor/` 底下，授权全文也在同一个目录。
+解码交给 [jsQR](https://github.com/cozmo/jsQR){target="_blank"}（Apache-2.0 授权，[授权全文](vendor/jsQR-LICENSE.txt)），原封不动放在 `utils/vendor/` 底下。这一区用到的第三方组件都列在[小工具首页](index.md#用了谁的程序)。
 
 那要处理定位、透视校正与纠错还原，比编码更大的工程。测试用[生成器](qrcode.md)那边的 qrcode-generator 生成已知内容的码，再交给 jsQR 读回来比对，两个各自独立的函式库互相验证。
 

--- a/docs/zh-CN/utils/vendor/pdf-lib-LICENSE.txt
+++ b/docs/zh-CN/utils/vendor/pdf-lib-LICENSE.txt
@@ -1,0 +1,1 @@
+../../../zh-TW/utils/vendor/pdf-lib-LICENSE.txt

--- a/docs/zh-CN/utils/vendor/pdf-lib.min.js
+++ b/docs/zh-CN/utils/vendor/pdf-lib.min.js
@@ -1,0 +1,1 @@
+../../../zh-TW/utils/vendor/pdf-lib.min.js

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -63,6 +63,23 @@ icon: material/tools
 
 這些工具的程式與資料會跟頁面一起存下來。在[離線閱讀](../offline.md)的清單裡勾起這一區的頁面，之後沒有網路也打得開。
 
+## 用了誰的程式
+
+這一區大部分的程式是自己寫的，放在 [anoni-net/docs](https://github.com/anoni-net/docs/tree/main/docs/zh-TW/js){target="_blank"} 底下。有四樣東西來自別人，原封不動放進來，不做任何修改：
+
+| 元件 | 用在 | 授權 | 授權文字在哪 |
+|---|---|---|---|
+| [qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator){target="_blank"} 1.4.4 | [QR code 產生器](qrcode.md) | MIT | [檔案開頭的標頭](vendor/qrcode-generator.js) |
+| [jsQR](https://github.com/cozmo/jsQR){target="_blank"} 1.4.0 | [QR code 讀取器](qr-read.md) | Apache-2.0 | [jsQR-LICENSE.txt](vendor/jsQR-LICENSE.txt) |
+| [pdf-lib](https://github.com/Hopding/pdf-lib){target="_blank"} 1.17.1 | [檔案 metadata 清除器](strip-metadata.md)的 PDF 部分 | MIT | [pdf-lib-LICENSE.txt](vendor/pdf-lib-LICENSE.txt) |
+| [asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"} 的 7776 字詞表 | [密語與密碼產生器](passphrase.md) | 詞表資料 CC-BY-4.0，程式 MIT | [上游的 repo](https://github.com/anoni-net/asian-diceware){target="_blank"} |
+
+`pdf-lib.min.js` 那一份裡面還打包了微軟的 tslib（Apache-2.0），它的版權標頭跟著留在檔案裡，沒有被壓縮工具剝掉。
+
+不做修改是刻意的。改過就失去「這是上游那一份」的可審性，讀者要驗的時候只能相信我們的說法。檔案都在 `utils/vendor/` 底下，可以自己跟上游的版本比對。
+
+為什麼這幾樣不自己寫，每一頁最後那一節有說明。共通的理由是那些東西寫錯不會當掉，只會產生看起來正常但實際上錯的結果，而那比壞掉更難發現。
+
 ## 沒有收進來的東西
 
 需要連到外部服務才能運作的功能不會放在這裡，那跟「離線可用」與「不送出資料」兩條規則衝突。網路測量請用 [OONI Probe](../tools/what-is-ooni.md)，那是設計來做這件事的工具，資料的處理方式也公開。

--- a/docs/zh-TW/utils/passphrase.md
+++ b/docs/zh-TW/utils/passphrase.md
@@ -19,7 +19,7 @@ offline_assets:
 
 ## 這一頁在做什麼
 
-「密語」模式從 [asian-diceware](../tools/asian-diceware.md) 的 7776 字詞表裡獨立抽幾個字串起來。那份詞表是社群參考 EFF Diceware 做的版本，混進了 `oolong`、`boba`、`tofu` 這類已經進英文字典的亞洲外來語，對在台灣與亞洲各地生活的人更好認、更好記。
+「密語」模式從 [asian-diceware](../tools/asian-diceware.md) 的 7776 字詞表裡獨立抽幾個字串起來。那份詞表是社群自己做的，資料採 CC-BY-4.0，完整版與產生它的程式在 [GitHub](https://github.com/anoni-net/asian-diceware){target="_blank"}。那份詞表是社群參考 EFF Diceware 做的版本，混進了 `oolong`、`boba`、`tofu` 這類已經進英文字典的亞洲外來語，對在台灣與亞洲各地生活的人更好認、更好記。
 
 「隨機密碼」模式從你勾選的字元集裡逐字抽。適合用密碼管理器保管、不需要用手打的場合。
 

--- a/docs/zh-TW/utils/qr-read.md
+++ b/docs/zh-TW/utils/qr-read.md
@@ -79,7 +79,7 @@ QR code 有容錯能力，但照片太模糊、角度太斜、周圍留白不夠
 
 ## 解碼用的是誰的程式
 
-解碼交給 [jsQR](https://github.com/cozmo/jsQR){target="_blank"}（Apache-2.0 授權），原封不動放在 `utils/vendor/` 底下，授權全文也在同一個目錄。
+解碼交給 [jsQR](https://github.com/cozmo/jsQR){target="_blank"}（Apache-2.0 授權，[授權全文](vendor/jsQR-LICENSE.txt)），原封不動放在 `utils/vendor/` 底下。這一區用到的第三方元件都列在[小工具首頁](index.md#用了誰的程式)。
 
 那要處理定位、透視校正與容錯還原，比編碼更大的工程。測試用[產生器](qrcode.md)那邊的 qrcode-generator 產生已知內容的碼，再交給 jsQR 讀回來比對，兩個各自獨立的函式庫互相驗證。
 

--- a/docs/zh-TW/utils/strip-metadata.md
+++ b/docs/zh-TW/utils/strip-metadata.md
@@ -71,7 +71,7 @@ PDF 也在範圍裡，但做法跟前面兩種不同。
 
 照片與影片可以直接把某一段剪掉，PDF 不行。那個格式的每個物件在交叉索引表裡都記著自己在檔案裡的位置，拿掉一段之後後面全部位移，整張表要重算。而且 PDF 1.5 之後常見的做法是把好幾個物件壓進同一段壓縮資料，從外面連內容都看不到。
 
-所以這一部分交給 [pdf-lib](https://github.com/Hopding/pdf-lib){target="_blank"}（MIT 授權，原封不動放在 `utils/vendor/` 底下），由它負責解析與重寫，這一頁只決定拿掉哪些欄位。
+所以這一部分交給 [pdf-lib](https://github.com/Hopding/pdf-lib){target="_blank"}（MIT 授權，[授權全文](vendor/pdf-lib-LICENSE.txt)），原封不動放在 `utils/vendor/` 底下，由它負責解析與重寫，這一頁只決定拿掉哪些欄位。
 
 清掉的是：
 

--- a/tools/test_vendor_attribution.mjs
+++ b/tools/test_vendor_attribution.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * 第三方元件的標示與授權檔守門測試。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * MIT 與 Apache-2.0 都要求散布時附上授權。檔案少一份、表格漏一列、頁面連錯路徑，
+ * 站台照樣建得起來，沒有任何錯誤訊息，只有授權沒有被履行。
+ *
+ * 這件事在加新元件的時候特別容易漏：把 .js 放進 vendor、在頁面上引用，工具就會動了，
+ * 而登記與授權那兩步不做也不會有人發現。
+ *
+ * 用法：
+ *   node tools/test_vendor_attribution.mjs
+ * 不需要建置產物，也沒有外部相依。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DOCS = path.join(HERE, '..', 'docs');
+const VENDOR = path.join(DOCS, 'zh-TW', 'utils', 'vendor');
+const LANGS = ['zh-TW', 'zh-CN', 'en'];
+
+const read = (p) => fs.readFileSync(p, 'utf8');
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+// vendor 目錄裡的每一個 .js 都是第三方元件
+const vendorScripts = fs.readdirSync(VENDOR).filter((f) => f.endsWith('.js'));
+
+test('vendor 目錄裡的每一支程式都被頁面引用，沒有孤兒檔案', () => {
+  // 留著沒人用的第三方程式會被一起部署，也會進讀者的離線副本
+  const pages = fs.readdirSync(path.join(DOCS, 'zh-TW', 'utils'))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => read(path.join(DOCS, 'zh-TW', 'utils', f)))
+    .join('\n');
+  for (const script of vendorScripts) {
+    assert.ok(pages.includes(script), `vendor/${script} 沒有任何頁面引用它`);
+  }
+});
+
+test('每一支第三方程式的授權文字都拿得到', () => {
+  // 要嘛檔案自己帶版權標頭，要嘛旁邊有一份授權檔，兩者都沒有就是沒有履行授權
+  for (const script of vendorScripts) {
+    const body = read(path.join(VENDOR, script));
+    const inline = /copyright/i.test(body.slice(0, 4000));
+    const base = script.replace(/\.min\.js$|\.js$/, '');
+    const licence = fs.existsSync(path.join(VENDOR, base + '-LICENSE.txt'));
+    assert.ok(inline || licence,
+      `${script} 既沒有內嵌版權標頭，也沒有 ${base}-LICENSE.txt`);
+  }
+});
+
+test('小工具首頁列出了每一支第三方程式', () => {
+  // 散在各頁的說明讀者要一頁一頁翻，集中的那一份才是能查的
+  for (const lang of LANGS) {
+    const index = read(path.join(DOCS, lang, 'utils', 'index.md'));
+    for (const script of vendorScripts) {
+      const name = script.replace(/\.min\.js$|\.js$/, '');
+      assert.ok(index.includes(name), `${lang} 的 index.md 沒有列出 ${name}`);
+    }
+    // 詞表是資料不是程式，一樣要標
+    assert.ok(index.includes('asian-diceware'), `${lang} 的 index.md 沒有列出詞表`);
+  }
+});
+
+test('首頁那份表格連到的授權檔案真的存在', () => {
+  for (const lang of LANGS) {
+    const index = read(path.join(DOCS, lang, 'utils', 'index.md'));
+    const links = [...index.matchAll(/\]\((vendor\/[^)]+)\)/g)].map((m) => m[1]);
+    assert.ok(links.length >= 3, `${lang} 的 index.md 只有 ${links.length} 個 vendor 連結`);
+    for (const link of links) {
+      const target = path.join(DOCS, 'zh-TW', 'utils', link);
+      assert.ok(fs.existsSync(target), `${lang} 的 index.md 連到 ${link}，但檔案不存在`);
+    }
+  }
+});
+
+test('授權檔不是空的', () => {
+  for (const f of fs.readdirSync(VENDOR).filter((x) => x.includes('LICENSE'))) {
+    const size = fs.statSync(path.join(VENDOR, f)).size;
+    assert.ok(size > 500, `${f} 只有 ${size} 位元組，不像一份完整的授權`);
+  }
+});
+
+test('vendor 的 README 把每一支都登記了', () => {
+  const readme = read(path.join(VENDOR, 'README.md'));
+  for (const script of vendorScripts) {
+    assert.ok(readme.includes(script), `vendor/README.md 沒有登記 ${script}`);
+  }
+});
+
+test('三個語系的表格列出一樣多的元件', () => {
+  // 少一列的那個語系，讀者就查不到那一項
+  const counts = LANGS.map((lang) => {
+    const index = read(path.join(DOCS, lang, 'utils', 'index.md'));
+    return [...index.matchAll(/\]\(vendor\/[^)]+\)/g)].length;
+  });
+  assert.equal(new Set(counts).size, 1, `三個語系的 vendor 連結數不同：${counts}`);
+});
+
+test('三個語系的 vendor 目錄內容一致', () => {
+  // 這一項是踩過才加的：pdf-lib 只放進 zh-TW，en 與 zh-CN 的 PDF 功能在正式站
+  // 是壞的（script 404），而三語系建置全部通過、測試也全綠，因為端對端測試
+  // 只跑了 zh-TW。少一個檔案不會有任何錯誤訊息。
+  const base = fs.readdirSync(VENDOR).filter((f) => !f.endsWith('.md')).sort();
+  for (const lang of ['en', 'zh-CN']) {
+    const dir = path.join(DOCS, lang, 'utils', 'vendor');
+    assert.ok(fs.existsSync(dir), `${lang} 沒有 vendor 目錄`);
+    const here = fs.readdirSync(dir).sort();
+    assert.deepEqual(here, base,
+      `${lang} 的 vendor 少了：${base.filter((f) => !here.includes(f)).join('、') || '（無）'}`);
+  }
+});
+
+test('其他語系的 vendor 檔案是指向 zh-TW 的 symlink', () => {
+  // 複製一份的話兩邊會各自漂移，換版時只更新一邊不會有人發現
+  for (const lang of ['en', 'zh-CN']) {
+    const dir = path.join(DOCS, lang, 'utils', 'vendor');
+    for (const f of fs.readdirSync(dir)) {
+      assert.ok(fs.lstatSync(path.join(dir, f)).isSymbolicLink(),
+        `${lang}/utils/vendor/${f} 是實體檔案，應該是 symlink`);
+      assert.ok(fs.existsSync(path.join(dir, f)), `${lang}/utils/vendor/${f} 這個 symlink 指到不存在的地方`);
+    }
+  }
+});
+
+test('每一頁引用的 vendor 檔案在自己的語系底下都找得到', () => {
+  // 頁面寫的是相對路徑，檔案要在同語系的 vendor 底下才連得到
+  for (const lang of LANGS) {
+    const dir = path.join(DOCS, lang, 'utils');
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.md'))) {
+      const text = read(path.join(dir, file));
+      for (const m of text.matchAll(/(?:src="|\]\()\.{0,2}\/?vendor\/([^"')]+)/g)) {
+        const target = path.join(dir, 'vendor', m[1]);
+        assert.ok(fs.existsSync(target),
+          `${lang}/utils/${file} 引用 vendor/${m[1]}，但那個語系底下沒有這個檔案`);
+      }
+    }
+  }
+});
+
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message.split('\n').slice(0, 3).join('\n    ')}`);
+    failed += 1;
+  }
+}
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
起點是一個問題：這一區引用的第三方套件，有宣告它們的存在嗎。

答案是**有登記，但登記在讀者看不到的地方**。

| | 現況 |
|---|---|
| `vendor/README.md`（登記表） | 沒有被建置成頁面，只有看 GitHub 的人找得到 |
| `jsQR-LICENSE.txt` | 線上是 200，但沒有任何頁面連過去 |
| 各工具頁 | 提到名字與授權，都是純文字，點不動 |
| `utils/index.md` | 完全沒提 |
| 詞表 CC-BY-4.0 | 只寫在 `tools/asian-diceware.md`，`passphrase.md` 沒說 |

MIT 與 Apache-2.0 都要求散布時附上授權。檔案在，但讀者要自己猜路徑。

## 順著查下去發現一個已經上線的缺陷

en 與 zh-CN 的 `utils/vendor/` 底下**沒有 pdf-lib**。上一個 PR 只把它放進 zh-TW，沒有替另外兩個語系建 symlink：

```
/utils/vendor/pdf-lib.min.js          200
/en/utils/vendor/pdf-lib.min.js       404
/zh-cn/utils/vendor/pdf-lib.min.js    404
```

英文版與簡體版的 PDF 清除功能是壞的，script 根本載不到。而三語系建置全部通過、13 支測試也全綠——因為我的端對端測試只跑了 zh-TW。

補上 symlink，並加測試守著三個語系的 vendor 目錄內容要一致。

## 標示

小工具首頁加一節「用了誰的程式」，表格列出元件、用在哪一頁、授權、授權文字在哪，每個授權連結都指向實際檔案。

三個檔案的狀況不同，表格照實寫：

- `qrcode-generator.js` 的版權標頭在檔案開頭（Kazuhiko Arase，含 MIT 全文）
- `jsQR.js` 檔內**沒有**版權字樣，靠獨立的 `jsQR-LICENSE.txt`
- `pdf-lib.min.js` 檔內那幾段 Copyright 其實是打包進去的**微軟 tslib**（Apache-2.0），pdf-lib 自己的 MIT 另外附

`passphrase.md` 補上詞表授權（資料 CC-BY-4.0），原本只寫在 `tools/asian-diceware.md`。

## 測試

`tools/test_vendor_attribution.mjs` 10 項：孤兒檔案、授權文字拿不拿得到、首頁有沒有列出、連結目標存不存在、三語系一不一致、symlink 有沒有被換成實體檔案、每頁引用的檔案在自己語系底下找不找得到。

四處故意改壞都會紅，其中一項就是重現「拿掉 en 的 pdf-lib」那個狀況。

## 驗證

三語系建置通過，`docs_style_lint.py` 28 個檔案 0 error 0 warn，另外 13 支測試與 `check_precache.mjs` 全綠。建置產物裡三個語系的 vendor 目錄內容一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)