### PR TITLE
metadata 清除器改成遇到 PDF 才載入 pdf-lib

### DIFF
--- a/docs/en/utils/strip-metadata.md
+++ b/docs/en/utils/strip-metadata.md
@@ -2,13 +2,16 @@
 title: File metadata remover
 description: Strip EXIF, GPS, device model, authoring software and comment fields from photos, videos and PDFs without the file leaving your device. For photos and videos, not one byte of compressed data is touched.
 icon: material/image-off-outline
+offline_assets:
+  # 這一份改成遇到 PDF 才動態載入，頁面裡沒有 script 標籤了。離線副本仍然要包含它，
+  # 不然存下這一頁的人在斷網時處理不了 PDF。
+  - utils/vendor/pdf-lib.min.js
 ---
 
 # :material-image-off-outline: File metadata remover
 
 <div id="stripmeta-tool"></div>
 
-<script src="../vendor/pdf-lib.min.js"></script>
 <script src="../../js/stripmeta.js"></script>
 
 Two situations that come up:

--- a/docs/zh-CN/utils/strip-metadata.md
+++ b/docs/zh-CN/utils/strip-metadata.md
@@ -2,13 +2,16 @@
 title: 文件 metadata 清除器
 description: 拿掉照片、视频与 PDF 里的 EXIF、GPS、设备型号、制作软件与注释字段，文件不离开你的设备。照片与视频的压缩数据一个比特都没动。
 icon: material/image-off-outline
+offline_assets:
+  # 這一份改成遇到 PDF 才動態載入，頁面裡沒有 script 標籤了。離線副本仍然要包含它，
+  # 不然存下這一頁的人在斷網時處理不了 PDF。
+  - utils/vendor/pdf-lib.min.js
 ---
 
 # :material-image-off-outline: 文件 metadata 清除器
 
 <div id="stripmeta-tool"></div>
 
-<script src="../vendor/pdf-lib.min.js"></script>
 <script src="../../js/stripmeta.js"></script>
 
 ## 什么时候用得上

--- a/docs/zh-TW/js/stripmeta.js
+++ b/docs/zh-TW/js/stripmeta.js
@@ -553,12 +553,38 @@
     ["Producer", "setProducer", "getProducer"],
   ];
 
+  // pdf-lib 有五百多 KB，是這一頁最大的一塊。放在頁面裡用 script 標籤載，等於每個
+  // 打開這一頁的人都要先等它下載完，而六種格式裡只有 PDF 需要它。改成真的遇到
+  // PDF 才去拿。
+  //
+  // 離線副本仍然包含它：那個檔案列在這一頁 frontmatter 的 offline_assets 裡，
+  // 讀者存下這一頁的時候會一起存，斷網時這裡取到的是 service worker 的快取。
+  let pdfLibLoading = null;
+
   function pdfLib() {
     return typeof window !== "undefined" ? window.PDFLib : null;
   }
 
+  function loadPdfLib() {
+    if (pdfLib()) return Promise.resolve(pdfLib());
+    if (!pdfLibLoading) {
+      pdfLibLoading = new Promise((resolve) => {
+        const script = document.createElement("script");
+        script.src = new URL("../vendor/pdf-lib.min.js", location.href).href;
+        script.onload = () => resolve(pdfLib());
+        script.onerror = () => {
+          // 失敗就讓下一次重試，不要卡在一個永遠不會完成的 promise 上
+          pdfLibLoading = null;
+          resolve(null);
+        };
+        document.head.appendChild(script);
+      });
+    }
+    return pdfLibLoading;
+  }
+
   async function stripPdf(bytes) {
-    const lib = pdfLib();
+    const lib = await loadPdfLib();
     if (!lib) return { ok: false, reason: "pdfLibMissing" };
     let doc;
     try {
@@ -747,6 +773,10 @@
     #stripmeta-tool button:hover, #stripmeta-tool a.sm-dl:hover {
       border-color: var(--md-accent-fg-color); color: var(--md-accent-fg-color);
     }
+    #stripmeta-tool .sm-loading {
+      font-size: .78rem; line-height: 1.8; margin: .8rem 0 0;
+      border-left: .15rem solid var(--md-primary-fg-color); padding-left: .6rem;
+    }
     #stripmeta-tool .sm-formats {
       font-size: .72rem; opacity: .8; line-height: 2; margin: .6rem 0 0;
     }
@@ -809,6 +839,7 @@
         verify: "清完的檔案解不開，這是這一頁的問題。原始檔沒有被動到，請不要用清完的那一份，並且回報這個狀況。",
       },
       supports: "吃得下這些：",
+      loadingLib: "第一次處理 PDF 要先把解析用的程式抓回來，大約半 MB，抓完就會留在裝置上。",
       note: "檔案在你的瀏覽器裡改，沒有上傳到任何地方。斷網時照樣可以用。清完的是新的一份，原始檔不會被動到。",
     },
     zh: {
@@ -862,6 +893,7 @@
         verify: "清完的文件解不开，这是这一页的问题。原始文件没有被动到，请不要用清完的那一份，并且回报这个状况。",
       },
       supports: "吃得下这些：",
+      loadingLib: "第一次处理 PDF 要先把解析用的程序抓回来，大约半 MB，抓完就会留在设备上。",
       note: "文件在你的浏览器里改，没有上传到任何地方。断网时照样可以用。清完的是新的一份，原始文件不会被动到。",
     },
     en: {
@@ -915,6 +947,7 @@
         verify: "The cleaned file will not open. That is a fault in this page. Your original was not touched. Please do not use the cleaned copy, and report this.",
       },
       supports: "Handles:",
+      loadingLib: "Handling a PDF for the first time fetches the parsing library, about half a megabyte. It stays on your device afterwards.",
       note: "Files are modified in your browser and never uploaded. This works with the network off. The cleaned file is a new copy; your original is not touched.",
     },
   };
@@ -936,6 +969,8 @@
 
   // 每個處理過的檔案一列。物件 URL 留著給下載與縮圖用，換一批的時候一起收掉。
   const files = [];
+  // 第一次遇到 PDF 要先把函式庫抓回來，那段時間畫面要說一聲
+  let loadingLib = false;
 
   function release() {
     for (const item of files) {
@@ -1047,6 +1082,7 @@
     }
     root.appendChild(formats);
 
+    if (loadingLib) root.appendChild(el("p", "sm-loading", t.loadingLib));
     for (const item of files) root.appendChild(renderFile(item));
 
     if (files.length) {
@@ -1076,7 +1112,8 @@
       };
       if (kind === "pdf") {
         // PDF 沒辦法丟給 img 或 video，改成用同一個函式庫重新讀一次。
-        // 結構被改壞的話這一步會丟例外。
+        // 結構被改壞的話這一步會丟例外。走到這裡函式庫一定已經載好了，
+        // 因為前一步就是用它處理的。
         const lib = pdfLib();
         if (!lib) return resolve(url);
         blob.arrayBuffer()
@@ -1134,6 +1171,17 @@
   async function handle(list) {
     if (!list || !list.length) return;
     release();
+    // 第一次遇到 PDF 要先把函式庫抓回來，那要一點時間。先讓畫面說一聲，
+    // 不然讀者只會看到一個沒有反應的頁面。
+    for (const file of list) {
+      if (file.type === "application/pdf" && !pdfLib()) {
+        loadingLib = true;
+        render();
+        // 交還主執行緒，讓那行字先畫出來
+        await new Promise((next) => setTimeout(next, 0));
+        break;
+      }
+    }
     for (const file of list) {
       const okType = !file.type || file.type.indexOf("image/") === 0 ||
         file.type.indexOf("video/") === 0 || file.type === "application/pdf";
@@ -1143,6 +1191,7 @@
       }
       files.push(await handleOne(file));
     }
+    loadingLib = false;
     render();
   }
 

--- a/docs/zh-TW/utils/strip-metadata.md
+++ b/docs/zh-TW/utils/strip-metadata.md
@@ -2,13 +2,16 @@
 title: 檔案 metadata 清除器
 description: 拿掉照片、影片與 PDF 裡的 EXIF、GPS、裝置型號、製作軟體與註解欄位，檔案不離開你的裝置。照片與影片的壓縮資料一個位元都沒動。
 icon: material/image-off-outline
+offline_assets:
+  # 這一份改成遇到 PDF 才動態載入，頁面裡沒有 script 標籤了。離線副本仍然要包含它，
+  # 不然存下這一頁的人在斷網時處理不了 PDF。
+  - utils/vendor/pdf-lib.min.js
 ---
 
 # :material-image-off-outline: 檔案 metadata 清除器
 
 <div id="stripmeta-tool"></div>
 
-<script src="../vendor/pdf-lib.min.js"></script>
 <script src="../../js/stripmeta.js"></script>
 
 ## 什麼時候用得上

--- a/tools/test_stripmeta.mjs
+++ b/tools/test_stripmeta.mjs
@@ -707,6 +707,49 @@ test('三個語系都有支援清單的說明文字', () => {
   }
 });
 
+test('pdf-lib 不放在頁面裡用 script 標籤載', () => {
+  // 那一份有五百多 KB，是這一頁最大的一塊。放在頁面裡等於每個打開這一頁的人
+  // 都要先等它下載完，而六種格式裡只有 PDF 需要它。
+  for (const lang of ['zh-TW', 'zh-CN', 'en']) {
+    const page = fs.readFileSync(path.join(HERE, '..', 'docs', lang, 'utils', 'strip-metadata.md'), 'utf8');
+    assert.ok(!/<script[^>]*pdf-lib/.test(page), `${lang} 的頁面還在用 script 標籤載 pdf-lib`);
+  }
+  assert.ok(/function loadPdfLib\(\)/.test(code), '沒有動態載入的路徑');
+  assert.ok(/createElement\("script"\)/.test(code), '沒有動態插入 script');
+});
+
+test('離線副本仍然包含 pdf-lib', () => {
+  // 頁面裡沒有 script 標籤之後，offline_index 的資產掃描就看不到它了。
+  // 漏掉的話，存下這一頁的人在斷網時處理不了 PDF，而且不會有任何錯誤訊息。
+  for (const lang of ['zh-TW', 'zh-CN', 'en']) {
+    const page = fs.readFileSync(path.join(HERE, '..', 'docs', lang, 'utils', 'strip-metadata.md'), 'utf8');
+    const front = page.slice(0, page.indexOf('\n---', 4));
+    assert.ok(front.includes('offline_assets'), `${lang} 沒有宣告 offline_assets`);
+    assert.ok(front.includes('utils/vendor/pdf-lib.min.js'), `${lang} 的 offline_assets 少了 pdf-lib`);
+  }
+});
+
+test('載入函式庫的時候畫面要說一聲', () => {
+  // 半 MB 在慢一點的網路上要等好幾秒，沒有回饋的話讀者會以為卡住了
+  assert.ok(/loadingLib = true/.test(code), '沒有進入載入狀態');
+  assert.ok(/sm-loading/.test(code), '沒有把載入狀態畫出來');
+  for (const [lang, strings] of Object.entries(tool.STRINGS)) {
+    assert.ok(strings.loadingLib, `${lang} 少了載入中的文字`);
+  }
+  // 設了旗標之後要讓出主執行緒，那行字才畫得出來
+  const handle = code.slice(code.indexOf('async function handle(list)'));
+  const guard = handle.slice(0, handle.indexOf('files.push'));
+  assert.ok(/loadingLib = true[\s\S]*?render\(\)[\s\S]*?setTimeout/.test(guard),
+            '設了載入狀態卻沒有讓畫面有機會更新');
+});
+
+test('函式庫載入失敗時不會卡在一個永遠不完成的等待上', () => {
+  const fn = code.slice(code.indexOf('function loadPdfLib()'));
+  const body = fn.slice(0, fn.indexOf('async function stripPdf'));
+  assert.ok(/onerror[\s\S]*?pdfLibLoading = null/.test(body),
+            '載入失敗沒有把 promise 清掉，下一次會直接拿到失敗的結果');
+});
+
 for (const [name, fn] of tests) {
   try {
     fn();


### PR DESCRIPTION
回報是點進這一頁會停頓一下才跳過去。

## 量出來的原因

| 頁面 | JS 總量 | 最大的那一支 |
|---|---|---|
| `strip-metadata` | **646 KB** | `pdf-lib.min.js` 513 KB |
| `clean-url`（對照） | 137 KB | material 的 bundle 112 KB |

pdf-lib 掛在頁面上用 `<script>` 載，是同步的，而六種支援的格式裡**只有 PDF 需要它**。換頁的時候那半 MB 擋在中間，讀者看到的就是一段沒有反應的空檔。

## 改法

真的遇到 PDF 才動態插入 script。頁面的 JS 從 **646 KB 降到 213 KB**。

實測：

```
頁面載入完成後：
  pdf-lib 被請求了嗎： 沒有
  window.PDFLib： undefined
  頁面的 JS 總量： 213 KB

先丟一張 JPEG（不該觸發下載）：
  pdf-lib 被請求了嗎： 沒有       結果： 成功

再丟一份 PDF（這時才該下載）：
  pdf-lib 被請求了嗎： 有（正確）  window.PDFLib： object
  結果： m-xmp.pdf 成功，拿掉 3 項
```

## 離線副本不能跟著少掉

頁面裡沒有 `<script>` 之後，`offline_index` 的資產掃描就看不到 pdf-lib 了。漏掉的話，存下這一頁的人在斷網時處理不了 PDF，**而且不會有任何錯誤訊息**。

用 frontmatter 的 `offline_assets` 補上，建置後確認它還在資產表裡（`utils/vendor/pdf-lib.min.js`）。有一項測試守著這件事。

## 載入的時候畫面要說一聲

第一次遇到 PDF 要等半 MB 下載完，那段時間畫面上出現一行說明：講清楚在等什麼、大概多大、抓完就留在裝置上。設了旗標之後先讓出主執行緒，那行字才畫得出來。

載入失敗會把 promise 清掉讓下一次重試，不會卡在一個永遠不完成的等待上。

### 這一項我沒能完整驗證

那行提示在本機測不到，因為檔案讀取太快，畫面還來不及更新就載完了（216 ms）。我試過限速與請求攔截兩種方式重現，都沒成功，Chrome 對 localhost 不套用網路節流。

邏輯本身有測試守著（旗標設定、`render()` 呼叫、讓出主執行緒的順序、三語系文案），但真實慢網路上的行為要等部署之後才能確認。

## 驗證

測試 48 → 52 項，五處故意改壞都會紅：把 script 標籤放回頁面、拿掉 `offline_assets`、載入時不顯示狀態、設了狀態卻不讓出主執行緒、載入失敗不清掉 promise。

三語系建置通過，`docs_style_lint.py` 28 個檔案 0 error 0 warn，另外 13 支測試與 `check_precache.mjs`、`test_offline_index.py` 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)