### PR TITLE
fix(utils): QR code 讀取器把「瀏覽器打不開這張圖」跟「圖裡沒有 QR code」分開

### DIFF
--- a/docs/zh-TW/js/qrread.js
+++ b/docs/zh-TW/js/qrread.js
@@ -402,6 +402,13 @@
       dropOver: "放開就開始解讀",
       reading: "解讀中",
       notFound: "這張圖裡找不到 QR code。試試裁掉周圍、或換一張更清楚的。",
+      cantOpen: "你的瀏覽器打不開這張圖，所以還沒開始找 QR code。",
+      cantOpenHint: {
+        heic: "這是 iPhone 預設的 HEIC 格式，Safari 以外的瀏覽器多半解不開。到「設定 → 相機 → 格式」選「最相容」，之後拍的就是 JPEG。已經拍好的用 AirDrop 或郵件傳給自己，那個過程多半會轉成 JPEG。",
+        avif: "這是 AVIF 格式，較舊的瀏覽器還不支援。用看圖程式另存成 JPEG 或 PNG 再試。",
+        tiff: "這是 TIFF 格式，瀏覽器一律不顯示。用看圖程式另存成 JPEG 或 PNG 再試。",
+        jp2: "這是 JPEG 2000 格式，瀏覽器一律不顯示。用看圖程式另存成 JPEG 或 PNG 再試。",
+      },
       notImage: "那不是圖片檔。",
       copy: "複製內容",
       copyFull: "複製完整內容",
@@ -452,6 +459,13 @@
       dropOver: "放开就开始解读",
       reading: "解读中",
       notFound: "这张图里找不到 QR code。试试裁掉周围、或换一张更清楚的。",
+      cantOpen: "你的浏览器打不开这张图，所以还没开始找 QR code。",
+      cantOpenHint: {
+        heic: "这是 iPhone 默认的 HEIC 格式，Safari 以外的浏览器多半解不开。到「设置 → 相机 → 格式」选「最兼容」，之后拍的就是 JPEG。已经拍好的用 AirDrop 或邮件传给自己，那个过程多半会转成 JPEG。",
+        avif: "这是 AVIF 格式，较旧的浏览器还不支持。用看图程序另存为 JPEG 或 PNG 再试。",
+        tiff: "这是 TIFF 格式，浏览器一律不显示。用看图程序另存为 JPEG 或 PNG 再试。",
+        jp2: "这是 JPEG 2000 格式，浏览器一律不显示。用看图程序另存为 JPEG 或 PNG 再试。",
+      },
       notImage: "那不是图片文件。",
       copy: "复制内容",
       copyFull: "复制完整内容",
@@ -502,6 +516,13 @@
       dropOver: "Release to read it",
       reading: "Reading",
       notFound: "No QR code found in that image. Try cropping the surroundings, or use a sharper photo.",
+      cantOpen: "Your browser cannot open that image, so the search for a QR code never started.",
+      cantOpenHint: {
+        heic: "That is HEIC, the iPhone default, which browsers other than Safari mostly cannot decode. Under Settings \u2192 Camera \u2192 Formats, choose \"Most Compatible\" and new photos will be JPEG. For photos already taken, sending them to yourself over AirDrop or email usually converts them.",
+        avif: "That is AVIF, which older browsers do not support yet. Re-save it as JPEG or PNG in an image viewer and try again.",
+        tiff: "That is TIFF, which browsers never display. Re-save it as JPEG or PNG in an image viewer and try again.",
+        jp2: "That is JPEG 2000, which browsers never display. Re-save it as JPEG or PNG in an image viewer and try again.",
+      },
       notImage: "That is not an image file.",
       copy: "Copy contents",
       copyFull: "Copy full contents",
@@ -557,7 +578,15 @@
     return node;
   };
 
-  const state = { status: "idle", text: "", info: null, copied: false, revealed: false };
+  const state = {
+    status: "idle",
+    text: "",
+    info: null,
+    copied: false,
+    revealed: false,
+    // 瀏覽器打不開的時候，從檔頭認出來的格式代號，見 sniffFormat
+    format: null,
+  };
 
   // 圖片畫進 canvas 取像素。大圖先縮到合理尺寸，不然手機拍的照片動輒四千萬像素，
   // 解起來會卡住整個分頁。
@@ -662,11 +691,59 @@
           }
           if (Date.now() - started > DECODE_BUDGET_MS) break;
         }
-        resolve(null);
+        resolve({ notFound: true });
       };
-      image.onerror = () => resolve(null);
+      // 瀏覽器解不開這張圖。iPhone 預設拍出來的 HEIC 在 Safari 以外多半是這一條，
+      // 跟「圖裡沒有 QR code」是兩件不同的事，訊息要分開，見 handle。
+      image.onerror = () => {
+        URL.revokeObjectURL(image.src);
+        resolve({ unreadable: true });
+      };
       image.src = URL.createObjectURL(source);
     });
+  }
+
+  // 從檔頭認格式。副檔名與 MIME 都是別人給的，遇到「瀏覽器打不開」的時候，
+  // 能講出它實際是什麼格式，讀者才知道下一步要做什麼。
+  //
+  // 只認幾種真的會被拿來拍照或轉存的：HEIC 是 iPhone 的預設，AVIF 越來越常見，
+  // TIFF 與 JPEG 2000 偶爾從掃描器或舊系統流出來。認不出來就回 null，訊息退回
+  // 一般說法。
+  function sniffFormat(bytes) {
+    const ascii = (from, len) =>
+      String.fromCharCode.apply(null, bytes.subarray(from, from + len));
+    if (bytes.length >= 12 && ascii(4, 4) === "ftyp") {
+      const brand = ascii(8, 4);
+      if (/^(heic|heix|heim|heis|hevc|hevx|mif1|msf1)$/.test(brand)) return "heic";
+      if (/^(avif|avis)$/.test(brand)) return "avif";
+    }
+    if (bytes.length >= 4) {
+      const head = bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3];
+      if (head === 0x49492a00 || head === 0x4d4d002a) return "tiff";
+      if (head === 0x0000000c && ascii(4, 4) === "jP  ") return "jp2";
+    }
+    return null;
+  }
+
+  function readHead(file) {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(new Uint8Array(reader.result));
+      reader.onerror = () => resolve(new Uint8Array(0));
+      reader.readAsArrayBuffer(file.slice(0, 16));
+    });
+  }
+
+  // decode 的結果對到畫面狀態。
+  //
+  // 「瀏覽器打不開這張圖」與「圖裡沒有 QR code」原本共用 notFound 一個狀態，讀者
+  // 拿到的建議是「裁掉周圍、換一張更清楚的」，而那張圖從頭到尾沒有被解開過，照著
+  // 做幾次都不會成功。抽成具名函式是為了能在 Node 裡驗，decode 需要 Image 與
+  // canvas，測不到，見 tools/test_qrread.mjs。
+  function statusFor(result) {
+    if (result && result.unreadable) return "cantOpen";
+    if (result && result.data) return "done";
+    return "notFound";
   }
 
   function handle(file) {
@@ -676,10 +753,19 @@
       return;
     }
     state.status = "reading";
+    state.format = null;
     render();
-    decode(file).then((result) => {
-      if (!result || !result.data) {
-        state.status = "notFound";
+    decode(file).then(async (result) => {
+      const status = statusFor(result);
+      if (status === "cantOpen") {
+        // 認得出格式就講清楚是哪一種，認不出來只說打不開
+        state.format = sniffFormat(await readHead(file));
+        state.status = status;
+        render();
+        return;
+      }
+      if (status === "notFound") {
+        state.status = status;
         render();
         return;
       }
@@ -720,8 +806,13 @@
     root.appendChild(picker);
     root.appendChild(drop);
 
-    if (state.status === "notFound" || state.status === "notImage") {
-      root.appendChild(el("p", "qd-error", t[state.status]));
+    if (state.status === "notFound" || state.status === "notImage" || state.status === "cantOpen") {
+      // cantOpen 分兩段：第一句說瀏覽器打不開，第二句依格式給下一步。
+      // 認不出格式就只有第一句，不會擺一句猜的建議在那裡。
+      const detail = state.status === "cantOpen" && state.format
+        ? t.cantOpenHint[state.format]
+        : null;
+      root.appendChild(el("p", "qd-error", t[state.status] + (detail ? " " + detail : "")));
     }
 
     if (state.status === "done") {

--- a/tools/test_qrread.mjs
+++ b/tools/test_qrread.mjs
@@ -52,10 +52,30 @@ const harness = `
   ${grab(/^  const DANGEROUS = [\s\S]*?\n  function classify\(text\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  const DOTS = [\s\S]*?\n  function maskRaw\(text, info\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  const STRINGS = \{[\s\S]*?\n  \};/m)}
+  ${grab(/^  function sniffFormat\(bytes\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  function statusFor\(result\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  function drawAndRead\(image, plan, box\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  function decode\(source\) \{[\s\S]*?\n  \}/m)}
   return { SCALE, QUIET, classify, maskRaw, STRINGS, SHORTENERS, TRACKERS,
-           ATTEMPTS, DECODE_BUDGET_MS, boostContrast, planSize };
+           ATTEMPTS, DECODE_BUDGET_MS, boostContrast, planSize, sniffFormat, statusFor, decode };
 `;
-const tool = new Function(harness)();
+// decode 需要 Image 與 URL。這裡只驗「瀏覽器打不開這張圖」那一條，替身讓
+// image.src 一被設定就觸發 onerror，跟 Chrome 拿到 HEIC 時的行為一樣。
+const revoked = [];
+class FailingImage {
+  set src(value) {
+    this._src = value;
+    setTimeout(() => this.onerror && this.onerror(), 0);
+  }
+  get src() { return this._src; }
+}
+// 繼承真的 URL，classify 也靠它解析網址，換成普通物件會把那一整組測試弄壞
+class URLStub extends URL {}
+URLStub.createObjectURL = () => 'blob:stub';
+URLStub.revokeObjectURL = (u) => revoked.push(u);
+const tool = new Function('Image', 'URL', 'document', 'window', harness)(
+  FailingImage, URLStub, { createElement: () => { throw new Error('不該畫布'); } }, {}
+);
 
 // 依 key 取欄位，測試裡到處要用
 const field = (info, key) => (info.fields || []).find((f) => f.key === key);
@@ -90,6 +110,7 @@ const roundTrip = (text, level) => {
   const result = jsQR(img.data, img.width, img.height);
   return result ? result.data : null;
 };
+
 
 let passed = 0;
 let failed = 0;
@@ -493,9 +514,111 @@ test('拉對比是把像素推到純黑與純白', () => {
   ]);
 });
 
+
+// === 瀏覽器打不開的圖 ===
+//
+// iPhone 預設拍的是 HEIC，Safari 以外的瀏覽器多半解不開。原本這條路徑跟「圖裡
+// 沒有 QR code」共用同一句訊息，讀者照著「裁掉周圍、換一張更清楚的」做，做幾次
+// 都不會成功，因為那張圖從頭到尾沒有被解開過。
+
+const bytesOf = (...parts) => {
+  const out = [];
+  for (const part of parts) {
+    if (typeof part === 'string') for (const ch of part) out.push(ch.charCodeAt(0));
+    else out.push(part);
+  }
+  return new Uint8Array(out);
+};
+// ISO-BMFF：前四個 byte 是 box 長度，接著 "ftyp"，再接 brand
+const ftyp = (brand) => bytesOf(0, 0, 0, 0x18, 'ftyp', brand, 0, 0, 0, 0);
+
+test('瀏覽器打不開圖片時，decode 回報的是「打不開」而不是空結果', async () => {
+  // Chrome 拿到 HEIC 就是走這一條：image.onerror 觸發，一個像素都沒讀到。
+  // 回 null 的話 handle 會歸到 notFound，讀者就拿到「裁掉周圍」那句沒用的建議。
+  revoked.length = 0;
+  const result = await tool.decode({});
+  assert.deepEqual(result, { unreadable: true });
+  assert.equal(tool.statusFor(result), 'cantOpen');
+  // 順手驗物件網址有收回去，那一條原本只在 onload 收，onerror 會漏掉
+  assert.deepEqual(revoked, ['blob:stub']);
+});
+
+test('打不開的圖與沒有 QR code 是兩個不同的狀態', () => {
+  assert.equal(tool.statusFor({ unreadable: true }), 'cantOpen');
+  assert.equal(tool.statusFor({ notFound: true }), 'notFound');
+  assert.equal(tool.statusFor(null), 'notFound');
+  assert.equal(tool.statusFor({ data: 'https://anoni.net/' }), 'done');
+});
+
+test('打不開的圖不會退回叫人裁圖的那條訊息', () => {
+  // 這是整個修法的重點：decode 走 onerror 的時候，畫面不能再說「找不到 QR code」
+  const status = tool.statusFor({ unreadable: true });
+  assert.notEqual(status, 'notFound');
+  assert.ok(tool.STRINGS['zh-TW'][status], '狀態要有對應的訊息');
+});
+
+test('iPhone 的 HEIC 認得出來', () => {
+  for (const brand of ['heic', 'heix', 'mif1', 'hevc']) {
+    assert.equal(tool.sniffFormat(ftyp(brand)), 'heic', brand);
+  }
+});
+
+test('AVIF 跟 HEIC 同一種容器，brand 不同要分得開', () => {
+  assert.equal(tool.sniffFormat(ftyp('avif')), 'avif');
+  assert.equal(tool.sniffFormat(ftyp('avis')), 'avif');
+});
+
+test('同一種容器裡的影片不會被當成圖片格式', () => {
+  // mp4 與 HEIC 都是 ISO-BMFF，只有 brand 分得出來
+  assert.equal(tool.sniffFormat(ftyp('isom')), null);
+  assert.equal(tool.sniffFormat(ftyp('mp42')), null);
+});
+
+test('TIFF 兩種位元組順序都認得', () => {
+  assert.equal(tool.sniffFormat(bytesOf(0x49, 0x49, 0x2a, 0x00, 0, 0, 0, 0)), 'tiff');
+  assert.equal(tool.sniffFormat(bytesOf(0x4d, 0x4d, 0x00, 0x2a, 0, 0, 0, 0)), 'tiff');
+});
+
+test('JPEG 2000 認得出來', () => {
+  assert.equal(tool.sniffFormat(bytesOf(0, 0, 0, 0x0c, 'jP  ', 0x0d, 0x0a, 0x87, 0x0a)), 'jp2');
+});
+
+test('瀏覽器打得開的格式不會被誤認', () => {
+  assert.equal(tool.sniffFormat(bytesOf(0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0)), null, 'JPEG');
+  assert.equal(tool.sniffFormat(bytesOf(0x89, 'PNG', 0x0d, 0x0a, 0x1a, 0x0a)), null, 'PNG');
+  assert.equal(tool.sniffFormat(bytesOf('GIF89a', 0, 0)), null, 'GIF');
+  assert.equal(tool.sniffFormat(bytesOf('RIFF', 0, 0, 0, 0, 'WEBP')), null, 'WebP');
+});
+
+test('檔頭太短不會爆掉', () => {
+  assert.equal(tool.sniffFormat(new Uint8Array(0)), null);
+  assert.equal(tool.sniffFormat(bytesOf(0xff, 0xd8)), null);
+});
+
+test('三個語系都有打不開時的訊息與各格式的下一步', () => {
+  for (const lang of ['zh-TW', 'zh', 'en']) {
+    const s = tool.STRINGS[lang];
+    assert.ok(s.cantOpen && s.cantOpen.length > 10, lang + ' cantOpen');
+    for (const fmt of ['heic', 'avif', 'tiff', 'jp2']) {
+      assert.ok(s.cantOpenHint[fmt] && s.cantOpenHint[fmt].length > 10, lang + ' ' + fmt);
+    }
+    // 這一句不該再叫讀者去裁圖，那是 notFound 的建議
+    assert.ok(!/裁|crop/i.test(s.cantOpen), lang + ' 不該叫人裁圖');
+  }
+});
+
+test('HEIC 的下一步要講得出 iPhone 的設定路徑', () => {
+  assert.match(tool.STRINGS['zh-TW'].cantOpenHint.heic, /設定.*相機.*格式/);
+  assert.match(tool.STRINGS['zh'].cantOpenHint.heic, /设置.*相机.*格式/);
+  assert.match(tool.STRINGS['en'].cantOpenHint.heic, /Settings.*Camera.*Formats/);
+});
+
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，
+// 斷言失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，
+// 頂層 await 可以直接用。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {


### PR DESCRIPTION
回報是辨識能力很差。我用合成圖跑了一百多張（斜角 25°、光線漸層、反光、螢幕摩爾紋、位置偏移到角落、CPU 節流 6 倍模擬手機）**全部通過**，重現不出來。追下去發現問題不在解碼器，在錯誤處理。

## 根本原因

`decode` 的 `image.onerror` 直接 `resolve(null)`，`handle` 收到 `null` 就歸到 `notFound`，畫面顯示：

> 這張圖裡找不到 QR code。試試裁掉周圍、或換一張更清楚的。

但那張圖從頭到尾**沒有被解開過，一個像素都沒讀到**。讀者照著裁圖、重拍、靠近拍，做幾次都不會成功，因為問題根本不在那裡。

iPhone 預設拍出來是 HEIC，Safari 以外的瀏覽器多半解不開，走的就是這一條。同一張照片在 Safari 打得開、在 Chrome 或 Android 上顯示「找不到 QR code」，而畫面上沒有任何線索指向格式。

實測（餵一個瀏覽器解不開的 TIFF）：

```
改前  這張圖裡找不到 QR code。試試裁掉周圍、或換一張更清楚的。
改後  你的瀏覽器打不開這張圖，所以還沒開始找 QR code。
      這是 TIFF 格式，瀏覽器一律不顯示。用看圖程式另存成 JPEG 或 PNG 再試。
```

## 改法

`decode` 回 `{ unreadable: true }` 與 `{ notFound: true }` 兩種結果，`statusFor` 對到 `cantOpen` 與 `notFound` 兩個狀態，訊息分開。

再從**檔頭**認格式（`sniffFormat`），認得出來就接一句能照做的下一步：

| 格式 | 下一步 |
|---|---|
| HEIC | 「設定 → 相機 → 格式」選「最相容」，之後拍的就是 JPEG。已經拍好的用 AirDrop 或郵件傳給自己，那個過程多半會轉成 JPEG |
| AVIF | 較舊的瀏覽器還不支援，用看圖程式另存成 JPEG 或 PNG |
| TIFF / JPEG 2000 | 瀏覽器一律不顯示，另存成 JPEG 或 PNG |

認不出來就只有第一句，不擺一句猜的建議在那裡。

`sniffFormat` 認的是 ISO-BMFF 的 **brand** 不是副檔名，因為 HEIC 與 mp4 是同一種容器，只有 brand 分得出來。三語系訊息同步。

順手修掉 `onerror` 沒有 `URL.revokeObjectURL` 的漏失，那一條原本只在 `onload` 收。

## 測試執行器的缺陷

`test_qrread.mjs` 的執行迴圈寫的是 `fn()` 沒有 `await`：

```js
for (const [name, fn] of tests) {
  try {
    fn();                    // ← 非同步測試回一個 promise 就被當成通過
```

非同步的測試函式回一個 promise 就算通過，斷言失敗變成 unhandled rejection，整支照樣印綠色。這次要驗 `decode` 的 `onerror` 才踩到。改成 `await fn()`。

## 驗證

`test_qrread.mjs` 39 → 51 通過。八種弄壞的改法逐一確認測試會抓到：

```
✓ decode 的 onerror 又回 null           ✓ HEIC brand 漏掉 mif1
✓ onerror 忘了收回物件網址              ✓ ftyp 不分 brand 全當 HEIC
✓ statusFor 把打不開歸回 notFound       ✓ TIFF 只認一種位元組順序
✓ cantOpen 訊息又叫人裁圖               ✓ HEIC 建議拿掉 iPhone 設定路徑
```

`decode` 需要 `Image` 與 `URL`，用替身讓 `image.src` 一設定就觸發 `onerror`，跟 Chrome 拿到 HEIC 的行為一樣。`URL` 替身繼承真的 `URL`，因為 `classify` 也靠它解析網址（第一版用普通物件，把 12 個既有測試弄壞了）。

本機建置後用 headless Chrome 走三種輸入，三種都給出不同且可行動的回應：

```
TIFF（解不開）        → 格式訊息 + 轉檔建議
有效 PNG 但沒有碼     → 裁圖建議
正常照片              → 解出：https://anoni.net/docs/utils/qr-read/
```

三語系 `docs_style_lint` 0 error、`check_invisible_chars` 783 檔乾淨、14 支 JS 測試套件全過。

## 還沒做的

同一輪量測發現 jsQR 有硬天花板。在 36 張難度掃描上（px/模組 4→1.3 × 模糊 × 光線漸層）：

| 解碼器 | 成功 | 單張耗時 |
|---|---|---|
| 現行 jsQR 五階 | 11/36 | 250–1100ms |
| jsQR + unsharp 前處理 | 13/36 | 相近 |
| zxing-wasm | **16/36** | **67–90ms** |

換成 zxing 要多 vendor 一個 919 KB 的 wasm 並納入離線快取，做成「jsQR 先試、失敗才動態載入」，另外開一支處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
