### PR TITLE
perf(ci): Cloudflare 快取清除改成並行送出，58 秒降到 10 秒

### DIFF
--- a/tools/cf_purge.py
+++ b/tools/cf_purge.py
@@ -31,6 +31,7 @@ anoni.net 這個 zone 底下還有主站、pad、form、search 等服務，`purg
 from __future__ import annotations
 
 import argparse
+import concurrent.futures as futures
 import json
 import os
 import sys
@@ -42,6 +43,10 @@ from urllib.parse import quote
 
 # Pro 方案 purge by URL 的單次上限。Enterprise 是 500，改方案時記得一起調。
 BATCH_SIZE = 30
+
+# 同時送幾批。Cloudflare 的 purge_cache 限制是每個 zone 每分鐘 1000 次呼叫，站上
+# 四十幾批離上限很遠，這個數字是為了不要在對方那邊排隊，不是為了逼近限制。
+MAX_WORKERS = 6
 API = "https://api.cloudflare.com/client/v4/zones/{zone}/purge_cache"
 DEFAULT_BASE_URL = "https://anoni.net/docs"
 
@@ -143,15 +148,41 @@ def main() -> int:
         )
         return 0
 
-    for i, chunk in enumerate(batches, 1):
-        try:
-            purge_batch(zone, token, chunk)
-        except RuntimeError as exc:
-            print(f"::error::第 {i}/{len(batches)} 批清除失敗：{exc}", file=sys.stderr)
-            return 1
-        print(f"  第 {i}/{len(batches)} 批完成（{len(chunk)} 條）")
+    return run_batches(zone, token, batches, len(urls), args.base_url)
 
-    print(f"Cloudflare 快取已清除，共 {len(urls)} 個 {args.base_url} 底下的網址")
+
+def run_batches(zone: str, token: str, batches, url_count: int, base_url: str) -> int:
+    """把每一批送出去，錯一批就整支失敗。
+
+    原本是逐批循序呼叫。四十幾批、每批往返一秒多，光清快取就花掉部署的五分之一。
+    改成同時送幾批，實際的清除工作在 Cloudflare 那邊本來就是各自獨立的。
+
+    失敗的處理跟循序版一樣：任何一批失敗就回 1，讓建置變紅燈。差別是已經送出去的
+    批次會讓它跑完再回報，中途硬停只會讓清除的範圍更難講清楚。
+    """
+    failed: list[str] = []
+    done = 0
+    with futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        pending = {
+            pool.submit(purge_batch, zone, token, chunk): (i, chunk)
+            for i, chunk in enumerate(batches, 1)
+        }
+        for fut in futures.as_completed(pending):
+            i, chunk = pending[fut]
+            done += 1
+            try:
+                fut.result()
+            except RuntimeError as exc:
+                failed.append(f"第 {i}/{len(batches)} 批清除失敗：{exc}")
+                continue
+            print(f"  {done}/{len(batches)} 批完成（第 {i} 批，{len(chunk)} 條）")
+
+    if failed:
+        for line in failed:
+            print(f"::error::{line}", file=sys.stderr)
+        return 1
+
+    print(f"Cloudflare 快取已清除，共 {url_count} 個 {base_url} 底下的網址")
     return 0
 
 

--- a/tools/test_cf_purge.py
+++ b/tools/test_cf_purge.py
@@ -16,6 +16,7 @@ import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
+import cf_purge  # noqa: E402
 from cf_purge import BATCH_SIZE, batched, collect_urls, to_url  # noqa: E402
 
 BASE = "https://anoni.net/docs"
@@ -120,12 +121,68 @@ def test_batched() -> None:
     check("batched 空清單", list(batched([], BATCH_SIZE)), [])
 
 
+# === 並行送出 ===
+#
+# 逐批循序呼叫時，四十幾批每批往返一秒多，光清快取就吃掉部署的五分之一。改成並行
+# 之後，「錯一批就整支失敗」與「每一批都送到」這兩件事要有測試守著，不然清一半
+# 也會是綠燈，而漏清的症狀是訪客看到舊內容，不會有人立刻發現。
+
+def _fake_purge(sent, fail_on=()):
+    import threading
+    lock = threading.Lock()
+
+    def fake(zone, token, urls, attempts=3):
+        with lock:
+            sent.append(tuple(urls))
+        if urls[0] in fail_on:
+            raise RuntimeError("boom")
+
+    return fake
+
+
+def _run(batches, fail_on=()):
+    sent = []
+    original = cf_purge.purge_batch
+    cf_purge.purge_batch = _fake_purge(sent, fail_on)
+    try:
+        code = cf_purge.run_batches("z", "t", batches, sum(len(b) for b in batches), BASE)
+    finally:
+        cf_purge.purge_batch = original
+    return code, sent
+
+
+def test_run_batches_sends_every_batch() -> None:
+    batches = [[f"{BASE}/p{i}/"] for i in range(50)]
+    code, sent = _run(batches)
+    check("全部成功時回 0", code, 0)
+    check("每一批都送到", len(sent), 50)
+    check("沒有漏件", sorted(x for c in sent for x in c),
+          sorted(x for c in batches for x in c))
+
+
+def test_run_batches_fails_when_any_batch_fails() -> None:
+    batches = [[f"{BASE}/p{i}/"] for i in range(20)]
+    code, sent = _run(batches, fail_on={f"{BASE}/p7/"})
+    check("有一批失敗就回 1", code, 1)
+    # 已經送出去的讓它跑完，中途硬停只會讓清除範圍更難講清楚
+    check("其餘批次照樣送完", len(sent), 20)
+
+
+def test_run_batches_empty() -> None:
+    code, sent = _run([])
+    check("沒有東西要清時回 0", code, 0)
+    check("沒有呼叫", sent, [])
+
+
 def main() -> int:
     for fn in [
         test_to_url,
         test_to_url_encodes_special_chars,
         test_collect_urls,
         test_batched,
+        test_run_batches_sends_every_batch,
+        test_run_batches_fails_when_any_batch_fails,
+        test_run_batches_empty,
     ]:
         fn()
     if failures:


### PR DESCRIPTION
部署量測（見 #323）裡，清 Cloudflare 快取佔 58 秒，是標準那格 298 秒的 19%。

cf_purge.py 把產物映射成約 1440 個網址，每批 30 條分成 48 批，原本逐批循序呼叫，
每批往返約 1.2 秒。清除工作在 Cloudflare 那邊本來就是各自獨立的，沒有理由排隊。

改用 ThreadPoolExecutor 同時送 6 批。用實測的往返延遲模擬 48 批：

```
循序                57.6s
並行（6 workers）    9.6s
省下 48.0s（83%）
```

worker 數取 6 不是為了逼近上限。Cloudflare 的 purge_cache 限制是每個 zone 每分鐘
1000 次呼叫，48 批離上限很遠，這個數字只是為了不要在對方那邊排隊。

## 失敗處理

跟循序版一樣：任何一批失敗就回 1，讓建置變紅燈。差別是已經送出去的批次會讓它跑完
再回報，中途硬停只會讓清除的範圍更難講清楚。重試邏輯（400/401/403 直接放棄、其餘
退避重試三次）沒有動。

## 測試

purge_batch 換成替身，補三個案例：

- 全部成功時回 0，而且每一批都送到、沒有漏件
- 有一批失敗就回 1，其餘批次照樣送完
- 沒有東西要清時回 0

三種弄壞的改法逐一確認測試會抓到：失敗被吞掉照樣回 0、只送前十批、fut.result()
沒被呼叫導致例外被吞。漏清的症狀是訪客看到舊內容，不會有人立刻發現，所以這幾條
值得守著。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
