### PR TITLE
fix(ci): Cloudflare 清除補上 index.html 那個網址形式

### DIFF
--- a/tools/cf_purge.py
+++ b/tools/cf_purge.py
@@ -62,13 +62,35 @@ def to_url(rel_path: Path, base_url: str) -> str:
     return f"{base_url}/{tail}"
 
 
+def to_urls(rel_path: Path, base_url: str) -> list[str]:
+    """一個產物檔案對應的所有網址形式。
+
+    `index.html` 有兩個網址指向同一份內容：目錄式的 `/a/b/` 與檔案式的
+    `/a/b/index.html`。Cloudflare 把它們當成兩個獨立的快取項目，只清一個，另一個
+    會無限期留著舊內容。
+
+    站內連結全是目錄式的，所以檔案式那個平常沒人打得到，問題出在搜尋引擎收錄過、
+    或有人存了舊書籤。2026-08-22 抽驗正式站時就撞到：目錄式網址與新產物一致，
+    檔案式的同一頁還是上一版，`cf-cache-status` 是 HIT。
+
+    無結尾斜線的 `/a/b` 不在這裡，nginx 對它發 302 轉到目錄式網址，轉址的目標
+    每次都會被清，內容不會過期。
+    """
+    canonical = to_url(rel_path, base_url)
+    parts = list(rel_path.parts)
+    if parts and parts[-1] == "index.html":
+        return [canonical, canonical + "index.html"]
+    return [canonical]
+
+
 def collect_urls(output_dir: Path, base_url: str) -> list[str]:
     """列出這份產物對應的所有網址，含不帶結尾斜線的網站根路徑。"""
     base_url = base_url.rstrip("/")
     urls = {
-        to_url(p.relative_to(output_dir), base_url)
+        url
         for p in output_dir.rglob("*")
         if p.is_file()
+        for url in to_urls(p.relative_to(output_dir), base_url)
     }
     # nginx 對 `/docs`（無結尾斜線）自己發 301，那個回應也會進 edge 快取。
     urls.add(base_url)

--- a/tools/test_cf_purge.py
+++ b/tools/test_cf_purge.py
@@ -17,7 +17,7 @@ import tempfile
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 import cf_purge  # noqa: E402
-from cf_purge import BATCH_SIZE, batched, collect_urls, to_url  # noqa: E402
+from cf_purge import BATCH_SIZE, batched, collect_urls, to_url, to_urls  # noqa: E402
 
 BASE = "https://anoni.net/docs"
 
@@ -70,6 +70,26 @@ def test_to_url_encodes_special_chars() -> None:
     )
 
 
+def test_to_urls_covers_both_shapes() -> None:
+    """index.html 有兩個網址指向同一份內容，只清一個另一個會留著舊的。
+
+    2026-08-22 抽驗正式站時撞到：目錄式網址與新產物一致，檔案式的同一頁還是上一版，
+    cf-cache-status 是 HIT。站內連結都是目錄式，所以平常看不出來。
+    """
+    import pathlib as _p
+    check("首頁兩種形式", to_urls(_p.Path("index.html"), BASE),
+          [f"{BASE}/", f"{BASE}/index.html"])
+    check("一般頁面兩種形式", to_urls(_p.Path("basics/index.html"), BASE),
+          [f"{BASE}/basics/", f"{BASE}/basics/index.html"])
+    check("多層路徑", to_urls(_p.Path("zh-cn/utils/qrcode/index.html"), BASE),
+          [f"{BASE}/zh-cn/utils/qrcode/", f"{BASE}/zh-cn/utils/qrcode/index.html"])
+    # 不是 index.html 的只有一個網址，不能無中生有
+    check("404.html 只有一個", to_urls(_p.Path("404.html"), BASE), [f"{BASE}/404.html"])
+    check("靜態資產只有一個", to_urls(_p.Path("assets/x.css"), BASE), [f"{BASE}/assets/x.css"])
+    # to_url 仍然回目錄式那一個，它是站內連結用的正規形式
+    check("to_url 維持正規形式", to_url(_p.Path("basics/index.html"), BASE), f"{BASE}/basics/")
+
+
 def test_collect_urls() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = pathlib.Path(td)
@@ -97,6 +117,11 @@ def test_collect_urls() -> None:
                 f"{BASE}/basics/",
                 f"{BASE}/zh-cn/",
                 f"{BASE}/en/",
+                # 每個 index.html 的檔案式網址是獨立的快取項目，見 to_urls
+                f"{BASE}/index.html",
+                f"{BASE}/basics/index.html",
+                f"{BASE}/zh-cn/index.html",
+                f"{BASE}/en/index.html",
                 f"{BASE}/404.html",
                 f"{BASE}/stylesheets/extra.css",
                 f"{BASE}/assets/stylesheets/main.484c7ddc.min.css",
@@ -178,6 +203,7 @@ def main() -> int:
     for fn in [
         test_to_url,
         test_to_url_encodes_special_chars,
+        test_to_urls_covers_both_shapes,
         test_collect_urls,
         test_batched,
         test_run_batches_sends_every_batch,


### PR DESCRIPTION
#325 部署後抽驗正式站，46 個檔案裡有 5 個跟本機產物不一致。追下去發現不是漏傳，
是 Cloudflare 上有一份從來沒被清過的舊副本。

```
.../mistaken-for-anonymity/            與本機一致
.../mistaken-for-anonymity/index.html  不同，cf-cache-status: HIT
```

加隨機 query 繞過快取直接取源站，三個抽驗的內容全部與本機一致，所以 S3 是對的。

cf_purge.py 的 to_url 把 `a/b/index.html` 映射成目錄式網址 `a/b/`，而 Cloudflare
把 `a/b/` 與 `a/b/index.html` 當成兩個獨立的快取項目。只清前者，後者會無限期留著
舊內容，因為沒有任何東西去清它。

站內連結全是目錄式的，所以平常看不出來。會打到檔案式網址的是搜尋引擎收錄過的舊
連結、或有人存的舊書籤，那些人拿到的是過期的頁面。

## 改法

新增 to_urls()，index.html 同時產出兩種形式，其餘檔案維持一個。to_url 保留原樣，
它是站內連結用的正規形式，測試也還在用。

無結尾斜線的 `/a/b` 不加。實測 nginx 對它發 302 轉到目錄式網址，而轉址的目標每次
都會被清，內容不會過期。

網址數 2261 → 3054，批數 76 → 102。以 #324 的 6 條並行，多約 4 秒。

## 測試

補一個案例涵蓋兩種形式、多層路徑，以及「非 index.html 的檔案不能無中生有多一個
網址」。既有的 collect_urls 期望值一併更新。

三種弄壞的改法確認測試會抓到：只回目錄式、非 index 也硬加 index.html、
collect_urls 沒走 to_urls。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
