### PR TITLE
fix(utils): 補上 en 版指紋頁漏掉的瀏覽器決策表

### DIFF
--- a/docs/en/utils/leaks.md
+++ b/docs/en/utils/leaks.md
@@ -70,7 +70,14 @@ Menu paths shift between system and browser versions. Searching the settings for
 
 ### The single most effective step is changing browser
 
-One action covers more items than anything else: use a browser with built-in defences.
+One action covers more items than anything else: use a browser with built-in defences. Three choices, for three situations:
+
+| Your situation | Choice | Cost |
+|---|---|---|
+| An adversary able to spend resources on a specific target | [Tor Browser](../tools/what-is-tor.md) | Slower connections, some sites refuse to load |
+| Leaving fewer traces in everyday browsing | Brave | Noise or normalisation for canvas, WebGL, fonts and audio, far less disruption |
+| Staying on the Firefox you already use | Turn on `privacy.resistFingerprinting` | Only reachable through `about:config`, and it breaks the layout of some sites |
+
 
 [Tor Browser](../tools/what-is-tor.md) normalises nearly every item above, at the cost of slower connections and some sites refusing to load. Brave adds noise or normalisation for canvas, WebGL, fonts and audio, with far less disruption to everyday browsing. Firefox has `privacy.resistFingerprinting`, close to Tor Browser's approach. It only appears if you type `about:config` into the address bar, and it is off by default. That settings page opens with a warning of its own, and changing other entries there can affect how the browser behaves elsewhere, so if `about:config` is unfamiliar territory, Tor Browser or Brave is the simpler route. Enabling it also breaks the layout of some sites.
 


### PR DESCRIPTION
## 問題

#329 把「效益最高的一步是換瀏覽器」那段散文改成「你的情況、選擇、代價」三欄的表格，zh-TW 與 zh-CN 都進去了，en 版沒有。上線後逐語系用 curl 驗證才發現。

## 原因

當時的批次腳本對每個語系跑兩個替換、最後才寫檔：

```python
for lang in (...):
    t = p.read_text()
    for old, new in (TABLE[lang], WHEN[lang]):
        assert old in t
        t = t.replace(old, new, 1)
    p.write_text(t)      # ← 迴圈的最後才寫
```

en 的第二個替換（`WHEN`）因為原文句子與我預期的不同而 assert 中止，於是第一個替換（`TABLE`）也跟著沒有落地。後續補做時我只補了中止的那一個，沒有回頭確認第一個。

教訓是這種「先全部替換、最後一次寫檔」的寫法，中途失敗會把同一輪已完成的部分一起丟掉，而補救時很容易只看失敗的那一項。

## 內容

與另外兩個語系相同，Tor Browser、Brave 與 Firefox 的 `resistFingerprinting` 各對應一種處境與代價。

## 檢查

- `docs_style_lint.py` 0 error 0 warn
- `node tools/test_leaks.mjs` 21 通過
- `sh run_en.sh` 建置 exit 0，產物 `output/en/utils/leaks/index.html` 裡確認有表格

🤖 Generated with [Claude Code](https://claude.com/claude-code)