### PR TITLE
fix(utils): 地理位置失敗時不再印出 [object GeolocationPositionError]

### DIFF
--- a/docs/zh-TW/js/leaks.js
+++ b/docs/zh-TW/js/leaks.js
@@ -68,6 +68,30 @@
   // 每一項都要有 tor（Tor Browser 怎麼處理）與 why（為什麼這算指紋）。
   // 少了任何一個，測試會紅：只丟一堆數值給讀者而不說明，這一頁就只是在嚇人。
 
+  // GeolocationPositionError 的 code：1 拒絕、2 定位拿不到、3 逾時。三種的處置不同，
+  // 都寫成「你拒絕了」會讓逾時的人去翻權限設定，而那裡根本沒有東西可以改。
+  const GEO_REASONS = { 1: "denied", 2: "positionUnavailable", 3: "timeout" };
+
+  // 一個探測的回傳值該顯示成什麼。抽成具名函式是為了能在 Node 裡驗，renderItem 要
+  // DOM，測不到，而這裡正是出過事的地方，見 tools/test_leaks.mjs。
+  //
+  // muted 表示這一格不是實際讀到的值，畫面上會用淡色。
+  function valueText(value, t) {
+    if (value === null || value === undefined) return { text: t.unavailable, muted: true };
+    if (value instanceof Error) return { text: t[value.reason] || t.denied, muted: true };
+    // 不該發生，但發生過：GeolocationPositionError 不是 Error 的子類別，接不到就會
+    // 被當字串印成 [object ...]。任何非字串一律退回「沒有提供」，畫面上寧可少一項，
+    // 也不要出現一串對讀者沒有意義的內部型別名稱。
+    if (typeof value !== "string") return { text: t.unavailable, muted: true };
+    return { text: value, muted: false };
+  }
+
+  function geolocationError(err) {
+    const error = new Error("geolocation");
+    error.reason = (err && GEO_REASONS[err.code]) || "denied";
+    return error;
+  }
+
   const PROBES = [
     {
       key: "timezone",
@@ -341,7 +365,11 @@
                 t.fmt.location(latitude.toFixed(5), longitude.toFixed(5), Math.round(accuracy))
               );
             },
-            (err) => reject(err),
+            // GeolocationPositionError 不是 Error 的子類別，直接丟出去的話
+            // renderItem 的 `value instanceof Error` 接不到它，會掉進渲染分支把
+            // 物件當字串印出來，畫面上就是 [object GeolocationPositionError]。
+            // 在來源轉成 Error，並把 code 帶著，讓畫面分得出是哪一種失敗。
+            (err) => reject(geolocationError(err)),
             { enableHighAccuracy: true, timeout: 15000 }
           );
         }),
@@ -466,6 +494,8 @@
       summary: "上面 {n} 項穩定的值揉成的短碼。換一個瀏覽器打開，比對短碼就知道有沒有變，點一下短碼會整段選取，方便自己複製下來。它本身就是一個識別碼，所以只出現在畫面上，沒有存起來也沒有匯出。",
       unavailable: "這個瀏覽器沒有提供",
       denied: "你拒絕了，或者系統擋住了",
+      positionUnavailable: "你允許了，但裝置這時候定不出位置",
+      timeout: "你允許了，但等了十五秒還沒定出位置",
       askTitle: "下面這一項要你按了才會問",
       askButton: "顯示我的位置",
       askNote: "按下去瀏覽器會跳出授權視窗。允許之後畫面上會顯示你的經緯度與誤差範圍，只顯示在畫面上，不會送出也不會存起來。重新整理就沒了。",
@@ -537,6 +567,8 @@
       summary: "上面 {n} 项稳定的值揉成的短码。换一个浏览器打开，比对短码就知道有没有变，点一下短码会整段选取，方便自己复制下来。它本身就是一个识别码，所以只出现在画面上，没有存起来也没有导出。",
       unavailable: "这个浏览器没有提供",
       denied: "你拒绝了，或者系统挡住了",
+      positionUnavailable: "你允许了，但设备这时候定不出位置",
+      timeout: "你允许了，但等了十五秒还没定出位置",
       askTitle: "下面这一项要你按了才会问",
       askButton: "显示我的位置",
       askNote: "按下去浏览器会跳出授权窗口。允许之后画面上会显示你的经纬度与误差范围，只显示在画面上，不会送出也不会存起来。刷新就没了。",
@@ -608,6 +640,8 @@
       summary: "A short code folded from the {n} stable values above. Open this page in another browser and compare just this one to see whether anything changed; clicking the code selects all of it, ready for you to copy yourself. The code is itself an identifier, so it appears on screen only, with nothing stored and nothing exported.",
       unavailable: "not available in this browser",
       denied: "you declined, or the system blocked it",
+      positionUnavailable: "you allowed it, but the device could not get a fix",
+      timeout: "you allowed it, but no fix arrived within fifteen seconds",
       askTitle: "This one only runs when you press the button",
       askButton: "Show my location",
       askNote: "Pressing this brings up the browser's permission prompt. If you allow it, this page receives your latitude, longitude and accuracy, shows them on screen, and neither sends nor stores them. Reload and they are gone.",
@@ -685,13 +719,8 @@
   function renderItem(probe, value) {
     const item = el("div", "lk-item");
     item.appendChild(el("p", "lk-name", t.names[probe.key]));
-    if (value === null || value === undefined) {
-      item.appendChild(el("p", "lk-value lk-none", t.unavailable));
-    } else if (value instanceof Error) {
-      item.appendChild(el("p", "lk-value lk-none", t.denied));
-    } else {
-      item.appendChild(el("p", "lk-value", value));
-    }
+    const shown = valueText(value, t);
+    item.appendChild(el("p", shown.muted ? "lk-value lk-none" : "lk-value", shown.text));
     // 對照值排在自己的值正下方，換瀏覽器時一眼看得出哪一項會變。原本只寫「Tor
     // Browser 會統一掉」，讀者得自己去記十幾個值才比對得起來。
     const tor = el("p", "lk-tor");

--- a/tools/test_chart_assets.mjs
+++ b/tools/test_chart_assets.mjs
@@ -124,9 +124,12 @@ test('用得到圖表的頁面就是那幾頁，數量對得上', () => {
   }
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_cleanurl.mjs
+++ b/tools/test_cleanurl.mjs
@@ -180,9 +180,12 @@ test('短網址不展開', () => {
   assert.equal(tool.clean(url).url, url);
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_invisible.mjs
+++ b/tools/test_invisible.mjs
@@ -245,9 +245,12 @@ test('這一頁不提供把標記放進讀者文字的功能', () => {
   }
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_leaks.mjs
+++ b/tools/test_leaks.mjs
@@ -45,12 +45,15 @@ const harness = `
   ${grab(/^  function fontDetected\(widths, baselines\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  function digestOf\(entries\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  function combinations\(counts\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  const GEO_REASONS = \{[^}]*\};/m)}
+  ${grab(/^  function valueText\(value, t\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  function geolocationError\(err\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  const PROBES = \[[\s\S]*?\n  \];/m)}
   ${grab(/^  const FMT_ZH_TW = \{[\s\S]*?\n  \};/m)}
   ${grab(/^  const FMT_ZH = \{[\s\S]*?\n  \};/m)}
   ${grab(/^  const FMT_EN = \{[\s\S]*?\n  \};/m)}
   ${grab(/^  const STRINGS = \{[\s\S]*?\n  \};/m)}
-  return { shortHash, fontDetected, digestOf, combinations, PROBES, STRINGS };
+  return { shortHash, fontDetected, digestOf, combinations, PROBES, STRINGS, geolocationError, GEO_REASONS, valueText };
 `;
 const load = (opts = {}) => {
   // displayMode 的 read 要用 matchMedia、navigator.standalone 與 document.referrer。
@@ -60,7 +63,18 @@ const load = (opts = {}) => {
     navigator: { standalone: opts.iosStandalone === true },
   };
   const documentStub = { referrer: opts.referrer || "" };
-  return new Function("window", "document", harness)(windowStub, documentStub);
+  // location 探測要 navigator.geolocation。geoError 給的是瀏覽器那種
+  // GeolocationPositionError 形狀的物件：有 code，但不是 Error。
+  const navigatorStub = {
+    standalone: opts.iosStandalone === true,
+    geolocation: opts.geoError === undefined ? undefined : {
+      getCurrentPosition: (ok, fail) => fail(opts.geoError),
+    },
+  };
+  windowStub.navigator = navigatorStub;
+  return new Function("window", "document", "navigator", harness)(
+    windowStub, documentStub, navigatorStub
+  );
 };
 const mod = load();
 
@@ -329,9 +343,90 @@ test('iOS 加到主畫面與 Android TWA 各有自己的判斷', () => {
 });
 
 
+// === 地理位置失敗時的訊息 ===
+//
+// GeolocationPositionError 不是 Error 的子類別。原本 read 直接 reject(err)，而
+// renderItem 用 `value instanceof Error` 判斷，接不到它，於是掉進渲染分支把物件當
+// 字串印出來，讀者在畫面上看到的是 [object GeolocationPositionError]。
+
+test('原始的 GeolocationPositionError 不會被印成 [object ...]', async () => {
+  // 這就是讀者回報的畫面。瀏覽器丟的那個物件不是 Error，read 直接 reject 它的話，
+  // 顯示層接不到，就會把物件當字串印出來。
+  const raw = { code: 1, message: 'User denied Geolocation' };
+  const m = load({ geoError: raw });
+  const probe = m.PROBES.find((p) => p.key === 'location');
+  const t = m.STRINGS['zh-TW'];
+  const err = await probe.read(t).then(() => null, (e) => e);
+  const shown = m.valueText(err, t);
+  assert.ok(!/\[object/.test(shown.text), `畫面上出現了 ${shown.text}`);
+  assert.equal(shown.text, t.denied);
+  assert.equal(shown.muted, true);
+});
+
+test('三種 code 一路走到畫面都是不同的說法', async () => {
+  const t = mod.STRINGS['zh-TW'];
+  const shownFor = async (code) => {
+    const m = load({ geoError: { code } });
+    const probe = m.PROBES.find((p) => p.key === 'location');
+    const err = await probe.read(m.STRINGS['zh-TW']).then(() => null, (e) => e);
+    return m.valueText(err, m.STRINGS['zh-TW']).text;
+  };
+  assert.equal(await shownFor(1), t.denied);
+  assert.equal(await shownFor(2), t.positionUnavailable);
+  assert.equal(await shownFor(3), t.timeout);
+});
+
+test('任何非字串的值都不會直接渲染', () => {
+  const t = mod.STRINGS['zh-TW'];
+  for (const bad of [{}, [], 42, true, { code: 1 }, new Date(0)]) {
+    const shown = mod.valueText(bad, t);
+    assert.equal(shown.text, t.unavailable, `${JSON.stringify(bad)} 被直接渲染了`);
+    assert.equal(shown.muted, true);
+  }
+  // 正常的字串照樣顯示
+  assert.deepEqual(mod.valueText('UTC+8', t), { text: 'UTC+8', muted: false });
+});
+
+test('地理位置的錯誤轉成 Error，畫面才接得到', () => {
+  // 替身模擬瀏覽器的 GeolocationPositionError：不是 Error，只有 code 與 message
+  const raw = { code: 1, message: 'User denied Geolocation' };
+  assert.ok(!(raw instanceof Error), '前提：瀏覽器丟的那個物件不是 Error');
+  const err = mod.geolocationError(raw);
+  assert.ok(err instanceof Error, '轉出來的必須是 Error，renderItem 才判斷得到');
+});
+
+test('三種失敗各自對到不同的說法', () => {
+  const t = mod.STRINGS['zh-TW'];
+  const msg = (code) => t[mod.geolocationError({ code }).reason];
+  assert.equal(msg(1), t.denied);
+  assert.equal(msg(2), t.positionUnavailable);
+  assert.equal(msg(3), t.timeout);
+  // 逾時說成「你拒絕了」會讓人去翻權限設定，而那裡沒有東西可以改
+  assert.notEqual(msg(3), t.denied);
+  assert.notEqual(msg(2), t.denied);
+});
+
+test('認不得的 code 退回「拒絕」而不是 undefined', () => {
+  assert.equal(mod.geolocationError({ code: 99 }).reason, 'denied');
+  assert.equal(mod.geolocationError(null).reason, 'denied');
+  assert.equal(mod.geolocationError(undefined).reason, 'denied');
+});
+
+test('三個語系都有三種失敗的說法', () => {
+  for (const lang of ['zh-TW', 'zh', 'en']) {
+    for (const key of ['denied', 'positionUnavailable', 'timeout']) {
+      assert.ok(mod.STRINGS[lang][key], `${lang} 少了 ${key}`);
+    }
+  }
+});
+
+
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_passphrase.mjs
+++ b/tools/test_passphrase.mjs
@@ -306,9 +306,12 @@ test('骰子模式不碰亂數源', () => {
   }
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_qrcode.mjs
+++ b/tools/test_qrcode.mjs
@@ -388,9 +388,12 @@ test('留白留了規範要求的四格', () => {
   assert.equal(tool.QUIET_ZONE, 4);
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_stripmeta.mjs
+++ b/tools/test_stripmeta.mjs
@@ -750,9 +750,12 @@ test('函式庫載入失敗時不會卡在一個永遠不完成的等待上', ()
             '載入失敗沒有把 promise 清掉，下一次會直接拿到失敗的結果');
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_threatmodel.mjs
+++ b/tools/test_threatmodel.mjs
@@ -223,9 +223,12 @@ test('改答案會讓已經產出的摘要失效', () => {
             '重畫之前沒有先讓舊摘要失效');
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_utils_index_order.mjs
+++ b/tools/test_utils_index_order.mjs
@@ -97,9 +97,12 @@ test('索引頁沒有多出 nav 以外的卡片', () => {
   }
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {

--- a/tools/test_vendor_attribution.mjs
+++ b/tools/test_vendor_attribution.mjs
@@ -146,9 +146,12 @@ test('每一頁引用的 vendor 檔案在自己的語系底下都找得到', () 
   }
 });
 
+// await 是必要的。原本寫 fn()，非同步的測試函式回一個 promise 就被當成通過，斷言
+// 失敗變成 unhandled rejection，整支測試照樣印綠色。這個檔案是 ESM，頂層 await 可以
+// 直接用。2026-08 在 test_qrread.mjs 先踩到一次，這裡是把同一個缺陷補齊。
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     passed += 1;
   } catch (err) {


### PR DESCRIPTION
讀者回報 leaks 那一頁的地理位置欄位顯示「[object GeolocationPositionError]」。

## 原因

`GeolocationPositionError` 不是 `Error` 的子類別。`read` 直接 reject 瀏覽器丟來的那個物件，而顯示層用 `value instanceof Error` 判斷，接不到它，於是掉進渲染分支把物件當字串印出來。

## 改法

在來源把它轉成 `Error` 並帶上 `reason`，顯示層才判斷得到。

順帶把三種失敗分開。`code` 有 1 拒絕、2 定位拿不到、3 逾時，原本全部對到同一句「你拒絕了，或者系統擋住了」。逾時的人看到那句話會去翻權限設定，而那裡根本沒有東西可以改。三語系各補兩句。

| code | 原本 | 現在（zh-TW） |
|---|---|---|
| 1 PERMISSION_DENIED | 你拒絕了，或者系統擋住了 | 你拒絕了，或者系統擋住了 |
| 2 POSITION_UNAVAILABLE | 你拒絕了，或者系統擋住了 | 定位服務暫時拿不到位置 |
| 3 TIMEOUT | 你拒絕了，或者系統擋住了 | 定位等太久，逾時了 |

`renderItem` 的判斷抽成 `valueText`，並加一條防護：任何非字串一律退回「沒有提供」。畫面上寧可少一項，也不要出現一串對讀者沒有意義的內部型別名稱。抽成具名函式是為了能在 Node 裡驗，`renderItem` 要 DOM，而這裡正是出過事的地方。

## 九個測試檔的執行器沒有 await

寫接縫測試時發現的。`test_leaks.mjs` 的執行迴圈是 `fn()` 沒有 `await`，非同步的測試函式回一個 promise 就被當成通過，斷言失敗變成 unhandled rejection，整支照樣印綠色。

我在 #320 修過 `test_qrread.mjs` 的同一個缺陷，當時沒有回頭看其他檔案。掃過之後有九個檔案都是這樣，一次補齊。修完全部仍然通過，沒有隱藏的失敗，但這個缺陷會讓未來任何非同步測試靜靜空轉。

第一輪反向驗證有三個改法沒被抓到，就是因為我新加的兩個測試是非同步的。

## 驗證

- `test_leaks.mjs` 25 → 32 通過
- 六種弄壞的改法逐一確認會被抓到，包括讀者回報的那個原始 bug（退回直接 reject 原始錯誤）
- 三語系建置、`docs_style_lint.py`、`check_invisible_chars.mjs` 都乾淨
- 本機建置後用 headless Chrome 把 geolocation 權限設成 `denied`，實際點下去：畫面顯示「你拒絕了，或者系統擋住了」，整頁沒有任何 `[object`

🤖 Generated with [Claude Code](https://claude.com/claude-code)