### PR TITLE
fix(pulse): api healthcheck 改探測 readyz，DB 連不上時回 503

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 
 - FastAPI 使用 `root_path="/api"` 設定，所有端點需加上 `/api` 前綴
 - CORS 設定透過環境變數 `CORS_ALLOW_ORIGINS` 和 `CORS_ALLOW_CREDENTIALS` 控制
-- 健康檢查端點：`/api/healthz` (基礎健康) 和 `/api/readyz` (含資料庫檢查)
+- 健康檢查端點：`/api/healthz`（只回版本，不連資料庫）與 `/api/readyz`（每次呼叫都連資料庫，連不上回 503）。容器 healthcheck 探測 `/api/readyz`，`healthz` 綠燈不代表資料查得到
 
 ### 資料庫操作
 

--- a/pulse/CLAUDE.md
+++ b/pulse/CLAUDE.md
@@ -67,6 +67,8 @@ backend/
 
 **API 路由前綴**：`root_path="/api"`，所有端點實際路徑加 `/api`。Swagger UI 在 `GET /api/readme`。
 
+**健康檢查分工**：`/api/healthz` 只回應用程式版本，`/api/readyz` 每次呼叫都開一條 PostgreSQL 連線，連不上回 503。compose 裡 api 的 healthcheck 探測 `readyz`。判斷「圖表沒資料」時看 `readyz`，`healthz` 綠燈只代表 process 還活著。
+
 **Vega 端點**：共 5 個，均接受 `country`（TW/JP/KR/HK enum）和 `limit=45` 參數，回傳 Pydantic model 的 JSON 陣列。
 
 **Cron 設定**：Dockerfile 建置時寫入 `/etc/crontabs/root`，`5 * * * *` 執行四次（各地區），容器重啟時 `@reboot` 也觸發一次。

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -30,7 +30,7 @@ pulse/
 - **完整資料儲存**: PostgreSQL 資料庫儲存中繼節點詳細資訊與歷史紀錄
 - **RESTful API**: FastAPI 提供高效能 REST API
 - **視覺化支援**: Vega-Lite 格式圖表資料端點
-- **健康檢查**: 內建 `/api/healthz` 和 `/api/readyz` 端點（`root_path="/api"`）
+- **健康檢查**: 內建 `/api/healthz` 與 `/api/readyz` 端點（`root_path="/api"`），容器 healthcheck 探測 `/api/readyz`
 - **CORS 支援**: 可配置跨域請求設定
 - **Docker 部署**: 一鍵啟動完整服務
 
@@ -123,15 +123,15 @@ docker-compose down
 - **端點路徑**: `/api/*` (配置 `root_path="/api"`)
 - **文件**: `/api/readme` (Swagger UI)
 - **健康檢查**:
-  - `/api/healthz`: 基本健康檢查
-  - `/api/readyz`: 包含資料庫連線檢查
+  - `/api/healthz`: 基本健康檢查，只回應用程式版本，不連資料庫
+  - `/api/readyz`: 每次呼叫都連線資料庫，連不上回 503。容器 healthcheck 探測這一支
 
 ## 🔧 API 端點
 
 ### 健康檢查
 
-- `GET /api/healthz` - 基本健康檢查
-- `GET /api/readyz` - 就緒檢查（含資料庫連線）
+- `GET /api/healthz` - 基本健康檢查，只回版本，不連資料庫
+- `GET /api/readyz` - 就緒檢查，連線資料庫，連不上回 503
 
 ### Vega-Lite 圖表資料
 
@@ -301,7 +301,7 @@ pulse/
 - **Complete Data Storage**: PostgreSQL database stores relay node details and historical records
 - **RESTful API**: High-performance REST API provided by FastAPI
 - **Visualization Support**: Vega-Lite format chart data endpoints
-- **Health Checks**: Built-in `/healthz` and `/readyz` endpoints
+- **Health Checks**: Built-in `/api/healthz` and `/api/readyz` endpoints; the container healthcheck probes `/api/readyz`
 - **CORS Support**: Configurable cross-origin request settings
 - **Docker Deployment**: One-click launch of complete services
 
@@ -394,15 +394,15 @@ docker-compose down
 - **Endpoint Path**: `/api/*` (configured with `root_path="/api"`)
 - **Documentation**: `/api/readme` (Swagger UI)
 - **Health Checks**:
-  - `/api/healthz`: Basic health check
-  - `/api/readyz`: Readiness check (includes database connection)
+  - `/api/healthz`: Basic health check, reports the app version only, never touches the database
+  - `/api/readyz`: Opens a database connection on every call, answers 503 when it fails. The container healthcheck probes this one
 
 ## 🔧 API Endpoints
 
 ### Health Checks
 
-- `GET /api/healthz` - Basic health check
-- `GET /api/readyz` - Readiness check (includes database connection)
+- `GET /api/healthz` - Basic health check, version only, never touches the database
+- `GET /api/readyz` - Readiness check, opens a database connection, answers 503 when it fails
 
 ### Vega-Lite Chart Data
 

--- a/pulse/backend/api.py
+++ b/pulse/backend/api.py
@@ -15,7 +15,7 @@ import logging
 import os
 
 import psycopg
-from fastapi import FastAPI
+from fastapi import FastAPI, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 
 from routers import vega
@@ -93,7 +93,14 @@ async def healthz():
 
 
 @app.get("/readyz")
-async def readyz():
+async def readyz(response: Response):
+    """
+    Readiness probe. Connects to PostgreSQL on every call.
+
+    Returns 503 when the database is unreachable so that container
+    healthchecks and uptime monitors see the failure. A 200 here means the
+    vega endpoints can actually serve data.
+    """
     if not PG_CONN:
         return {"status": "ok", "db": "skipped"}
     try:
@@ -102,4 +109,5 @@ async def readyz():
         return {"status": "ok", "db": "ok"}
     except Exception:
         logger.exception("DB readiness check failed")
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
         return {"status": "error", "db": "error"}

--- a/pulse/docker-compose.yml
+++ b/pulse/docker-compose.yml
@@ -84,8 +84,11 @@ services:
       CORS_ALLOW_CREDENTIALS: "${CORS_ALLOW_CREDENTIALS:-false}"
     healthcheck:
       # Note: FastAPI is configured with root_path="/api", so health endpoints live under /api/*.
-      test: ["CMD-SHELL", "python3 -c 'import urllib.request; urllib.request.urlopen(\"http://127.0.0.1:8000/api/healthz\", timeout=2).read()'"]
-      interval: 10s
-      timeout: 3s
-      retries: 10
-      start_period: 10s
+      # Probe readyz, not healthz: healthz only reports the app version and stays
+      # green while PostgreSQL is unreachable. readyz opens a real connection and
+      # answers 503 when it fails, which urlopen surfaces as a non-zero exit.
+      test: ["CMD-SHELL", "python3 -c 'import urllib.request; urllib.request.urlopen(\"http://127.0.0.1:8000/api/readyz\", timeout=5).read()'"]
+      interval: 30s
+      timeout: 6s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
## 背景

2026-08-24 發現文件站的 [Tor Relays 觀測點](https://anoni.net/docs/taiwan/tor-relay-watcher/) 六張圖與兩張表全部空白，`/api/vega/tor/relays/*` 五個端點都回 500。

追下去是 `pulse-db-1` 在 2026-07-07 那次 dockerd 重啟後沒有 join 回 `pulse_default` network（`docker inspect` 的 `NetworkSettings.Networks` 是空的），API 與收集器的症狀是：

```
psycopg.OperationalError: failed to resolve host 'db': [Errno -3] Try again
```

連線問題已經用 `docker network connect --alias db pulse_default pulse-db-1` 在 m6 上修好，這個 PR 處理的是另一半：**為什麼斷了 48 天沒人發現**。

## 問題

三個容器在整段期間都顯示 `healthy`：

| 容器 | healthcheck | 為什麼測不出來 |
|------|-------------|----------------|
| `api` | `GET /api/healthz` | 只回 `{"status":"ok","version":...}`，不碰資料庫 |
| `db` | `pg_isready` | 走容器內 localhost，測不到 network 掉了 |
| `backend` | `pidof crond` | crond 活著，每小時十次寫入全數失敗也一樣綠 |

`readyz` 本來就會連資料庫，但失敗時回的是 200 加 `{"status":"error"}`，任何以 HTTP 狀態碼判斷的監控都會當成正常。

## 改動

- `readyz` 在資料庫連不上時回 503，`PG_CONN` 未設定時維持 200 `db: skipped`
- `api` 的 healthcheck 從 `healthz` 改探測 `readyz`；`interval` 10s → 30s（每次呼叫都會開一條真連線，不需要那麼密）、`timeout` 3s → 6s（容納 `connect_timeout=3`）、`retries` 10 → 3
- 同步 `CLAUDE.md`、`pulse/CLAUDE.md`、`pulse/README.md`（中英兩份）的健康檢查說明

這個做法跟 `onionoo-fastapi` 一致：那邊的 `/healthz` 是靜態存活檢查，`/healthz/ready` 打上游、不可達回 503。

## 驗證

```
readyz(DB down)          -> 503 {'status': 'error', 'db': 'error'}
healthz(DB down)         -> 200 {'status': 'ok', 'version': '2026.01.31'}
readyz(PG_CONN 未設定)   -> 200 {'status': 'ok', 'db': 'skipped'}
urlopen 遇到 503 的 exit code = 1   (healthcheck 會判定 unhealthy)
docker compose config    解析正常，跳脫的引號無誤
ruff check / format      All checks passed / 8 files already formatted
```

## 已知範圍

`restart: always` 不會因為 unhealthy 就重啟容器，所以這個改動帶來的是「狀態看得見」，不是自動修復。要能主動通知，還需要把 m6 上的 beszel 接到 `https://anoni.net/api/readyz`。

`backend` 的 `pidof crond` 仍然測不出收集失敗。要補的話得讓 `tor.py` 成功寫入後 touch 一個檔案、healthcheck 檢查 mtime，改動會動到 `tor.py` 與 `Dockerfile`，留待另一個 PR 討論。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
