### PR TITLE
fix(pulse): 圖表端點自帶 Cache-Control，健康檢查改 no-store

### DIFF
--- a/pulse/CLAUDE.md
+++ b/pulse/CLAUDE.md
@@ -67,7 +67,9 @@ backend/
 
 **API 路由前綴**：`root_path="/api"`，所有端點實際路徑加 `/api`。Swagger UI 在 `GET /api/readme`。
 
-**健康檢查分工**：`/api/healthz` 只回應用程式版本，`/api/readyz` 每次呼叫都開一條 PostgreSQL 連線，連不上回 503。compose 裡 api 的 healthcheck 探測 `readyz`。判斷「圖表沒資料」時看 `readyz`，`healthz` 綠燈只代表 process 還活著。
+**健康檢查分工**：`/api/healthz` 只回應用程式版本，`/api/readyz` 每次呼叫都開一條 PostgreSQL 連線，連不上回 503。compose 裡 api 的 healthcheck 探測 `readyz`。判斷「圖表沒資料」時看 `readyz`，`healthz` 綠燈只代表 process 還活著。兩支都送 `Cache-Control: no-store`，否則 CDN 會把某一刻的健康狀態存起來，監控讀到的是過期答案。
+
+**快取兩層**：`vega.py` 的 `TTLCache` 是行程內快取，`cache_headers` 依賴項讓五個圖表端點都送 `Cache-Control: public, max-age=300`，兩者共用 `CACHE_TTL_SECONDS`。沒有這個 header 時 CDN 會套用 zone 預設值（anoni.net 是 4 小時），收集器每小時寫一次，edge 上那份會讓圖表在資料恢復後繼續顯示舊值好幾個小時。查「資料是不是真的沒更新」時先繞過 CDN 打 origin，或加一個隨機查詢參數。
 
 **Vega 端點**：共 5 個，均接受 `country`（TW/JP/KR/HK enum）和 `limit=45` 參數，回傳 Pydantic model 的 JSON 陣列。
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -125,6 +125,7 @@ docker-compose down
 - **健康檢查**:
   - `/api/healthz`: 基本健康檢查，只回應用程式版本，不連資料庫
   - `/api/readyz`: 每次呼叫都連線資料庫，連不上回 503。容器 healthcheck 探測這一支
+  - 兩支都送 `Cache-Control: no-store`，避免 CDN 把健康狀態存起來
 
 ## 🔧 API 端點
 
@@ -132,6 +133,8 @@ docker-compose down
 
 - `GET /api/healthz` - 基本健康檢查，只回版本，不連資料庫
 - `GET /api/readyz` - 就緒檢查，連線資料庫，連不上回 503
+
+圖表端點送 `Cache-Control: public, max-age=300`，與 `vega.py` 行程內的 `TTLCache` 同一個 TTL。健康檢查端點送 `no-store`。
 
 ### Vega-Lite 圖表資料
 
@@ -396,6 +399,7 @@ docker-compose down
 - **Health Checks**:
   - `/api/healthz`: Basic health check, reports the app version only, never touches the database
   - `/api/readyz`: Opens a database connection on every call, answers 503 when it fails. The container healthcheck probes this one
+  - Both send `Cache-Control: no-store` so a CDN never serves a stale health verdict
 
 ## 🔧 API Endpoints
 
@@ -403,6 +407,8 @@ docker-compose down
 
 - `GET /api/healthz` - Basic health check, version only, never touches the database
 - `GET /api/readyz` - Readiness check, opens a database connection, answers 503 when it fails
+
+Chart endpoints send `Cache-Control: public, max-age=300`, the same TTL as the in-process `TTLCache` in `vega.py`. Health endpoints send `no-store`.
 
 ### Vega-Lite Chart Data
 

--- a/pulse/backend/api.py
+++ b/pulse/backend/api.py
@@ -88,7 +88,8 @@ async def main():
 
 
 @app.get("/healthz")
-async def healthz():
+async def healthz(response: Response):
+    response.headers["Cache-Control"] = "no-store"
     return {"status": "ok", "version": app.version}
 
 
@@ -101,6 +102,7 @@ async def readyz(response: Response):
     healthchecks and uptime monitors see the failure. A 200 here means the
     vega endpoints can actually serve data.
     """
+    response.headers["Cache-Control"] = "no-store"
     if not PG_CONN:
         return {"status": "ok", "db": "skipped"}
     try:

--- a/pulse/backend/routers/vega.py
+++ b/pulse/backend/routers/vega.py
@@ -12,18 +12,33 @@ from enum import Enum
 from typing import Any
 
 from cachetools import TTLCache
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel, Field
 
 from pgdb import PGConn
 
-_cache: TTLCache = TTLCache(maxsize=128, ttl=300)
+CACHE_TTL_SECONDS = 300
+
+_cache: TTLCache = TTLCache(maxsize=128, ttl=CACHE_TTL_SECONDS)
+
+
+def cache_headers(response: Response) -> None:
+    """
+    Advertise the same TTL the in-process cache uses.
+
+    Without a Cache-Control header the CDN falls back to the zone default,
+    which is measured in hours. The collector writes hourly, so an edge copy
+    that old shows stale charts long after the data is back.
+    """
+    response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
+
 
 router = APIRouter(
     prefix="/vega",
     tags=[
         "vega",
     ],
+    dependencies=[Depends(cache_headers)],
     responses={status.HTTP_404_NOT_FOUND: {"description": "Not found"}},
 )
 


### PR DESCRIPTION
接續 #339。那個 PR 讓 DB 斷線變得看得見，這個處理另一個把同一次故障延長的環節：CDN 快取。

## 問題

`pulse-db-1` 的 network 在 2026-08-24 修好、collector 也把十個地區的資料寫回 DB 之後，[Tor Relays 觀測點](https://anoni.net/docs/taiwan/tor-relay-watcher/) 的圖表仍然顯示 2026-07-07：

```
cf-cache-status: HIT
cache-control:   max-age=14400
age:             3321
→ [{"created_at":"2026-07-07T00:00:00", ...}]

同一支端點加上 cache-buster：
cf-cache-status: MISS
→ [{"created_at":"2026-08-24T00:00:00","count":11,"running":true}, ...]
```

從 m6 內部直接打 origin，uvicorn 回的 header 只有 `date / server / content-length / content-type`，一個 cache 指示都沒有。Cloudflare 因此套用 zone 預設的 4 小時。收集器每小時寫一次，edge 上壓四小時的那份等於讓圖表落後到四小時前。

健康檢查端點也中一樣的招。診斷過程中 `readyz` 已經恢復 `db: ok`，外部讀到的仍是快取住的 `db: error`，白繞了一段路。監控端點被快取，等於監控失效。

## 改動

- `vega.py` 用 router dependency 統一送 `Cache-Control: public, max-age=300`，五個圖表端點都適用
- 該 TTL 與行程內的 `TTLCache` 共用 `CACHE_TTL_SECONDS`，兩層快取不會各走各的
- `healthz` 與 `readyz` 送 `Cache-Control: no-store`
- `pulse/CLAUDE.md`、`pulse/README.md`（中英）補上兩層快取的說明與「怎麼繞過 CDN 確認資料」

## 驗證

```
vega asn        -> 200  public, max-age=300
/api/healthz    -> 200  no-store
/api/readyz     -> 503  no-store   （DB 連不上，#339 的行為維持）
ruff check      All checks passed!
```

## 部署後要做的事

這個改動只讓 origin 開始送 header，既有的 edge 快取不受影響。合併並在 m6 重建 api 容器之後，還要清一次 `/api/vega/` 的 Cloudflare 快取，或等目前這批自然過期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
