### PR TITLE
fix(pulse): uv 改從官方 image 複製，不再 curl | sh

### DIFF
--- a/pulse/CLAUDE.md
+++ b/pulse/CLAUDE.md
@@ -71,6 +71,8 @@ backend/
 
 **Vega 端點**：共 5 個，均接受 `country`（TW/JP/KR/HK enum）和 `limit=45` 參數，回傳 Pydantic model 的 JSON 陣列。
 
+**uv 來源**：兩個 Dockerfile 都用 `COPY --from=ghcr.io/astral-sh/uv:<版本> /uv /uvx /bin/` 取得 uv，build 期間不連 astral.sh。改回 `curl | sh` 會讓網路失敗變成難查的 `exit code 127`，因為 pipeline 的 exit code 取自 `sh`，curl 的失敗被吞掉，一路走到 `uv sync` 才報錯。升級 uv 就是改那個版本號。
+
 **Cron 設定**：Dockerfile 建置時寫入 `/etc/crontabs/root`，`5 * * * *` 執行四次（各地區），容器重啟時 `@reboot` 也觸發一次。
 
 ## 環境設定

--- a/pulse/backend/Dockerfile
+++ b/pulse/backend/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/astral-sh/uv:0.9.30 AS uvbin
+
 FROM python:3.12.13-alpine3.23
 
 WORKDIR /app
@@ -9,16 +11,17 @@ ADD pyproject.toml \
     tor.py \
     ./
 
-ENV PATH="/root/.local/bin:${PATH}"
+# uv 從官方 image 複製進來，build 不再連 astral.sh。
+#
+# 原本是 curl -LsSf https://astral.sh/uv/install.sh | sh。pipeline 的 exit
+# code 取自 sh，curl 解不到主機名時 sh 讀到空輸入照樣回 0，&& 鏈不會斷，
+# build 一路走到 uv sync 才以 127 收場，訊息完全看不出真正的原因。
+COPY --from=uvbin /uv /uvx /bin/
 
 RUN \
     apk update && apk upgrade && \
     apk add --no-cache ca-certificates && \
-    apk add --no-cache --virtual .build-deps curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv sync && \
-    apk del .build-deps && \
-    cd ~/.cache/ && \
     rm -rf /var/cache/apk/* /var/lib/apk/* /etc/apk/cache/*
 
 RUN \

--- a/pulse/backend/Dockerfile.api
+++ b/pulse/backend/Dockerfile.api
@@ -1,3 +1,5 @@
+FROM ghcr.io/astral-sh/uv:0.9.30 AS uvbin
+
 FROM python:3.12.13-alpine3.23
 
 WORKDIR /app
@@ -8,19 +10,22 @@ ADD pyproject.toml \
     ./
 ADD ./routers ./routers
 
-ENV PATH="/root/.local/bin:${PATH}"
+# uv 從官方 image 複製進來，build 不再連 astral.sh。
+#
+# 原本是 curl -LsSf https://astral.sh/uv/install.sh | sh。pipeline 的 exit
+# code 取自 sh，curl 解不到主機名時 sh 讀到空輸入照樣回 0，&& 鏈不會斷，
+# build 一路走到 uv sync 才以 127 收場，訊息完全看不出真正的原因。
+COPY --from=uvbin /uv /uvx /bin/
 
 RUN \
     apk update && apk upgrade && \
     apk add --no-cache ca-certificates && \
-    apk add --no-cache --virtual .build-deps curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv sync && \
-    apk del .build-deps && \
-    cd ~/.cache/ && \
     rm -rf /var/cache/apk/* /var/lib/apk/* /etc/apk/cache/*
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD wget -qO /dev/null http://127.0.0.1:8000/api/healthz || exit 1
+# readyz，不是 healthz：healthz 只回應用程式版本，資料庫連不上時照樣綠。
+# compose 會覆蓋這一段，這裡對齊是為了直接跑 image 的情況。
+HEALTHCHECK --interval=30s --timeout=6s --retries=3 \
+    CMD wget -qO /dev/null http://127.0.0.1:8000/api/readyz || exit 1
 
 ENTRYPOINT ["/bin/sh", "-c", "uv run fastapi run --host 0.0.0.0 --port 8000 api.py"]


### PR DESCRIPTION
## 現象

在 m6 上 `docker compose up -d --build api` 撞到這個：

```
Dockerfile.api:13
failed to solve: process "/bin/sh -c apk update && apk upgrade && ..."
did not complete successfully: exit code: 127
Try again
Try again
```

同一份 Dockerfile 在別台機器 build 得起來，所以不是語法或依賴的問題。

## 為什麼是 127，又為什麼訊息看不懂

127 是 shell 的 command not found，發生在 `uv sync`。真正的失敗在前一行：

```sh
curl -LsSf https://astral.sh/uv/install.sh | sh && \
uv sync && \
```

pipeline 的 exit code 取自最後一個指令，也就是 `sh`。curl 解不到主機名的時候 `sh` 讀到空輸入，正常結束回 0，`&&` 鏈不會斷，build 就帶著一個沒有 uv 的環境往下走，直到 `uv sync` 才炸。實測：

```
$ curl -LsSf https://this-host-does-not-exist.invalid/install.sh | sh
curl: (6) Could not resolve host: this-host-does-not-exist.invalid
pipeline_exit=0          ← 失敗被吞掉
$ uv-not-installed sync
next_cmd_exit=127
```

訊息末尾那兩個 `Try again` 是 DNS 的 `EAI_AGAIN`，跟同一天 `pulse-db-1` 那個 `failed to resolve host 'db': [Errno -3] Try again` 同源。m6 的容器 DNS 目前已經恢復，所以單純重跑也會過，這個 PR 處理的是「下次網路抽一下不要再變成無從判讀的 127」。

## 改動

- 兩個 Dockerfile 改用 `COPY --from=ghcr.io/astral-sh/uv:0.9.30 /uv /uvx /bin/`，build 期間不再連 astral.sh，也不需要 `apk add curl` 再 `apk del`
- 移除 `ENV PATH="/root/.local/bin:${PATH}"`（curl 安裝方式的遺留）與 `cd ~/.cache/`（後面接的 `rm` 全是絕對路徑，那個 `cd` 沒有作用）
- `Dockerfile.api` 的 `HEALTHCHECK` 對齊到 `readyz`。compose 會覆蓋 image 這一段，#339 只改了 compose，直接跑 image 的情況仍是舊的
- `pulse/CLAUDE.md` 記下 uv 的取得方式與升級位置

`uv sync` 仍然要連 PyPI，網路壞掉還是會失敗，但錯誤會直接指向 uv 而不是一個 127。

## 驗證

```
docker build -f Dockerfile.api      成功，那個 RUN 從 32.9s 降到 4.1s
docker build -f Dockerfile          成功
api image      uv 0.9.30 / import api, routers.vega 成功
backend image  uv 0.9.30 / import tor, structs 成功 / crontab 就位
busybox wget   503 -> exit 1、200 -> exit 0（image HEALTHCHECK 有效）
```

uv 的 binary 是靜態連結，在 Alpine（musl）上直接可執行，已在 `python:3.12.13-alpine3.23` 內實測。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
