### PR TITLE
feat(home): 首頁改用讀者意圖分類，新增場景與實際操作區塊

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - index.md
   - !ENV [NAV_GUIDES, "指南"]:
       - guides/index.md
+      - help/index.md
       - !ENV [NAV_BASICS, "概念"]:
           - basics/index.md
           - basics/internet-freedom.md
@@ -174,7 +175,6 @@ nav:
   - !ENV [NAV_ABOUT, "關於我們"]:
       - about/index.md
       - contact.md
-      - help/index.md
       - offline.md
 theme:
   name: material

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -14,6 +14,7 @@ nav:
   - index.md
   - !ENV [NAV_GUIDES, "指南"]:
       - guides/index.md
+      - help/index.md
       - !ENV [NAV_BASICS, "概念"]:
           - basics/index.md
           - basics/internet-freedom.md
@@ -153,7 +154,6 @@ nav:
   - !ENV [NAV_ABOUT, "关于我们"]:
       - about/index.md
       - contact.md
-      - help/index.md
       - offline.md
 theme:
   name: material

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -15,10 +15,10 @@ nav:
   - !ENV [NAV_ABOUT, "About"]:
       - about/index.md
       - contact.md
-      - help/index.md
       - offline.md
   - !ENV [NAV_GUIDES, "Guides"]:
       - guides/index.md
+      - help/index.md
       - !ENV [NAV_BASICS, "Concepts"]:
           - basics/index.md
           - basics/internet-freedom.md

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -13,125 +13,109 @@ hide:
 
 [:material-account-group: 认识社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 订阅电子报](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/zh-cn/feed_rss_created.xml){ .md-button }
 
-## :material-account-multiple-outline: 我们是谁、为谁写
+一群关注匿名网络、隐私与网络自由的在地社群成员。长期推广 Tor、Tails、OONI 等开源工具，维运在地的网络观测，追踪台湾的个资与加密支付法规，并与 EFF、Tor Project、OONI 合作把全球议题带回台湾脉络讨论。完整介绍见 [关于我们](./about/index.md)。
 
-<div class="grid cards" markdown>
-
-- :material-account-group-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我们是谁**
-
-    ---
-
-    一群关注匿名网络、隐私与网络自由的在地社群成员。长期推广 Tor、Tails、OONI 等开源工具，并与 EFF、Tor Project、OONI 等国际组织合作，把全球议题带回台湾脉络讨论。
-
-- :material-target:{ .lg .middle style="color: var(--brand-cyan-500);" } **我们在做什么**
-
-    ---
-
-    维运在地的网络观测（OONI 检测清单、ASN 覆盖分析、Tor Relay 观测）、追踪台湾个资与加密支付法规动态、举办工作坊与社群小聚，并翻译国际研究报告。所有产出都以 [anoni.net Docs](./guides/index.md) 为文件中心。
-
-- :material-account-supervisor-circle-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我们为谁写**
-
-    ---
-
-    新闻媒体、独立记者、公民团体、开源科技社群。这些参与者实务上常面对消息来源保护、跨境查证与封锁规避的挑战，匿名网络与隐私工具能补足现有制度的缺口。完整说明见 [什么是匿名网络？各参与者为何会用到](./tools/what-is-anonymity-network.md#stakeholders-why)。
-
-</div>
-
-## :material-flag-checkered: 2026 三大主题
-
-<div class="grid cards" markdown>
-
-- :material-shield-lock-outline:{ .lg .middle style="color: var(--cat-privacy);" } **个人隐私指引**
-
-    ---
-
-    整理可实际操作的隐私保护指引，依情境（日常、敏感工作、高风险）提供工具与步骤，搭配威胁模型评估。
-
-    [:octicons-arrow-right-24: 研究专题](./community/privacy-guide.md)
-
-- :material-server-network:{ .lg .middle style="color: var(--cat-relay);" } **Tor Relay 校园建立**
-
-    ---
-
-    与 EFF、Tor Project 合作推动校园中继节点。台师大已有成功案例，目标整理申请流程与活动企划供其他学校参考。
-
-    [:octicons-arrow-right-24: 研究专题](./community/relay-on-campus.md)
-
-- :material-cash-multiple:{ .lg .middle style="color: var(--cat-payments);" } **匿名支付**
-
-    ---
-
-    探索现金以外情境下的匿名支付（稳定币、区块链应用），含法规（VASP 法 2026）、技术与实现面向。
-
-    [:octicons-arrow-right-24: 研究专题](./community/payments-research.md)
-
-</div>
+2026 年社群投入三个主题，个人隐私指引、Tor Relay 校园建立、匿名支付，进度与参与方式见 [社群](./community/index.md)。
 
 ## :material-rocket-launch-outline: 从这里开始
 
 <div class="grid cards" markdown>
 
-- :material-compass-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **指南**
+- :material-check-circle-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我该先做什么**
 
     ---
 
-    从概念、工具、场景到进阶与报告，5 个阅读层次。
+    不想先读原理，只想知道现在该调整哪些设置。一篇读完就能开始操作。
 
-    [:octicons-arrow-right-24: 五个层次](./guides/index.md)
+    [:octicons-arrow-right-24: 一般人平常该做到什么](./scenarios/everyday-baseline.md)
 
-- :material-island:{ .lg .middle style="color: var(--brand-cyan-500);" } **在地脉络**
-
-    ---
-
-    台湾的网络观测、个资法、VASP 法、揭弊者保护法。
-
-    [:octicons-arrow-right-24: 切入观察](./taiwan/index.md)
-
-- :material-account-group:{ .lg .middle style="color: var(--brand-cyan-500);" } **社群参与**
+- :material-book-open-variant:{ .lg .middle style="color: var(--brand-cyan-500);" } **这些名词是什么**
 
     ---
 
-    2026 三大主题、如何加入、Matrix 与协作工具。
+    匿名与隐私差在哪、metadata 泄漏什么、威胁模型怎么评估。第一次接触从这里建立词汇。
 
-    [:octicons-arrow-right-24: 加入我们](./community/index.md)
+    [:octicons-arrow-right-24: 概念](./basics/index.md)
 
-- :material-lifebuoy:{ .lg .middle style="color: var(--accent-emergency);" } **紧急求救**
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **我要用哪个工具**
 
     ---
 
-    账号被盗、装置遗失、跟踪骚扰的紧急应对。
+    Tor、Tails、OONI、通讯软件、密码管理。每个工具的用途、限制与适用的威胁模型。
 
-    [:octicons-arrow-right-24: 取得协助](./help/index.md)
+    [:octicons-arrow-right-24: 工具](./tools/index.md)
+
+- :material-island:{ .lg .middle style="color: var(--brand-cyan-500);" } **台湾现在什么状况**
+
+    ---
+
+    OONI 观测数据、Tor Relay 分布、个资法与 VASP 法、揭弊者保护法的技术面。
+
+    [:octicons-arrow-right-24: 在地脉络](./taiwan/index.md)
 
 </div>
 
-## :material-account-supervisor-outline: 我们关注的参与者
+## :material-account-switch-outline: 换个处境看看
+
+同一套工具在不同处境下的用法差很多。这几篇从具体的人与具体的风险写起，读完会比较知道自己需要保护什么。
 
 <div class="grid cards" markdown>
 
-- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--neutral-muted);" } **新闻媒体**
+- :material-shield-account-outline:{ .lg .middle style="color: var(--cat-privacy);" } **一般人平常该做到什么**
 
     ---
 
-    降低采编过程中身分与流量被比对、追踪的风险，连线受阻时仍能查证与对外说明。
+    没有特殊处境，只是不想被平台与广告商过度画像。从最低成本的调整开始。
 
-- :material-account-edit-outline:{ .lg .middle style="color: var(--neutral-muted);" } **独立记者**
+    [:octicons-arrow-right-24: 日常基准](./scenarios/everyday-baseline.md)
 
-    ---
-
-    在信息安全与法律支持有限时，更仰赖匿名网络与以隐私为重的使用环境完成调查与联系。
-
-- :material-account-group-outline:{ .lg .middle style="color: var(--neutral-muted);" } **公民团体**
+- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--cat-privacy);" } **记者保护消息来源**
 
     ---
 
-    倡议与联络对象需要保护，官网、社群账号等组织服务也可能成为被锁定的对象。
+    采访到发稿的每一段都可能留下比对得出来的痕迹。从联系、收文件到刊出后的完整流程。
 
-- :material-source-branch:{ .lg .middle style="color: var(--neutral-muted);" } **开源科技社群**
+    [:octicons-arrow-right-24: 记者情境](./scenarios/journalist.md)
+
+- :material-bag-suitcase-outline:{ .lg .middle style="color: var(--cat-privacy);" } **出差与研讨会的数字准备**
 
     ---
 
-    通过中继（Relay）、测试与文件翻译等贡献，强化匿名网络基础建设的可用性。
+    入境查验设备、当地网络不可信、回国后的清理。东亚与东南亚逐地整理。
+
+    [:octicons-arrow-right-24: 出差准备](./scenarios/asia-travel.md)
+
+- :material-hand-coin-outline:{ .lg .middle style="color: var(--cat-payments);" } **倡议组织的匿名捐款渠道**
+
+    ---
+
+    捐款人不想被查到、组织仍需开立收据。含公益劝募条例与洗钱防制的限制。
+
+    [:octicons-arrow-right-24: 匿名捐款](./scenarios/nonprofit-anonymous-donation.md)
+
+</div>
+
+还有社运行动者、选举观察员、家暴幸存者、LGBTQ+ 与性少数等处境，见 [场景](./scenarios/index.md)。
+
+## :material-gamepad-variant-outline: 实际操作看看
+
+<div class="grid cards" markdown>
+
+- :material-cube-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **互动与呈现**
+
+    ---
+
+    用 3D 影像与可操作的游戏理解 Tor。走一遍三跳洋葱路由，看流量在会合点怎么相遇。
+
+    [:octicons-arrow-right-24: 玩玩看](./games/index.md)
+
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **小工具**
+
+    ---
+
+    在浏览器里直接执行，不送出任何数据。清除图片 metadata、生成密语、检查连接泄漏。
+
+    [:octicons-arrow-right-24: 直接使用](./utils/index.md)
 
 </div>
 
@@ -142,3 +126,7 @@ hide:
     <!-- latest-posts:5 -->
 
     更多公告请见 [:material-bullhorn-outline: 近期公告](./blog/index.md)。
+
+---
+
+账号被盗、钱已经汇给诈骗、设备遗失、跟踪骚扰或突然被断网，[紧急求救](./help/index.md) 整理了台湾的求助专线与现场能做的事。那页不取代专业协助，情境急迫时请优先拨打页面上列出的专线。海外读者请依当地对应资源替换。

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -11,11 +11,11 @@ hide:
 
 > 推广 Tor、Tails、OONI，串连台湾的网络自由实践与在地观测。
 
-[:material-account-group: 认识社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 订阅电子报](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/zh-cn/feed_rss_created.xml){ .md-button }
+[:material-account-group: 社群参与](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 订阅电子报](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/zh-cn/feed_rss_created.xml){ .md-button }
 
 一群关注匿名网络、隐私与网络自由的在地社群成员。长期推广 Tor、Tails、OONI 等开源工具，维运在地的网络观测，追踪台湾的个资与加密支付法规，并与 EFF、Tor Project、OONI 合作把全球议题带回台湾脉络讨论。完整介绍见 [关于我们](./about/index.md)。
 
-2026 年社群投入三个主题，个人隐私指引、Tor Relay 校园建立、匿名支付，进度与参与方式见 [社群](./community/index.md)。
+2026 年社群投入三个主题，个人隐私指引、Tor Relay 校园建立、匿名支付，进度与参与方式见 [社群参与](./community/index.md)。
 
 ## :material-rocket-launch-outline: 从这里开始
 

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -13,125 +13,109 @@ hide:
 
 [:material-account-group: 認識社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 訂閱電子報](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/feed_rss_created.xml){ .md-button }
 
-## :material-account-multiple-outline: 我們是誰、為誰寫
+一群關注匿名網路、隱私與網路自由的在地社群成員。長期推廣 Tor、Tails、OONI 等開源工具，維運在地的網路觀測，追蹤台灣的個資與加密支付法規，並與 EFF、Tor Project、OONI 合作把全球議題帶回台灣脈絡討論。完整介紹見 [關於我們](./about/index.md)。
 
-<div class="grid cards" markdown>
-
-- :material-account-group-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我們是誰**
-
-    ---
-
-    一群關注匿名網路、隱私與網路自由的在地社群成員。長期推廣 Tor、Tails、OONI 等開源工具，並與 EFF、Tor Project、OONI 等國際組織合作，把全球議題帶回台灣脈絡討論。
-
-- :material-target:{ .lg .middle style="color: var(--brand-cyan-500);" } **我們在做什麼**
-
-    ---
-
-    維運在地的網路觀測（OONI 檢測清單、ASN 覆蓋分析、Tor Relay 觀測）、追蹤台灣個資與加密支付法規動態、舉辦工作坊與社群小聚，並翻譯國際研究報告。所有產出都以 [anoni.net Docs](./guides/index.md) 為文件中心。
-
-- :material-account-supervisor-circle-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我們為誰寫**
-
-    ---
-
-    新聞媒體、獨立記者、公民團體、開源科技社群。這些參與者實務上常面對消息來源保護、跨境查證與封鎖規避的挑戰，匿名網路與隱私工具能補足現有制度的缺口。完整說明見 [什麼是匿名網路？各參與者為何會用到](./tools/what-is-anonymity-network.md#stakeholders-why)。
-
-</div>
-
-## :material-flag-checkered: 2026 三大主題
-
-<div class="grid cards" markdown>
-
-- :material-shield-lock-outline:{ .lg .middle style="color: var(--cat-privacy);" } **個人隱私指引**
-
-    ---
-
-    整理可實際操作的隱私保護指引，依情境（日常、敏感工作、高風險）提供工具與步驟，搭配威脅模型評估。
-
-    [:octicons-arrow-right-24: 研究專題](./community/privacy-guide.md)
-
-- :material-server-network:{ .lg .middle style="color: var(--cat-relay);" } **Tor Relay 校園建立**
-
-    ---
-
-    與 EFF、Tor Project 合作推動校園中繼節點。台師大已有成功案例，目標整理申請流程與活動企劃供其他學校參考。
-
-    [:octicons-arrow-right-24: 研究專題](./community/relay-on-campus.md)
-
-- :material-cash-multiple:{ .lg .middle style="color: var(--cat-payments);" } **匿名支付**
-
-    ---
-
-    探索現金以外情境下的匿名支付（穩定幣、區塊鏈應用），含法規（VASP 法 2026）、技術與實作面向。
-
-    [:octicons-arrow-right-24: 研究專題](./community/payments-research.md)
-
-</div>
+2026 年社群投入三個主題，個人隱私指引、Tor Relay 校園建立、匿名支付，進度與參與方式見 [社群](./community/index.md)。
 
 ## :material-rocket-launch-outline: 從這裡開始
 
 <div class="grid cards" markdown>
 
-- :material-compass-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **指南**
+- :material-check-circle-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **我該先做什麼**
 
     ---
 
-    從概念、工具、場景到進階與報告，5 個閱讀層次。
+    不想先讀原理，只想知道現在該調整哪些設定。一篇讀完就能開始操作。
 
-    [:octicons-arrow-right-24: 五個層次](./guides/index.md)
+    [:octicons-arrow-right-24: 一般人平常該做到什麼](./scenarios/everyday-baseline.md)
 
-- :material-island:{ .lg .middle style="color: var(--brand-cyan-500);" } **在地脈絡**
-
-    ---
-
-    台灣的網路觀測、個資法、VASP 法、揭弊者保護法。
-
-    [:octicons-arrow-right-24: 切入觀察](./taiwan/index.md)
-
-- :material-account-group:{ .lg .middle style="color: var(--brand-cyan-500);" } **社群參與**
+- :material-book-open-variant:{ .lg .middle style="color: var(--brand-cyan-500);" } **這些名詞是什麼**
 
     ---
 
-    2026 三大主題、如何加入、Matrix 與協作工具。
+    匿名與隱私差在哪、metadata 洩漏什麼、威脅模型怎麼評估。第一次接觸從這裡建立詞彙。
 
-    [:octicons-arrow-right-24: 加入我們](./community/index.md)
+    [:octicons-arrow-right-24: 概念](./basics/index.md)
 
-- :material-lifebuoy:{ .lg .middle style="color: var(--accent-emergency);" } **緊急求救**
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **我要用哪個工具**
 
     ---
 
-    帳號被盜、裝置遺失、跟蹤騷擾的緊急應對。
+    Tor、Tails、OONI、通訊軟體、密碼管理。每個工具的用途、限制與適用的威脅模型。
 
-    [:octicons-arrow-right-24: 取得協助](./help/index.md)
+    [:octicons-arrow-right-24: 工具](./tools/index.md)
+
+- :material-island:{ .lg .middle style="color: var(--brand-cyan-500);" } **台灣現在什麼狀況**
+
+    ---
+
+    OONI 觀測資料、Tor Relay 分布、個資法與 VASP 法、揭弊者保護法的技術面。
+
+    [:octicons-arrow-right-24: 在地脈絡](./taiwan/index.md)
 
 </div>
 
-## :material-account-supervisor-outline: 我們關注的參與者
+## :material-account-switch-outline: 換個處境看看
+
+同一套工具在不同處境下的用法差很多。這幾篇從具體的人與具體的風險寫起，讀完會比較知道自己需要保護什麼。
 
 <div class="grid cards" markdown>
 
-- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--neutral-muted);" } **新聞媒體**
+- :material-shield-account-outline:{ .lg .middle style="color: var(--cat-privacy);" } **一般人平常該做到什麼**
 
     ---
 
-    降低採編過程中身分與流量被比對、追蹤的風險，連線受阻時仍能查證與對外說明。
+    沒有特殊處境，只是不想被平台與廣告商過度側寫。從最低成本的調整開始。
 
-- :material-account-edit-outline:{ .lg .middle style="color: var(--neutral-muted);" } **獨立記者**
+    [:octicons-arrow-right-24: 日常基準](./scenarios/everyday-baseline.md)
 
-    ---
-
-    在資安與法律支援有限時，更仰賴匿名網路與以隱私為重的使用環境完成調查與聯繫。
-
-- :material-account-group-outline:{ .lg .middle style="color: var(--neutral-muted);" } **公民團體**
+- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--cat-privacy);" } **記者保護消息來源**
 
     ---
 
-    倡議與聯絡對象需要保護，官網、社群帳號等組織服務也可能成為被鎖定的對象。
+    採訪到發稿的每一段都可能留下比對得出來的痕跡。從聯繫、收檔案到刊出後的完整流程。
 
-- :material-source-branch:{ .lg .middle style="color: var(--neutral-muted);" } **開源科技社群**
+    [:octicons-arrow-right-24: 記者情境](./scenarios/journalist.md)
+
+- :material-bag-suitcase-outline:{ .lg .middle style="color: var(--cat-privacy);" } **出差與研討會的數位準備**
 
     ---
 
-    透過中繼（Relay）、測試與文件翻譯等貢獻，強化匿名網路基礎建設的可用性。
+    入境查驗裝置、當地網路不可信、回國後的清理。東亞與東南亞逐地整理。
+
+    [:octicons-arrow-right-24: 出差準備](./scenarios/asia-travel.md)
+
+- :material-hand-coin-outline:{ .lg .middle style="color: var(--cat-payments);" } **倡議組織的匿名捐款管道**
+
+    ---
+
+    捐款人不想被查到、組織仍需開立收據。含公益勸募條例與洗錢防制的限制。
+
+    [:octicons-arrow-right-24: 匿名捐款](./scenarios/nonprofit-anonymous-donation.md)
+
+</div>
+
+還有社運行動者、選舉觀察員、家暴倖存者、LGBTQ+ 與性少數等處境，見 [場景](./scenarios/index.md)。
+
+## :material-gamepad-variant-outline: 實際操作看看
+
+<div class="grid cards" markdown>
+
+- :material-cube-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **互動與呈現**
+
+    ---
+
+    用 3D 影像與可操作的遊戲理解 Tor。走一遍三跳洋蔥路由，看流量在會合點怎麼相遇。
+
+    [:octicons-arrow-right-24: 玩玩看](./games/index.md)
+
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **小工具**
+
+    ---
+
+    在瀏覽器裡直接執行，不送出任何資料。清除圖片 metadata、產生密語、檢查連線洩漏。
+
+    [:octicons-arrow-right-24: 直接使用](./utils/index.md)
 
 </div>
 
@@ -142,3 +126,7 @@ hide:
     <!-- latest-posts:5 -->
 
     更多公告請見 [:material-bullhorn-outline: 近期公告](./blog/index.md)。
+
+---
+
+帳號被盜、錢已經匯給詐騙、裝置遺失、跟蹤騷擾或突然被斷網，[緊急求救](./help/index.md) 整理了台灣的求助專線與現場能做的事。那頁不取代專業協助，情境急迫時請優先撥打頁面上列出的專線。

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -11,11 +11,11 @@ hide:
 
 > 推廣 Tor、Tails、OONI，串連台灣的網路自由實踐與在地觀測。
 
-[:material-account-group: 認識社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 訂閱電子報](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/feed_rss_created.xml){ .md-button }
+[:material-account-group: 社群參與](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 訂閱電子報](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/feed_rss_created.xml){ .md-button }
 
 一群關注匿名網路、隱私與網路自由的在地社群成員。長期推廣 Tor、Tails、OONI 等開源工具，維運在地的網路觀測，追蹤台灣的個資與加密支付法規，並與 EFF、Tor Project、OONI 合作把全球議題帶回台灣脈絡討論。完整介紹見 [關於我們](./about/index.md)。
 
-2026 年社群投入三個主題，個人隱私指引、Tor Relay 校園建立、匿名支付，進度與參與方式見 [社群](./community/index.md)。
+2026 年社群投入三個主題，個人隱私指引、Tor Relay 校園建立、匿名支付，進度與參與方式見 [社群參與](./community/index.md)。
 
 ## :material-rocket-launch-outline: 從這裡開始
 


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

首頁的分類軸從**格式**（指南、在地脈絡、社群參與、緊急求救）改成**讀者意圖**，並新增場景與實際操作兩個區塊。zh-TW 與 zh-CN 同步，en 版不動（它在 2026-08 已經重新定位成 observatory，是另一套架構）。

相關 Issue / Related issue：#

## 為什麼

Umami 流量資料（只取台灣讀者，濾掉 SG、US、CN 的自動化流量），近 11 天：

| 頁面 | 瀏覽 | 進入 | 離開 | 離開率 |
|---|---|---|---|---|
| **`/docs/` 首頁** | 74 | **51（第 1）** | **45（第 1）** | **61%** |
| `/docs/taiwan/` | 12 | 3 | 0 | 0% |
| `/docs/games/` | 13 | 2 | 2 | 15% |
| `/docs/blog/` | 19 | 2 | 3 | 16% |
| `/docs/guides/` | 18 | 2 | 4 | 22% |
| `/docs/community/` | 17 | 2 | 5 | 29% |

首頁同時是第一名進入頁與第一名離開頁。只要人走得進去，內容就留得住，問題在首頁本身。

樣本要誠實看待，首頁 11 天只有 51 次真人進入，方向可信但不是精密統計。另外站台整體 86.2% 跳出率不能用，那是 SG（5,385 次瀏覽、螢幕 66.3% 集中在不存在的 1280x1200）、US（停留 12.3 秒）、CN（停留 0.4 秒）的自動化流量拉的，真實 TW 讀者是 57.9% 跳出、每次造訪 3.69 頁、停留 176 秒。

## 分類軸不是新寫的

`guides/index.md` 的「如何走這條路徑」早就寫好六種意圖切入（想先知道該做什麼、第一次接觸、想找特定工具、有具體需求、想理解技術原理、看外部資源）。問題是它埋在一次點擊之後，而那頁 11 天只有 18 次瀏覽。這個 PR 把已經寫好的分類搬到首頁。

## 改了什麼

- **從這裡開始**四張卡改成「我該先做什麼」「這些名詞是什麼」「我要用哪個工具」「台灣現在什麼狀況」。第一張直接連 `scenarios/everyday-baseline.md` 這篇文章而不是索引頁，首頁到真內容變成一次點擊，比同類站台的兩次共識還短一步
- **新增「換個處境看看」**。`scenarios/` 是站上最貼近具體處境的內容（11 篇，7KB 到 44KB），首頁原本一個連結都沒有。精選四篇（日常基準、記者、出差準備、匿名捐款）並連到完整清單
- **新增「實際操作看看」**。`games/` 與 `utils/` 原本在首頁完全沒有入口，卻有人自己找到（games 13 次瀏覽、離開率 15%），而且是門檻最低的隱私體驗素材
- 「我們是誰、為誰寫」三張卡壓成一段文字並連到 `about/`
- 「2026 三大主題」壓成一行連到社群頁
- **移除「我們關注的參與者」**四張卡。它與「我們為誰寫」列的是逐字相同、順序相同的四個角色（新聞媒體、獨立記者、公民團體、開源科技社群），而且四張卡一個連結都沒有
- **緊急求救從卡片降為頁尾一行**

卡片從 14 張降到 10 張，其中導航用的從 4 張增為 10 張。

## 兩個刻意的取捨

**緊急求救降級。** 社群量能不足以承接緊急事件，首頁不該給人「這裡是求助站」的期待。但「不凸顯」與「找不到」是兩件事，所以保留頁尾一行文字連結。一個錢已經匯給詐騙、165 圈存只有 24 小時的人，還是要找得到那頁。`help/index.md` 本身的定位是轉介而非承接（開頭就寫「這頁不取代專業協助，情境急迫時請優先聯繫下方列出的求助專線」，列的是 113、110、165、1925），沒有過度承諾的問題。

**場景精選不含家暴、LGBTQ+、在中國大陸傳播資訊三篇。** 那些頁面本來就公開也在 nav 裡，放上首頁不會製造新的曝險，但首頁卡片的點擊會留在瀏覽紀錄，而共用裝置正好是那幾篇讀者的處境。三篇仍在 `scenarios/index.md`，首頁那段文字也有提到它們存在。

## 自我檢查 / Self-check

- [x] 檔名全小寫、用連字號分隔，slug 以英文為主。（未新增檔案）
- [x] front matter 齊全
- [x] 內部連結用相對路徑，沒有寫成 `/docs/zh-TW/...` 絕對路徑
- [x] 標點符合社群規範：掃過沒有 `——`、`；`、全形「／」與「不是...而是」
- [x] 連續「」引號之間有加「、」。（未新增連續引號）
- [x] 圖片放在 `assets/images/`，有 alt 文字與授權標示。（未改動圖片）
- [x] 文末有「相關閱讀」之類的橫向連結。（首頁性質不同，全頁都是橫向連結）

## 翻譯（如適用）/ Translation (if applicable)

- [x] 內容以 zh-TW 為來源同步，沒有自行更動事實
- [x] zh-CN 已調整為中國用語（設置、畫像、軟件、文件、渠道、生成），另在頁尾補一句提醒海外讀者替換當地資源

## 安全核心內容（如適用）/ Security-core content (if applicable)

- [ ] 本 PR 改到 tools、scenarios、advanced 的工具操作或 OPSEC 內容，我了解需要維護者技術審核才會合併。 / Touches tools/scenarios/advanced; I understand it needs maintainer review.

沒有改動 `tools/`、`scenarios/`、`advanced/` 底下任何檔案，只改 `index.md`，新增指向那些頁面的連結。

## 驗證

- 三語系用 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 建置，全部 `exit=0`、0 警告
- `tools/docs_style_lint.py` 對兩個改動檔案 0 error 0 warn（過程中抓到「動手」是口語詞，已改為「開始操作」與「實際操作」）
- 建置產物核對：新增的十個連結目標都正確渲染，三個移除的區塊標題在輸出中歸零

## 後續可以另外討論的

- nav 把 `help/index.md` 歸在「關於我們」底下，跟聯絡方式、離線閱讀並列。不是從首頁進站的人，nav 是唯一路徑，而那個分類名不會讓人想到求助內容。這是分類正確性問題，與凸顯與否無關，本 PR 沒有動
- `community/index.md` 在首頁與 nav 有「認識社群」「社群參與」「社群」三種稱呼
- `analytics.js` 的 `search-used`、`search-zero`、`search-hit` 三個事件 30 天零筆，而同一支腳本的 `read-depth` 送了 885 次。選擇器在線上 HTML 存在、腳本在 DOMContentLoaded 後綁定、theme 沒開 `navigation.instant`，接線看起來正確。要嘛真的沒人用站內搜尋，要嘛有細節沒接上。`search-zero` 是唯一能告訴我們「使用者想找什麼卻找不到」的訊號，值得手動測一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)
