### PR TITLE
feat(home): en 首頁補上被排除的讀者入口，並修正場景篇數

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -19,7 +19,7 @@ We combine OONI network measurements, Tor relay monitoring, and on-the-ground co
 
 For general digital safety guidance written for a global audience, well-established English resources include [EFF Surveillance Self-Defense](https://ssd.eff.org/){target="_blank"}, [Privacy Guides](https://www.privacyguides.org/){target="_blank"}, and the [Tor Project Support Portal](https://support.torproject.org/){target="_blank"}, and we link to them rather than duplicating them. What we add is the regional layer those sites are not set up to produce: how a tool behaves in Mainland China versus Taiwan, what a local statute changes about the threat model, and measurement from inside the region. Our introductions to Tor, Tails, OONI, and CryptPad are written with that context built in rather than as generic explainers.
 
-## :material-target: Three ways to use this site
+## :material-target: Four ways to use this site
 
 <div class="grid cards" markdown>
 
@@ -43,9 +43,17 @@ For general digital safety guidance written for a global audience, well-establis
 
     ---
 
-    Diaspora, cross-border travelers, and people whose families remain in less open jurisdictions. The first scenario guide is up; more are queued. The regional context is what global English-language privacy sites do not cover.
+    Diaspora, cross-border travelers, and people whose families remain in less open jurisdictions. Eleven guides are published, covering border crossings, source protection, speaking online from Singapore and Malaysia, and posting on mainland Chinese platforms. The regional context is what global English-language privacy sites do not cover.
 
     [:octicons-arrow-right-24: Scenarios](./scenarios/index.md)
+
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **Start protecting yourself**
+
+    ---
+
+    You are not here to cite us or work with us, you just want to know what to actually do. Start with what an ordinary person should change first, then read the tool introductions, each written with the regional context built in.
+
+    [:octicons-arrow-right-24: What to do first](./scenarios/everyday-baseline.md)
 
 </div>
 
@@ -119,27 +127,67 @@ Our standing varies by jurisdiction. We don't claim equal depth across the regio
 
 </div>
 
-## :material-account-supervisor-outline: Who we write for
+## :material-account-switch-outline: The same tools, different situations
+
+How a tool is used changes a lot with the situation it is used in. These guides start from a specific person and a specific risk, which makes it easier to work out what you need to protect.
 
 <div class="grid cards" markdown>
 
-- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--neutral-muted);" } **International rights organizations**
+- :material-shield-account-outline:{ .lg .middle style="color: var(--cat-privacy);" } **What an ordinary person should actually do**
 
     ---
 
-    Rights advocacy, anti-surveillance, and anti-censorship organizations covering the Asia-Pacific that may use this site for regional context and citable observations. Documented partners are listed on the [About page](./about/index.md).
+    No particular exposure, just no wish to be profiled by platforms and ad networks. Starts with the changes that cost the least.
 
-- :material-account-edit-outline:{ .lg .middle style="color: var(--neutral-muted);" } **Journalists & academic researchers**
+    [:octicons-arrow-right-24: Everyday baseline](./scenarios/everyday-baseline.md)
 
-    ---
-
-    Reporters and researchers covering Internet freedom, surveillance, and platform regulation in the Asia-Pacific who need regional context that complements the upstream English literature.
-
-- :material-airplane-takeoff:{ .lg .middle style="color: var(--neutral-muted);" } **The English-preferring Sinophone diaspora**
+- :material-newspaper-variant-outline:{ .lg .middle style="color: var(--cat-privacy);" } **Journalists and source protection**
 
     ---
 
-    People with family or networks in the region who read English more comfortably than Chinese, particularly post-NSL diaspora, students abroad, and second-generation readers.
+    Every stage from first contact to publication can leave something that correlates back to a source. Covers contact, receiving files, and what happens after the story runs.
+
+    [:octicons-arrow-right-24: Source protection](./scenarios/journalist.md)
+
+- :material-bag-suitcase-outline:{ .lg .middle style="color: var(--cat-privacy);" } **Device minimization and border crossings**
+
+    ---
+
+    Device inspection at the border, local networks you cannot trust, and cleaning up after you return. Written jurisdiction by jurisdiction across Asia.
+
+    [:octicons-arrow-right-24: Crossing borders](./scenarios/asia-travel.md)
+
+- :material-hand-coin-outline:{ .lg .middle style="color: var(--cat-payments);" } **Anonymous donation channels**
+
+    ---
+
+    A donor who does not want to be traced, an organization that still has to issue receipts. Covers what fundraising and anti-money-laundering rules allow.
+
+    [:octicons-arrow-right-24: Anonymous donations](./scenarios/nonprofit-anonymous-donation.md)
+
+</div>
+
+Seven more cover activists, election observers, domestic violence survivors, LGBTQ+ readers, speaking online from Singapore and Malaysia, and posting on mainland Chinese platforms. See [Scenarios](./scenarios/index.md).
+
+## :material-gamepad-variant-outline: Try it hands-on
+
+<div class="grid cards" markdown>
+
+- :material-cube-outline:{ .lg .middle style="color: var(--brand-cyan-500);" } **Interactive**
+
+    ---
+
+    Tor explained through 3D visuals and playable pieces. Walk a three-hop circuit yourself and watch where two streams meet at a rendezvous point.
+
+    [:octicons-arrow-right-24: Play](./games/index.md)
+
+- :material-tools:{ .lg .middle style="color: var(--brand-cyan-500);" } **Utilities**
+
+    ---
+
+    Small tools that run entirely in your browser and send nothing anywhere. Strip metadata from images, generate a passphrase, check what your connection leaks.
+
+    [:octicons-arrow-right-24: Use them](./utils/index.md)
 
 </div>
 
@@ -150,3 +198,7 @@ Our standing varies by jurisdiction. We don't claim equal depth across the regio
     <!-- latest-posts:5 -->
 
     More at [:material-bullhorn-outline: Updates](./blog/index.md).
+
+---
+
+For a compromised account, money already sent to a scam, a lost device, stalking, or a sudden loss of connectivity, [Emergency Help](./help/index.md) collects what to do first. The helpline numbers on that page are Taiwanese, and it points to the equivalents elsewhere. It does not replace professional help.


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

補上 en 首頁排除掉的讀者入口。zh-TW 與 zh-CN 的對應改動在 #346，這個 PR 只動 `docs/en/index.md`，兩者不衝突，可以各自合併。

相關 Issue / Related issue：#

## 為什麼只補不重做

en 首頁在 2026-08 被刻意重新定位成 observatory，那個定位是對的。`What we observe` 把觀察範圍分成第一手、密切追蹤、留意三個信心等級，誠實劃出可信度邊界，是三個語系裡最好的一段設計，這次完全保留。

問題在它把一整群讀者排除在首頁之外。實際查過連結分布：

| 連結目標 | 改之前的 en 首頁 |
|---|---|
| `tools/` | **0** |
| `games/` | **0** |
| `utils/` | **0** |
| `help/` | **0** |
| `scenarios/` | 1 |
| `basics/` | 1 |

`Three ways to use this site` 三張卡（Cite our work、Collaborate with us、Find a regional guide）全部預設讀者帶著機構性目的，要引用、要合作、或要找地區資訊。只是想學會保護自己的一般讀者，在 zh-TW 是被「指南」卡穩穩接住的，en 首頁沒有任何入口。

## 改了什麼

- **`Three ways` 改成 `Four ways`**，新增 `Start protecting yourself`，直接連 `scenarios/everyday-baseline.md` 這篇文章而不是索引頁
- **修正過時的篇數說法**。`Find a regional guide` 那張卡寫著 `The first scenario guide is up; more are queued`，實際上 en 已有 **11 篇**場景（activist、asia-travel、domestic-violence、election-observer、everyday-baseline、journalist、lgbtq、mainland-speech、nonprofit-anonymous-donation、singapore-malaysia-speech、travel-ai-briefing），改為正確描述
- **新增 `The same tools, different situations`**，精選四篇並說明其餘七篇涵蓋什麼
- **新增 `Try it hands-on`**。`games/` 與 `utils/` 原本零入口。`utils` 是純瀏覽器端、不送出任何資料，對國際讀者是很強的信任訊號
- **移除 `Who we write for`**。它列的三種讀者（國際人權組織、記者與學術研究者、英文為主的離散社群）與 `Three ways` 三張卡是同一批對象的第二次陳述，而且整區三張卡只有一個連結
- **頁尾補 `Emergency Help` 一行**

## 兩個與 #346 一致的取捨

**場景精選排除敏感處境。** 家暴、LGBTQ+、在中國大陸傳播資訊、星馬言論四篇留在 `scenarios/index.md`，不放首頁卡片。那些頁面本來就公開也在 nav 裡，放上首頁不會製造新的曝險，但首頁卡片的點擊會留在瀏覽紀錄，而共用裝置正好是那幾篇讀者的處境。首頁那段文字仍然點名它們存在。

**緊急求救只放頁尾一行。** 社群量能不足以承接緊急事件，不主動招攬，但要讓需要的人找得到。`en/help/index.md` 已針對國際讀者改寫過，開頭就說明專線是台灣專屬並指向當地對應資源（含 Access Now），只是首頁一直沒有接回來。

## 自我檢查 / Self-check

- [x] 檔名全小寫、用連字號分隔，slug 以英文為主。（未新增檔案）
- [x] front matter 齊全
- [x] 內部連結用相對路徑，沒有寫成 `/docs/en/...` 絕對路徑
- [x] 標點符合社群規範（en 依英文規則，中文的破折號禁令不適用）
- [x] 連續「」引號之間有加「、」。（不適用，英文頁）
- [x] 圖片放在 `assets/images/`，有 alt 文字與授權標示。（未改動圖片）
- [x] 文末有「相關閱讀」之類的橫向連結。（首頁性質不同，全頁都是橫向連結）

## 翻譯（如適用）/ Translation (if applicable)

- [x] 內容以 zh-TW 為來源同步，沒有自行更動事實。en 版是自己的架構不是逐字翻譯，這次維持它的 observatory 定位，只補結構性缺口
- [x] zh-CN 已在地化；en 已補上在地脈絡

## 安全核心內容（如適用）/ Security-core content (if applicable)

- [ ] 本 PR 改到 tools、scenarios、advanced 的工具操作或 OPSEC 內容，我了解需要維護者技術審核才會合併。 / Touches tools/scenarios/advanced; I understand it needs maintainer review.

沒有改動 `tools/`、`scenarios/`、`advanced/` 底下任何檔案，只改 `en/index.md`，新增指向那些頁面的連結。

## 驗證

- `run_en.sh` 建置 `exit=0`、0 警告
- `tools/docs_style_lint.py` 對 `docs/en/index.md` 0 error 0 warn
- 建置產物核對：新增的連結目標都正確渲染（`games/` 3、`utils/` 3、`help/` 2、四篇場景各 2 到 3），`Who we write for` 在輸出中歸零
- 篇數宣稱核對：4 篇精選 + 文字宣稱另有 7 篇 = 11，與 `en/scenarios/` 實際檔案數相符，七篇逐一確認存在

## 沒有真實使用資料可以佐證

#346 的 zh-TW 改動有流量資料支持（首頁同時是第一名進入頁與離開頁，61% 離開率）。en 沒有可用的對照數據，`/docs/en/` 近 11 天那 1,269 次瀏覽佔全站 53%，但幾乎都是 SG 的自動化流量（5,385 次、螢幕 66.3% 集中在不存在的 1280x1200）。

所以這個 PR 的依據是結構性缺口本身（連結數為零、篇數說法過時、讀者類別重複陳述），不是行為數據。合併後值得觀察真人流量的變化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
