### PR TITLE
fix(docs): 資產雜湊補回 9.7.7，並加上擋住這種漏同步的檢查

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -165,6 +165,27 @@ jobs:
       - name: Build Docs (/en)
         timeout-minutes: 20
         run: source ./.venv/bin/activate; BUILD_TAG="${GITHUB_SHA:0:7}" sh ./run_en.sh;
+      # theme 的資產檔名帶雜湊，而 overrides/base.html 與 zh-TW/sw.js 把它們寫死。
+      # mkdocs-material 一改版雜湊就變，忘了同步的話建置照樣成功，站上的 HTML 指向
+      # 一批不存在的檔案，而下一步的 s3 sync --delete 剛好把舊檔刪掉。2026-08-24 的
+      # #338 就是這樣讓三個語系同時掉樣式，讀者清快取、重裝 PWA 都救不回來。
+      #
+      # 擺在上傳之前是重點：這一關紅燈只是這次沒發布，站上維持上一版，比推上去再修
+      # 便宜得多。
+      - name: Verify theme assets
+        run: python3 ../tools/check_theme_assets.py
+
+      # 預快取清單裡的網址對不對得到產物。這支 2025 年就寫好了，卻一直沒有人跑，
+      # 理由見它的檔頭：sw.js 的 install 用 allSettled 容忍個別失敗，清單裡的錯字
+      # 線上完全看不出來，只有離線的讀者會遇到空白。
+      #
+      # 只在 clearnet 那格跑。onion 版的建置前會就地 sed 改寫整個工作目錄，這支要
+      # 原地抽出 sw.js 的清單來執行，沒必要讓它跟改寫過的原始碼互動，同一份模板在
+      # standard 驗過就夠。
+      - name: Verify precache list
+        if: matrix.variant == 'standard'
+        run: node ../tools/check_precache.mjs
+
       - name: Replace OG images
         timeout-minutes: 10
         run: |

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -37,6 +37,10 @@ on:
       - "docs/en/js/**"
       - "docs/zh-TW/utils/**"
       - "docs/mkdocs*.yml"
+      # 升級 mkdocs-material 會換掉 theme 資產的雜湊，而 base.html 把那些檔名寫死。
+      # #338 只動了這個檔案，當時的 paths 沒有納入，於是一支測試都沒跑，壞掉的雜湊
+      # 一路上線。
+      - "docs/uv.lock"
       - "docs/snippets/**"
       # overrides 的 main.html 是 test_before_send.mjs 的來源，送出前的白名單寫在裡面
       - "docs/overrides/base.html"
@@ -125,6 +129,12 @@ jobs:
       # 威脅模型清單：建議的頁面存不存在，以及答案有沒有被存到裝置上
       - name: 威脅模型清單
         run: node tools/test_threatmodel.mjs
+
+      # theme 資產的雜湊有沒有跟著 mkdocs-material 的版本一起換。忘了同步的話建置
+      # 與 PR 都是綠的，只有線上的 HTML 會指向一批不存在的檔案，而那種壞法讀者清
+      # 快取、重裝 PWA 都救不回來，因為錯的網址就寫在伺服器送出來的 HTML 裡。
+      - name: theme 資產雜湊同步
+        run: python3 tools/test_theme_assets.py
 
       # 部署後要清除的 Cloudflare 快取網址
       - name: Cloudflare 快取清除映射

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -1,6 +1,17 @@
 {#-
   Fork of mkdocs-material base.html: per-page hreflang + keep in sync with partials/alternate.html.
   When upgrading mkdocs-material, refresh asset hashes and generator line from theme base.html.
+
+  theme-assets-from: mkdocs-material 9.7.7
+
+  上面那行由 tools/check_theme_assets.py 讀，跟 docs/uv.lock 解出來的版本比對。兩者
+  對不上就是升級了套件卻沒回來換 hash，CI 擋在部署之前。2026-08-24 的 #338 用
+  uv sync -U 把 mkdocs-material 帶到 9.7.7，這個檔案的 hash 留在 9.7.6，部署的
+  s3 sync --delete 又把舊檔刪掉，線上三個語系的 main.*.min.css 與 bundle.*.min.js
+  同時 404，讀者看到的是沒有樣式的頁面，而且清快取、重裝 PWA 都救不回來。
+
+  換 hash 的時候這一行要一起改。底下 styles 與 scripts 兩個 block、
+  partials 裡的 search worker，以及 docs/zh-TW/sw.js 的 SHELL_ASSETS 是同一組值。
 -#}
 {% import "partials/language.html" as lang with context %}
 <!doctype html>
@@ -49,7 +60,7 @@
       {% endif %}
     {% endblock %}
     {% block styles %}
-      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.484c7ddc.min.css' | url }}">
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.ec1eaa64.min.css' | url }}">
       {% if config.theme.palette %}
         {% set palette = config.theme.palette %}
         <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.ab4e12ef.min.css' | url }}">
@@ -354,7 +365,7 @@
       </script>
     {% endblock %}
     {% block scripts %}
-      <script src="{{ 'assets/javascripts/bundle.79ae519e.min.js' | url }}"></script>
+      <script src="{{ 'assets/javascripts/bundle.d7400e89.min.js' | url }}"></script>
       {% for script in config.extra_javascript %}
         {{ script | script_tag }}
       {% endfor %}

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -80,9 +80,9 @@ const LANG_PREFIXES = ["", "zh-cn/", "en/"];
 // 加上離線內容管理頁要用的兩份。管理頁本身在 CORE_PAGES 裡，但它離線打開時還需要
 // 自己的程式與那份頁面索引，少了索引就只剩「清除全部」可以按。
 const SHELL_ASSETS = [
-  "assets/stylesheets/main.484c7ddc.min.css",
+  "assets/stylesheets/main.ec1eaa64.min.css",
   "assets/stylesheets/palette.ab4e12ef.min.css",
-  "assets/javascripts/bundle.79ae519e.min.js",
+  "assets/javascripts/bundle.d7400e89.min.js",
   "assets/javascripts/workers/search.2c215733.min.js",
   "assets/images/logo-white.svg",
   "assets/images/favicon.svg",

--- a/tools/check_theme_assets.py
+++ b/tools/check_theme_assets.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""檢查 theme 資產的檔名有沒有跟著 mkdocs-material 的版本一起換。
+
+=== 為什麼需要這支 ===
+
+docs/overrides/base.html 是 mkdocs-material base.html 的 fork，styles 與 scripts
+兩個 block 把資產檔名寫死成帶雜湊的形式（main.<hash>.min.css）。mkdocs-material
+改版時那些雜湊會變，套件裡只會有新的那一份，舊檔名不存在。
+
+2026-08-24 的 #338 用 uv sync -U 把 mkdocs-material 從 9.7.6 帶到 9.7.7，
+base.html 與 docs/zh-TW/sw.js 的雜湊都留在舊版。部署那步是 s3 sync --delete，
+舊檔案跟著被刪，於是線上三個語系的 HTML 同時指向 404 的 main.*.min.css 與
+bundle.*.min.js。
+
+這種壞法特別難救：壞的網址寫在伺服器送出來的 HTML 裡，讀者清快取、移除再重裝
+PWA 都只會拿到同一份。service worker 還讓症狀更難懂，precacheFor 用
+Promise.allSettled 容忍個別失敗，404 被靜靜跳過，install 照樣成功，接著 activate
+清掉舊的 PRECACHE，連原本靠舊快取撐著的裝置也一起失去樣式。
+
+=== 怎麼驗 ===
+
+兩層，各自守不同的時機。
+
+第一層不需要建置產物，PR 階段就能跑：docs/uv.lock 解出來的 mkdocs-material 版本，
+要等於 base.html 檔頭 theme-assets-from 記的版本。升級套件而沒回來換雜湊，這裡
+就會紅燈。
+
+第二層要有 docs/output（sh run.sh、run_zh-cn.sh、run_en.sh 建過），驗的是產物本身：
+三個語系的首頁 HTML 裡每一個指向 assets/ 的網址，在產物裡都要有對應的檔案。驗產物
+而不是驗模板，是因為讀者實際會去抓的就是這些網址，模板寫對而建置沒複製到一樣是 404。
+找不到 docs/output 時跳過那一層，沒建置過就不該擋人。
+
+用法：
+    python3 tools/check_theme_assets.py
+"""
+
+import pathlib
+import re
+import sys
+import tomllib
+from html.parser import HTMLParser
+
+HERE = pathlib.Path(__file__).resolve().parent
+DOCS = HERE.parent / "docs"
+BASE = DOCS / "overrides" / "base.html"
+LOCK = DOCS / "uv.lock"
+OUT = DOCS / "output"
+
+# 三個語系各跑一次 mkdocs build，assets 也各有一份。zh-TW 由 run.sh 建在根路徑。
+LANG_ROOTS = ["", "en", "zh-cn"]
+
+VERSION_MARK = re.compile(r"theme-assets-from:\s*mkdocs-material\s+(\S+)")
+
+
+def locked_version(lock_path=LOCK):
+    """uv.lock 裡鎖定的 mkdocs-material 版本，找不到回 None。"""
+    data = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    for package in data.get("package", []):
+        if package.get("name") == "mkdocs-material":
+            return package.get("version")
+    return None
+
+
+def recorded_version(base_path=BASE):
+    """base.html 檔頭記著「這些雜湊來自哪一版」，找不到回 None。"""
+    match = VERSION_MARK.search(base_path.read_text(encoding="utf-8"))
+    return match.group(1) if match else None
+
+
+class AssetRefs(HTMLParser):
+    """抓 HTML 裡 href 與 src 指向 assets/ 的本地網址。"""
+
+    def __init__(self):
+        super().__init__()
+        self.refs = []
+
+    def handle_starttag(self, tag, attrs):
+        for name, value in attrs:
+            if name not in ("href", "src") or not value:
+                continue
+            if "://" in value or value.startswith(("//", "#", "data:", "mailto:")):
+                continue
+            # 路徑段剛好等於 assets 才算，community/brand-assets/ 那種頁面連結不是。
+            parts = value.split("?")[0].split("#")[0].split("/")
+            if "assets" in parts:
+                self.refs.append(value)
+
+
+def missing_assets(out_dir=OUT, lang_roots=LANG_ROOTS):
+    """回傳 (語系首頁, 網址, 解出來的路徑) 三元組，全部都在的話是空的。"""
+    missing = []
+    for lang in lang_roots:
+        page = out_dir / lang / "index.html" if lang else out_dir / "index.html"
+        if not page.exists():
+            missing.append((str(page), "", "首頁不存在，建置沒跑完或語系少了一份"))
+            continue
+        parser = AssetRefs()
+        parser.feed(page.read_text(encoding="utf-8"))
+        for ref in parser.refs:
+            target = (page.parent / ref.split("?")[0].split("#")[0]).resolve()
+            if not target.exists():
+                missing.append((str(page), ref, str(target)))
+    return missing
+
+
+def main():
+    problems = []
+
+    locked = locked_version()
+    recorded = recorded_version()
+    if locked is None:
+        problems.append("docs/uv.lock 裡找不到 mkdocs-material")
+    elif recorded is None:
+        problems.append(
+            "docs/overrides/base.html 檔頭少了 theme-assets-from 標記，"
+            "補一行 `theme-assets-from: mkdocs-material <版本>`"
+        )
+    elif locked != recorded:
+        problems.append(
+            f"mkdocs-material 鎖在 {locked}，但 base.html 的資產雜湊記的是 {recorded}。\n"
+            f"    改版後雜湊會變，舊檔名在套件裡不存在，部署會讓線上的 HTML 指向 404。\n"
+            f"    到 .venv/lib/python3.12/site-packages/material/templates/assets/ 抄新的檔名，\n"
+            f"    改 base.html 的 styles、scripts 兩個 block 與 search worker、\n"
+            f"    docs/zh-TW/sw.js 的 SHELL_ASSETS，最後把檔頭那一行改成 {locked}。"
+        )
+    else:
+        print(f"  mkdocs-material {locked}，base.html 的資產雜湊標記一致。")
+
+    if OUT.exists():
+        missing = missing_assets()
+        for page, ref, target in missing:
+            problems.append(f"{page} 指向的 {ref} 在產物裡不存在（{target}）")
+        if not missing:
+            print("  三個語系首頁引用的 assets 都對得到 docs/output 裡的檔案。")
+    else:
+        print("  找不到 docs/output，跳過產物那一層。先建置過再跑這支。")
+
+    if problems:
+        print("\n資產檢查失敗：")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_theme_assets.py
+++ b/tools/test_theme_assets.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""check_theme_assets.py 的測試，外加 repo 本身的資產版本一致性。
+
+守的是兩件事。一件是那支檢查腳本的判斷邏輯：漏判會讓壞掉的產物過關，誤判會擋住
+沒問題的 PR，兩個方向都要有案例。另一件更直接，最後一個測試拿真實的 docs/uv.lock
+與 docs/overrides/base.html 比對，PR 只要升級了 mkdocs-material 而沒回來換資產雜湊，
+這支就會紅燈。那正是 2026-08-24 #338 漏掉的檢查，代價是線上三個語系同時掉樣式。
+
+不碰網路，不需要建置產物。
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from check_theme_assets import (  # noqa: E402
+    locked_version,
+    missing_assets,
+    recorded_version,
+)
+
+failures: list[str] = []
+
+
+def check(label: str, got, want) -> None:
+    if got != want:
+        failures.append(f"{label}\n    got:  {got!r}\n    want: {want!r}")
+
+
+LOCK_SAMPLE = """
+version = 1
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+
+def test_locked_version() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        lock = pathlib.Path(td) / "uv.lock"
+        lock.write_text(LOCK_SAMPLE, encoding="utf-8")
+        check("locked_version", locked_version(lock), "9.7.7")
+
+        # 套件被移掉時回 None 而不是丟例外，呼叫端才有機會印出人看得懂的訊息
+        lock.write_text('version = 1\n\n[[package]]\nname = "mkdocs"\nversion = "1.6.1"\n', encoding="utf-8")
+        check("locked_version 缺套件", locked_version(lock), None)
+
+
+def test_recorded_version() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = pathlib.Path(td) / "base.html"
+        base.write_text(
+            "{#-\n  theme-assets-from: mkdocs-material 9.7.7\n-#}\n<html></html>\n",
+            encoding="utf-8",
+        )
+        check("recorded_version", recorded_version(base), "9.7.7")
+
+        # 標記被刪掉時回 None，檢查腳本會要求補回來而不是默默放行
+        base.write_text("<html></html>\n", encoding="utf-8")
+        check("recorded_version 無標記", recorded_version(base), None)
+
+
+PAGE = """<!doctype html>
+<html><head>
+<link rel="stylesheet" href="{css}">
+<link rel="stylesheet" href="https://fonts.example.com/css?family=X">
+<link rel="canonical" href="//cdn.example.com/assets/x.css">
+</head><body>
+<a href="community/brand-assets/">品牌資產</a>
+<img src="assets/images/logo-white.svg?v=2">
+<script src="{js}"></script>
+</body></html>
+"""
+
+
+def build_output(root: pathlib.Path, *, drop: str | None = None) -> None:
+    """造一份三語系的假產物。drop 指定的檔案不建立，用來模擬雜湊沒同步。"""
+    files = [
+        "assets/stylesheets/main.ec1eaa64.min.css",
+        "assets/javascripts/bundle.d7400e89.min.js",
+        "assets/images/logo-white.svg",
+        "en/assets/stylesheets/main.ec1eaa64.min.css",
+        "en/assets/javascripts/bundle.d7400e89.min.js",
+        "en/assets/images/logo-white.svg",
+        "zh-cn/assets/stylesheets/main.ec1eaa64.min.css",
+        "zh-cn/assets/javascripts/bundle.d7400e89.min.js",
+        "zh-cn/assets/images/logo-white.svg",
+    ]
+    for rel in files:
+        if rel == drop:
+            continue
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x", encoding="utf-8")
+    for lang in ["", "en", "zh-cn"]:
+        page = root / lang / "index.html" if lang else root / "index.html"
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text(
+            PAGE.format(
+                css="assets/stylesheets/main.ec1eaa64.min.css",
+                js="assets/javascripts/bundle.d7400e89.min.js",
+            ),
+            encoding="utf-8",
+        )
+
+
+def test_missing_assets_all_present() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        build_output(root)
+        # 外部網址、協定相對網址與 community/brand-assets/ 那種頁面連結都不該被算進來，
+        # 誤判會擋住沒問題的 PR。帶 ?v=2 的圖也要能對到檔案。
+        check("產物齊全", missing_assets(root), [])
+
+
+def test_missing_assets_detects_stale_hash() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        build_output(root, drop="en/assets/stylesheets/main.ec1eaa64.min.css")
+        missing = missing_assets(root)
+        check("只抓到 en 那一份", len(missing), 1)
+        if missing:
+            page, ref, _ = missing[0]
+            check("回報的語系", pathlib.Path(page).parent.name, "en")
+            check("回報的網址", ref, "assets/stylesheets/main.ec1eaa64.min.css")
+
+
+def test_missing_assets_reports_absent_page() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        build_output(root)
+        (root / "zh-cn" / "index.html").unlink()
+        missing = missing_assets(root)
+        check("少一個語系首頁", len(missing), 1)
+
+
+def test_repo_versions_match() -> None:
+    """真實檔案的一致性。升級 mkdocs-material 而沒換資產雜湊時，這裡紅燈。"""
+    locked = locked_version()
+    recorded = recorded_version()
+    if locked is None:
+        failures.append("docs/uv.lock 裡找不到 mkdocs-material")
+        return
+    if recorded is None:
+        failures.append("docs/overrides/base.html 檔頭少了 theme-assets-from 標記")
+        return
+    if locked != recorded:
+        failures.append(
+            f"mkdocs-material 鎖在 {locked}，base.html 的資產雜湊記的是 {recorded}。"
+            " 改版後雜湊會變，部署會讓線上的 HTML 指向 404。"
+            " 詳細的修法見 tools/check_theme_assets.py 的檔頭。"
+        )
+
+
+def main() -> int:
+    for fn in [
+        test_locked_version,
+        test_recorded_version,
+        test_missing_assets_all_present,
+        test_missing_assets_detects_stale_hash,
+        test_missing_assets_reports_absent_page,
+        test_repo_versions_match,
+    ]:
+        fn()
+    if failures:
+        print(f"FAILED ({len(failures)})")
+        for f in failures:
+            print("  " + f)
+        return 1
+    print("theme assets tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 線上現況

`/docs/`、`/docs/en/`、`/docs/zh-cn/` 三個語系的 HTML 都指向兩個不存在的檔案：

```
https://anoni.net/docs/assets/stylesheets/main.484c7ddc.min.css   → 404
https://anoni.net/docs/assets/javascripts/bundle.79ae519e.min.js  → 404
https://anoni.net/docs/assets/stylesheets/palette.ab4e12ef.min.css → 200
https://anoni.net/docs/assets/javascripts/workers/search.2c215733.min.js → 200
```

palette 與 search worker 那兩份 9.7.7 沒改，所以站上還剩半套樣式，主樣式表與主程式都掉了。

## 根因

`docs/overrides/base.html` 是 mkdocs-material base.html 的 fork，`{% block styles %}` 與 `{% block scripts %}` 把帶雜湊的資產檔名寫死，`docs/zh-TW/sw.js` 的 `SHELL_ASSETS` 也有同一組。#338 用 `uv sync -U` 把 mkdocs-material 從 9.7.6 帶到 9.7.7，這兩個檔案留在舊雜湊。部署那步是 `s3 sync --delete`，舊檔案在部署當下就被刪掉。

| 舊（HTML 還在指） | 新（9.7.7 實際檔名） |
|---|---|
| `main.484c7ddc.min.css` | `main.ec1eaa64.min.css` |
| `bundle.79ae519e.min.js` | `bundle.d7400e89.min.js` |
| `palette.ab4e12ef.min.css` | 未變 |
| `workers/search.2c215733.min.js` | 未變 |

讀者自己救不了這種壞法。錯的網址寫在伺服器送出來的 HTML 裡，清快取、移除再重裝 PWA 都只會拿到同一份。service worker 讓症狀更難懂一層：`precacheFor` 用 `Promise.allSettled` 容忍個別失敗，404 被靜靜跳過，install 照樣成功，接著 activate 清掉舊的 `PRECACHE`，連原本靠舊快取撐著樣式的裝置也一起失去。

## 這次的改動

修雜湊，另外補上三道守門。

- `tools/check_theme_assets.py`：第一層不需要建置產物，比對 `docs/uv.lock` 解出來的 mkdocs-material 版本與 `base.html` 檔頭新增的 `theme-assets-from` 標記。第二層有 `docs/output` 時，驗三個語系首頁引用的每個 assets 網址都對得到檔案。
- `tools/test_theme_assets.py`：測那支腳本的判斷，最後一個案例直接拿真實檔案比對版本，掛在 `tools-tests.yml`。那份 workflow 的 paths 補上 `docs/uv.lock`，#338 只動了這個檔案，當時一支測試都沒被觸發。
- `build_docs.yml`：在三支 `run_*.sh` 之後、上傳之前加 `check_theme_assets.py`，以及 2025 年就寫好卻從來沒被跑過的 `check_precache.mjs`。擋在上傳前的話，最壞是這次沒發布，站上維持上一版。

## 驗證

- `uv sync` 到 9.7.7 後三支 `run_*.sh` 都 exit 0，只剩既有的 git follow 時間戳 warning
- `check_theme_assets.py` 與 `check_precache.mjs` 對三語系產物都通過（預快取 30.47 MB、245 個 URL 全部命中）
- 把標記改回 9.7.6、把產物裡的 `main.ec1eaa64.min.css` 移走，兩種情況各自紅燈
- `test_sw_offline.mjs` 74 通過、`test_offline_library.mjs` 26 通過、`offline_index` 通過

## 合併之後

要推 `docs` 分支才會重新建置上傳，站上才會恢復。部署完讀者正常重新載入就好，導覽是 network-first，拿到新 HTML 就會去抓新的 assets 網址，不需要等他們在換版提示上按更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
