### PR TITLE
docs(changelog): 補上 Tails 7.11（三語）

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,19 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.11
+
+> 2026-08-19 · [Upstream announcement](https://tails.net/news/version_7.11/){target="_blank"}
+
+- A scheduled release that also carries a Linux kernel security update.
+- Tor Browser updated to 15.0.20 (based on Firefox ESR 140.14).
+- The kernel is updated to 6.12.101, covering the 24 flaws in Debian security advisory DSA-6415-1, whose impact ranges over privilege escalation, denial of service, and information leaks.
+- Fixes Persistent Storage failing to unlock on some computers. Activation used to wait for `udevadm settle`, so an unrelated hardware problem could make that step time out or fail; the wait has been removed.
+- Adds the `proc_mem.force_override=ptrace` kernel parameter, which stops a process from writing directly to its own memory mappings and makes privilege-escalation flaws harder to exploit.
+- Circumvention settings now import Moat fronts and reflectors from Tor Browser automatically, so connections fail less often because of stale settings.
+- The flatpak package follows the Debian security update and is now based on 1.16.6-1~deb13u2.
+- Automatic upgrades are available from Tails 7.0 or later; a manual upgrade is available if the automatic one fails. Fresh installations will erase existing Persistent Storage.
+
 ## Tails 7.10.1
 
 > 2026-08-05 · [Upstream announcement](https://tails.net/news/version_7.10.1/){target="_blank"}

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,19 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.11
+
+> 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
+
+- 例行排程版本，同时带入 Linux 内核的安全更新。
+- Tor Browser 升至 15.0.20（基于 Firefox ESR 140.14）。
+- 内核升至 6.12.101，涵盖 Debian 安全公告 DSA-6415-1 的 24 个漏洞，影响包含提权、拒绝服务与信息泄露。
+- 修正部分电脑上 Persistent Storage 无法解锁的问题。启用流程原本会等待 `udevadm settle`，无关的硬件问题会让这一步超时或失败，现已不再等待。
+- 新增内核参数 `proc_mem.force_override=ptrace`，阻挡进程直接改写自己的内存映射，提高提权漏洞的利用难度。
+- 抗审查连接设置改为自动从 Tor Browser 导入 Moat fronts 与 reflectors，减少因设置过期而连不上的情况。
+- flatpak 软件包跟进 Debian 安全更新，改以 1.16.6-1~deb13u2 为基础。
+- 可从 Tails 7.0 以后版本自动升级，若自动升级失败可改用手动升级。全新安装会清除既有的 Persistent Storage。
+
 ## Tails 7.10.1
 
 > 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,19 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.11
+
+> 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
+
+- 例行排程版本，同時帶入 Linux 核心的安全更新。
+- Tor Browser 升至 15.0.20（基於 Firefox ESR 140.14）。
+- 核心升至 6.12.101，涵蓋 Debian 安全公告 DSA-6415-1 的 24 個漏洞，影響包含提權、阻斷服務與資訊外洩。
+- 修正部分電腦上 Persistent Storage 無法解鎖的問題。啟用流程原本會等待 `udevadm settle`，無關的硬體問題會讓這一步逾時或失敗，現已不再等待。
+- 新增核心參數 `proc_mem.force_override=ptrace`，阻擋行程直接改寫自己的記憶體映射，提高提權漏洞的利用難度。
+- 抗審查連線設定改為自動從 Tor Browser 匯入 Moat fronts 與 reflectors，減少因設定過期而連不上的情況。
+- flatpak 套件跟進 Debian 安全更新，改以 1.16.6-1~deb13u2 為基礎。
+- 可從 Tails 7.0 以後版本自動升級，若自動升級失敗可改用手動升級。全新安裝會清除既有的 Persistent Storage。
+
 ## Tails 7.10.1
 
 > 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}


### PR DESCRIPTION
## 這次更新

例行巡檢上游四個軟體，只有 Tails 有新版。

| 軟體 | 站上已收錄 | 上游最新 | 動作 |
|---|---|---|---|
| Tails | 7.10.1（08-05） | **7.11（08-19）** | 本 PR 新增 |
| Tor Browser | 15.0.20（08-18）/ 16.0a9（07-23） | 同左 | 無變更 |
| Arti | 2.5.1（08-03） | 同左 | 無變更 |
| OONI Probe | 6.2.0（08-13） | 同左 | 無變更 |

Tor Browser 以 `dist.torproject.org/torbrowser/` 目錄、Arti 以 crates.io 與 GitLab tag、OONI Probe 以 GitHub releases API 交叉驗證，確認部落格沒有漏發的釋出。

## Tails 7.11 條目內容

上游公告本身只寫兩行（Tor Browser 升級、修 Persistent Storage），其餘從 `debian/changelog` 的 7.11 區段補齊：

- Tor Browser 升至 15.0.20（Firefox ESR 140.14）
- 核心升至 6.12.101，涵蓋 DSA-6415-1 的 24 個漏洞，影響含提權、阻斷服務與資訊外洩
- Persistent Storage 無法解鎖的成因：啟用流程等待 `udevadm settle`，無關硬體問題會讓該步逾時，現已移除等待（tails#19913）
- 新增核心參數 `proc_mem.force_override=ptrace`，阻擋行程改寫自身記憶體映射（tails#21250）
- 抗審查連線設定改為自動從 Tor Browser 匯入 Moat fronts 與 reflectors（tails#21641）
- flatpak 跟進 Debian 安全更新至 1.16.6-1~deb13u2

## 驗證

- `tools/docs_style_lint.py` 掃三語系：0 error、0 warn
- `run.sh`、`run_en.sh`、`run_zh-cn.sh` 三語系建置（`-s` 嚴格模式）皆通過，產物確認含新條目

🤖 Generated with [Claude Code](https://claude.com/claude-code)