### PR TITLE
fix(ci): 補上 botocore，讓「跳過未變動檔案」真的生效

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -16,4 +16,10 @@ dependencies = [
 [dependency-groups]
 dev = [
     "awscli>=1.38.36",
+    # tools/s3_restore_mtime.py 用 botocore 讀 S3 物件清單。awscli 1.x 以前會把
+    # botocore 當成一般相依裝進 site-packages，1.46.0 起改成內嵌成 awscli.botocore，
+    # 頂層 `import botocore` 就再也找不到。那支腳本的例外處理會把 ImportError 吞掉
+    # 退回完整上傳，CI 只留下一則沒人看的 warning，優化等於靜靜失效。
+    # 這裡明講相依，不靠 awscli 的內部結構。
+    "botocore>=1.35",
 ]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "awscli" },
+    { name = "botocore" },
 ]
 
 [package.metadata]
@@ -31,7 +32,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "awscli", specifier = ">=1.38.36" }]
+dev = [
+    { name = "awscli", specifier = ">=1.38.36" },
+    { name = "botocore", specifier = ">=1.35" },
+]
 
 [[package]]
 name = "awscli"
@@ -71,6 +75,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
     { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
     { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.80"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/94/de291ad81495365682722efa9397c54c7b666f7bf1ae4064d26e40a55296/botocore-1.43.80.tar.gz", hash = "sha256:c021e60df26d17e9a8db05fa5071669449c8fd15e0fb4374f56a6c17d553f89b", size = 16003031, upload-time = "2026-08-25T20:38:29.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/93/7bba357266450f7d3e3075ee4d2f1e1d96c1617e40d8065c558485baed78/botocore-1.43.80-py3-none-any.whl", hash = "sha256:461bce2159eadd758d0651d2a11dced3450169383e6ca8ef65f5c250f8b7ebd4", size = 15695640, upload-time = "2026-08-25T20:38:26.76Z" },
 ]
 
 [[package]]

--- a/tools/s3_restore_mtime.py
+++ b/tools/s3_restore_mtime.py
@@ -117,14 +117,28 @@ def main() -> int:
         print("::error::--prefix 結尾要有斜線", file=sys.stderr)
         return 1
 
+    # 匯入失敗跟讀取失敗分開處理。讀不到清單可能是一時的（憑證、網路、S3 抽風），
+    # 退回完整上傳就好，warning 的份量剛好。匯入失敗是環境壞了，每一次部署都會踩到，
+    # 而這一步失敗不會讓任何一格變紅，只留下一則沒人看的訊息，這個優化就這樣靜靜
+    # 失效了好一段時間（awscli 1.46.0 把 botocore 內嵌成 awscli.botocore，不再宣告
+    # 頂層相依）。所以匯入失敗用 error 標，讓它在 Actions 頁面上是紅的。
+    # 仍然回 0：這是效能優化，不值得為它擋下整個部署。
     try:
         import botocore.session
+    except ImportError as exc:
+        print(
+            f"::error::botocore 匯入失敗（{exc}），略過時間戳還原，這次會完整上傳。"
+            "這是環境問題不是暫時性錯誤，補上相依之前每次部署都會完整上傳",
+            file=sys.stderr,
+        )
+        return 0
 
+    try:
         client = botocore.session.get_session().create_client(
             "s3", endpoint_url=args.endpoint_url
         )
         index = remote_index(client, args.bucket, args.prefix)
-    except Exception as exc:  # noqa: BLE001 - 任何問題都退回什麼都不做
+    except Exception as exc:  # noqa: BLE001 - 讀不到就退回什麼都不做
         print(
             f"::warning::讀不到 S3 物件清單（{type(exc).__name__}: {exc}），"
             "略過時間戳還原，這次會完整上傳",


### PR DESCRIPTION
## 症狀

2026-08-26 的部署（[run 32954092407](https://github.com/anoni-net/docs/actions/runs/32954092407)）留下一則 warning：

> 讀不到 S3 物件清單（`ModuleNotFoundError: No module named 'botocore'`），略過時間戳還原，這次會完整上傳

## 根因

`awscli` 1.46.0 把 botocore 內嵌成 `awscli.botocore`，不再宣告頂層 `botocore` 相依。`docs/pyproject.toml` 的 dev group 只寫 `awscli>=1.38.36`，升上 1.46 之後 site-packages 裡就沒有 botocore 了。

```
$ ls .venv/lib/python3.13/site-packages/ | grep -i boto
（沒有）
$ .venv/bin/python -c "import botocore.session"
ModuleNotFoundError: No module named 'botocore'
$ .venv/bin/python -c "from awscli.botocore import session; print('ok')"
ok
```

`s3_restore_mtime.py` 用 `except Exception` 把任何問題都吞掉退回完整上傳，這一步不會變紅，所以 #325 那個「兩千多個檔案通常只有個位數真的要傳」的優化靜靜失效，每次部署都在完整上傳。

## 改動

- `docs/pyproject.toml` 的 dev group 明講 `botocore>=1.35`，不靠 awscli 的內部結構。
- `tools/s3_restore_mtime.py` 把匯入失敗與讀取失敗分開。讀不到清單可能是憑證、網路或 S3 一時的問題，維持 `::warning::`；匯入失敗是環境壞了，每次部署都會踩到，改用 `::error::` 標成紅的。兩者都仍然回 `0`，這是效能優化，不值得為它擋下整個部署。

## 驗證

- `uv sync --group=dev` 後 `import botocore.session` 正常（1.43.80）
- `python3 tools/test_s3_restore_mtime.py` 全數通過

合併後下一次部署應該會從「完整上傳兩千多個檔案」回到「只傳實際變動的那幾個」，可以在 Actions 的上傳步驟看數字確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)