### PR TITLE
fix(ipfs): 發布後等 IPNS ttl 過去再移除舊版本

### DIFF
--- a/docs/upload_to_ipfs.sh
+++ b/docs/upload_to_ipfs.sh
@@ -63,7 +63,10 @@ echo "[upload] 新 CID: $NEW_CID"
 echo "[upload] 發布 IPNS ([anoni-net] key)..."
 # --lifetime=720h：DHT 上的 IPNS record 30 天內有效，避免 gateway 解析時找不到（預設 24h 對非每日 deploy 太短）
 # --ttl=1m：客戶端/閘道 cache IPNS 解析結果 1 分鐘，縮短發布後換新版的空窗。
-#          配合節點已開的 Routing.AcceleratedDHTClient（ipfs_host），重新解析很便宜，壓低 ttl 划算。
+#          這個註解原本寫「配合節點已開的 Routing.AcceleratedDHTClient，重新解析很便宜」，
+#          那個前提不成立：ipfs_host 上 Routing.AcceleratedDHTClient 實際是 false。
+#          不過 2026-08-26 實測 `ipfs name resolve --nocache` 是 0.27 到 0.42 秒，
+#          解析本身不慢，ttl 壓低沒有問題。真正被這個 ttl 影響的是下面 GC 的時機。
 ipfs $IPFS_API name publish \
     --key=anoni-net \
     --lifetime=720h \
@@ -71,7 +74,8 @@ ipfs $IPFS_API name publish \
     "/ipfs/$NEW_CID"
 
 # 主動把新 CID 宣告到 DHT（root 即可，閘道連上本節點後會用 bitswap 抓其餘區塊）。
-# 配合 Accelerated DHT Client，provide 很快；非致命，失敗不中斷發布。
+# 非致命，失敗不中斷發布。節點沒有開 Routing.AcceleratedDHTClient，
+# provide 會比開了慢，內容照樣宣告得出去，只是別預期它是瞬間完成。
 echo "[upload] provide 新 CID 到 DHT..."
 ipfs $IPFS_API routing provide "$NEW_CID" || echo "[upload] provide 非致命失敗，繼續"
 
@@ -96,11 +100,25 @@ if [ -n "$OLD_CID" ]; then
         # 內容未變時 add 出的 CID 會與舊版相同，這時 unpin + 後續 repo gc 會把剛發布的內容刪掉。
         echo "[upload] 內容未變（CID 與舊版相同 $NEW_CID），跳過 unpin 以免移除剛發布的內容"
     else
+        # 舊版本要等 IPNS 的 ttl 過去才能刪。閘道在 ttl 內仍然把 DNSLink 解析成舊 CID，
+        # 這時候舊 CID 的區塊已經被 unpin 加 GC 掉，閘道只好轉去網路上找一份沒有人
+        # 提供的內容，最後逾時。2026-08-26 那次發布之後，連續兩次請求回 504，第三次
+        # 才 200，就是這個窗口。nginx 的錯誤日誌沒有 upstream timeout，504 是 kubo 自己回的。
+        #
+        # 等待長度用 IPFS_GC_GRACE 覆蓋（秒），設 0 可以完全跳過。預設 90 秒是
+        # 上面 --ttl=1m 再加一點緩衝。
+        GC_GRACE="${IPFS_GC_GRACE:-90}"
+        if [ "$GC_GRACE" -gt 0 ]; then
+            echo "[upload] 等 ${GC_GRACE}s 讓閘道的 IPNS 快取過期，再移除舊版本..."
+            sleep "$GC_GRACE"
+        fi
         echo "[upload] Unpin 舊版本: $OLD_HASH"
         ipfs $IPFS_API pin rm "$OLD_HASH" 2>/dev/null || echo "[upload] Unpin 失敗（可能已移除），繼續"
     fi
 fi
 
+# GC 維持無條件執行。沒有 unpin 任何東西時（首次發布，或內容未變 CID 相同）它也沒有
+# 東西可刪，跑一次不影響剛發布的內容。
 echo "[upload] 執行 repo GC..."
 ipfs $IPFS_API repo gc
 


### PR DESCRIPTION
## 症狀

2026-08-26 那次發布（#356 合併後的第一次）之後，連續兩次請求 `https://ipfs.anoni.net/` 回 504，第三次才 200：

```
第 1 次: 504
第 2 次: 504
第 3 次: 200
```

## 根因

nginx 的錯誤日誌裡沒有 upstream timeout，所以 504 是 kubo 自己回的，不是反代逾時。

`upload_to_ipfs.sh` 的 unpin 加 `repo gc` 緊接在 `name publish` 之後。閘道在 `--ttl=1m` 的窗口內仍然把 DNSLink 解析成舊 CID，而舊 CID 的區塊那時候已經被刪掉，閘道只好轉去網路上找一份沒有人提供的內容，最後逾時。

## 改動

unpin 前先等一段時間，長度用 `IPFS_GC_GRACE` 覆蓋（秒），設 `0` 完全跳過。預設 90 秒是 ttl 的 1 分鐘再加緩衝。

`repo gc` 維持無條件執行。首次發布或內容未變（CID 相同）時它本來就沒有東西可刪，位置不動可以少一個行為差異。

## 順帶修掉兩則與實際不符的註解

原本寫著「配合節點已開的 `Routing.AcceleratedDHTClient`」，但那台節點上：

```
$ ipfs config Routing.AcceleratedDHTClient
false
```

`provide` 與 IPNS 解析的成本描述都建立在這個不成立的前提上。

實測 `ipfs name resolve --nocache` 是 0.27 到 0.42 秒，解析本身不慢，所以 `--ttl=1m` 的結論仍然成立，只是理由不是原本寫的那個。真正被這個 ttl 影響的是 GC 的時機，也就是這個 PR 修的東西。

要不要在節點上開 `AcceleratedDHTClient` 是另一個決定，它會吃記憶體與頻寬，那台是小規格 droplet，這個 PR 不動它。

🤖 Generated with [Claude Code](https://claude.com/claude-code)