### PR TITLE
feat(docs): 頁首標出目前是哪一種部署，IPFS 版加匿名性提醒

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -51,6 +51,10 @@ jobs:
     env:
       # clearnet 產物維持在既有的 docs/，onion 產物放同一個 bucket 的 docs-onion/。
       S3_PREFIX: ${{ matrix.variant == 'onion' && 'docs-onion' || 'docs' }}
+      # 頁首的版本小標記讀這個值。matrix 的兩個值剛好就是模板要的字串，
+      # 本機的 build_docs_anoni_onion.sh 也 export 同一個名字。IPFS 版不在這個
+      # workflow 裡建，它由 build_docs_anoni_ipfs.sh 帶 BUILD_VARIANT=ipfs。
+      BUILD_VARIANT: ${{ matrix.variant }}
     defaults:
       run:
         working-directory: ./docs

--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -22,6 +22,9 @@ set -euo pipefail
 # 不必重建鏡像。
 export IPFS_GATEWAY="${IPFS_GATEWAY:-https://ipfs.anoni.net}"
 
+# 頁首的版本小標記與 IPFS 版專屬的橫幅讀這個值。
+export BUILD_VARIANT=ipfs
+
 # macOS 本地建置前置：
 # - gnu-sed：BSD sed 不接受 `sed -i 's|x|y|g'` 格式
 # - DYLD_FALLBACK_LIBRARY_PATH：cairosvg 需 libcairo.2.dylib，SIP 會 strip 子 sh 的 DYLD_*

--- a/docs/build_docs_anoni_onion.sh
+++ b/docs/build_docs_anoni_onion.sh
@@ -1,3 +1,6 @@
+# 頁首的版本小標記讀這個值。run.sh 等三支是子行程，export 會傳下去。
+export BUILD_VARIANT=onion
+
 sh ./replace_sitename_anoni_onion.sh
 rm -rf ./output/*
 # 清掉 privacy plugin 快取，避免外部資源（如 vega-embed）換 URL 形狀後殘留舊鏡像 symlink 害圖表不 render

--- a/docs/en/about/how-you-are-reading.md
+++ b/docs/en/about/how-you-are-reading.md
@@ -1,0 +1,63 @@
+---
+title: How you are reading this
+description: The site is published three ways at once — as a standard website, a Tor onion service, and an IPFS mirror. The content is identical; the path it takes to reach you, and who can see what along the way, are not.
+icon: material/routes
+---
+
+# :material-routes: How you are reading this
+
+The site is published three times over, with identical content. What differs is how that content reaches you and who can see what along the way. The chip in the top right of the header tells you which edition you are on; the standard site carries no chip.
+
+## The three editions side by side
+
+| | Standard site | Onion | IPFS mirror |
+|---|---|---|---|
+| Address | `anoni.net/docs` | `docs.…onion` | `ipfs.anoni.net` or another gateway |
+| Who sees your IP address | our CDN and host | nobody | the gateway operator you connect to |
+| Who knows which pages you read | same as above | nobody | same as above |
+| What your ISP sees | that you reached anoni.net | that you are using Tor | that you reached that gateway |
+| If the site is taken down | unreachable | unaffected | unaffected |
+| What you need | an ordinary browser | Tor Browser | an ordinary browser |
+| Offline reading | available | not offered | not offered |
+| Traffic analytics | yes | no | no |
+
+## Standard site
+
+An ordinary connection to `anoni.net`. Fastest, most complete, and the only edition that offers [offline reading](../offline.md).
+
+The cost is that our CDN and host see your IP address, and the site keeps traffic statistics that do not record personal identity. When the domain is blocked or taken down, this edition becomes unreachable.
+
+## Onion
+
+The site runs inside the Tor network. Visitor and site cannot see each other's IP addresses, no DNS is involved, and there is no certificate authority. Your ISP sees that you are using Tor and nothing about which site you reached or which page you read.
+
+An `.onion` address carries no certificate authority endorsement, so checking the address itself is the only verification available. The full address is printed in the footer of every page: compare it against your address bar, and if they match you are on our site. That habit is worth forming, because look-alike phishing addresses are a real technique.
+
+This edition loads no analytics and registers no background Service Worker, which is why offline reading is absent. Latency is higher than the standard site, as it is for Tor generally.
+
+## IPFS mirror
+
+Content is addressed by fingerprint (CID), so any node can serve the same copy and there is no single location to take down. Community members can help keep a copy alive, described in [pin the IPFS mirror](../community/pin-ipfs-mirror.md).
+
+Note that reading over IPFS does not make the connection anonymous. You are using an ordinary browser to reach a gateway, that gateway sees your IP address and every address you request, and on the network you look like an ordinary HTTPS client. To get takedown resistance and connection anonymity together, open the onion edition in Tor Browser.
+
+The full exposure picture is in [networks mistaken for anonymity](../advanced/mistaken-for-anonymity.md), and the publisher-side trade-offs are in [decentralized website publishing](../advanced/dweb-ipfs-onion.md).
+
+## Which one to use
+
+For everyday reading, the standard site is fine.
+
+When it matters that the connection stays unseen, or you are on a network that is monitored, use the onion edition.
+
+When the standard site is unreachable and Tor Browser is not at hand, the IPFS mirror gets you the content. Do not treat it as an anonymity measure.
+
+## :fontawesome-solid-diagram-project: Related reading
+
+<div class="grid cards" markdown>
+
+- [:material-web-box: Decentralized website publishing](../advanced/dweb-ipfs-onion.md)
+- [:material-incognito: Networks mistaken for anonymity](../advanced/mistaken-for-anonymity.md)
+- [:simple-ipfs: Pin the IPFS mirror](../community/pin-ipfs-mirror.md)
+- [:material-download: Offline reading](../offline.md)
+
+</div>

--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -454,3 +454,63 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-typeset table:not([class]) {
   width: 100%;
 }
+
+/* ==========================================================================
+   Deployment variant chip and the IPFS banner
+
+   The pill in the header marks whether this build is the onion or the IPFS edition;
+   the standard site shows nothing. All three languages share one
+   partials/header.html through a symlink, so the wording comes from config.extra.
+
+   The border uses currentcolor so it follows the header foreground and survives a
+   palette change without edits here.
+
+   On narrow screens only the icon remains: the header already carries the language,
+   search and source buttons, and one more text run would squeeze out the site name.
+   ========================================================================== */
+
+.anoni-variant {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin: 0 0.2rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  color: inherit;
+  font-size: 0.62rem;
+  line-height: 1.7;
+  white-space: nowrap;
+  opacity: 0.82;
+  transition: opacity 125ms;
+}
+
+.anoni-variant:hover,
+.anoni-variant:focus-visible {
+  opacity: 1;
+}
+
+.anoni-variant__icon {
+  display: inline-flex;
+}
+
+.anoni-variant__icon svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: currentcolor;
+}
+
+@media screen and (max-width: 76.1875em) {
+  .anoni-variant__label {
+    display: none;
+  }
+
+  .anoni-variant {
+    padding: 0.15rem 0.35rem;
+  }
+}
+
+.anoni-announce__host {
+  font-family: var(--md-code-font-family);
+  overflow-wrap: anywhere;
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
               - event-workshop-2025-prepare.md
   - !ENV [NAV_ABOUT, "關於我們"]:
       - about/index.md
+      - about/how-you-are-reading.md
       - contact.md
       - offline.md
 theme:
@@ -219,6 +220,7 @@ theme:
     - content.tooltips
     - content.code.copy
     - content.footnote.tooltips
+    - announce.dismiss
 extra:
   # 每一筆分析資料都帶著這個標籤，改版前後才比較得出來。CI 由 build_docs.yml
   # 帶 commit 短碼進來，本機建置就是 dev。
@@ -229,6 +231,14 @@ extra:
   # 換 gateway 時設 IPFS_GATEWAY 環境變數，或改這一行的預設值。
   # DNSLink（_dnslink.anoni.net）指向同一個 IPNS 名稱，所以換主機名就能換入口。
   ipfs_gateway: !ENV [IPFS_GATEWAY, "https://ipfs.anoni.net"]
+  # 這份產物是哪一種部署。標準站不顯示任何標記，onion 與 IPFS 版在頁首掛一個小標記，
+  # 讓讀者知道手上這份內容是怎麼送到面前的。三支 build 腳本與 CI 的 matrix 各自帶值
+  # 進來，建置時就決定，不靠 JS 也不靠 hostname 判斷（IPFS 的 hostname 本來就會變）。
+  build_variant: !ENV [BUILD_VARIANT, "standard"]
+  # 小標記的文字。zh-TW 用這裡的預設值，另外兩個語系由 run_en.sh、run_zh-cn.sh 覆蓋，
+  # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
+  variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
+  variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
   alternate:
     # zh-TW 填 /docs/，不填 /docs/zh-tw/。zh-TW 是網站預設語系，run.sh 直接把它建在
     # 根路徑，沒有獨立的語系區段。填 /docs/ 讓 hreflang 有 self-reference（Google 要求

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -154,6 +154,7 @@ nav:
               - event-workshop-2025-prepare.md
   - !ENV [NAV_ABOUT, "关于我们"]:
       - about/index.md
+      - about/how-you-are-reading.md
       - contact.md
       - offline.md
 theme:
@@ -198,6 +199,7 @@ theme:
     - content.tooltips
     - content.code.copy
     - content.footnote.tooltips
+    - announce.dismiss
 extra:
   # 每一筆分析資料都帶著這個標籤，改版前後才比較得出來。CI 由 build_docs.yml
   # 帶 commit 短碼進來，本機建置就是 dev。
@@ -208,6 +210,14 @@ extra:
   # 換 gateway 時設 IPFS_GATEWAY 環境變數，或改這一行的預設值。
   # DNSLink（_dnslink.anoni.net）指向同一個 IPNS 名稱，所以換主機名就能換入口。
   ipfs_gateway: !ENV [IPFS_GATEWAY, "https://ipfs.anoni.net"]
+  # 這份產物是哪一種部署。標準站不顯示任何標記，onion 與 IPFS 版在頁首掛一個小標記，
+  # 讓讀者知道手上這份內容是怎麼送到面前的。三支 build 腳本與 CI 的 matrix 各自帶值
+  # 進來，建置時就決定，不靠 JS 也不靠 hostname 判斷（IPFS 的 hostname 本來就會變）。
+  build_variant: !ENV [BUILD_VARIANT, "standard"]
+  # 小標記的文字。zh-TW 用這裡的預設值，另外兩個語系由 run_en.sh、run_zh-cn.sh 覆蓋，
+  # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
+  variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
+  variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
   alternate:
     # zh-TW 是網站預設語系，建在根路徑，沒有獨立語系區段。理由見 mkdocs.yml 的註解。
     - name: 臺灣正體（zh-TW）

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -14,6 +14,7 @@ nav:
   - index.md
   - !ENV [NAV_ABOUT, "About"]:
       - about/index.md
+      - about/how-you-are-reading.md
       - contact.md
       - offline.md
   - !ENV [NAV_GUIDES, "Guides"]:
@@ -199,6 +200,7 @@ theme:
     - content.tooltips
     - content.code.copy
     - content.footnote.tooltips
+    - announce.dismiss
 extra:
   # 每一筆分析資料都帶著這個標籤，改版前後才比較得出來。CI 由 build_docs.yml
   # 帶 commit 短碼進來，本機建置就是 dev。
@@ -209,6 +211,14 @@ extra:
   # 換 gateway 時設 IPFS_GATEWAY 環境變數，或改這一行的預設值。
   # DNSLink（_dnslink.anoni.net）指向同一個 IPNS 名稱，所以換主機名就能換入口。
   ipfs_gateway: !ENV [IPFS_GATEWAY, "https://ipfs.anoni.net"]
+  # 這份產物是哪一種部署。標準站不顯示任何標記，onion 與 IPFS 版在頁首掛一個小標記，
+  # 讓讀者知道手上這份內容是怎麼送到面前的。三支 build 腳本與 CI 的 matrix 各自帶值
+  # 進來，建置時就決定，不靠 JS 也不靠 hostname 判斷（IPFS 的 hostname 本來就會變）。
+  build_variant: !ENV [BUILD_VARIANT, "standard"]
+  # 小標記的文字。zh-TW 用這裡的預設值，另外兩個語系由 run_en.sh、run_zh-cn.sh 覆蓋，
+  # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
+  variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
+  variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
   alternate:
     - name: English (en-US)
       link: /docs/en/

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -62,6 +62,23 @@
   {% endif %}
 {% endblock %}
 
+{% block announce %}{% if config.extra.build_variant == "ipfs" %}{#-
+  IPFS 版專屬的橫幅。onion 與標準站不顯示，base.html 用 self.announce() 判斷有沒有
+  內容，這個 if 之外不能留任何字元，留了會在另外兩個版本渲染出一條空的橫幅。
+
+  為什麼只有 IPFS 版有：onion 的讀者是刻意走過來的，頁首的小標記確認一下就夠。
+  IPFS 的讀者可能是點到閘道連結才進來的，甚至不知道自己在讀鏡像，而閘道業者
+  看得到他的 IP 與每一個請求，那件事值得在讀者踩到的當下講一次。
+
+  主機名由下面那段 JS 填。鏡像可以掛在任何閘道上（見 replace_sitename_anoni_ipfs.sh），
+  寫死一個名字就等於把好不容易拆掉的耦合裝回去。JS 被關掉時句子照樣讀得通。
+-#}IPFS 鏡像。你正在用的閘道<span id="anoni-gateway-host"></span>看得到你的 IP 與你要求的每一個位址，走 IPFS 讀不會讓連線變匿名。<a href="{{ 'about/how-you-are-reading/' | url }}">三種閱讀方式的差別</a><script>
+  (function () {
+    var el = document.getElementById("anoni-gateway-host");
+    if (el && location.hostname) el.textContent = "（" + location.hostname + "）";
+  })();
+</script>{% endif %}{% endblock %}
+
 {% block scripts %}
   {{ super() }}
 <!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,0 +1,97 @@
+{#-
+  Fork of mkdocs-material partials/header.html: 加一個部署版本的小標記。
+  升級 mkdocs-material 時比對上游這支有沒有變，只有 anoni-variant 那一段是我們加的。
+
+  theme-partial-from: mkdocs-material 9.7.7
+-#}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {#-
+      部署版本的小標記。標準站什麼都不顯示（讀者用一般網路連一般網站，沒有要說的），
+      onion 與 IPFS 版各掛一個，點下去是〈你正在用哪一種方式閱讀〉。
+      文案走 config，因為這支 partial 是三個語系共用的符號連結。
+      純 HTML 加 CSS，Tor Browser 把 JS 關到最嚴也看得到。
+    -#}
+    {% if config.extra.build_variant == "onion" or config.extra.build_variant == "ipfs" %}
+      {% if config.extra.build_variant == "onion" %}
+        {% set variant_label = config.extra.variant_label_onion %}
+        {% set variant_icon = "simple/torbrowser" %}
+      {% else %}
+        {% set variant_label = config.extra.variant_label_ipfs %}
+        {% set variant_icon = "simple/ipfs" %}
+      {% endif %}
+      <a
+        href="{{ 'about/how-you-are-reading/' | url }}"
+        class="anoni-variant anoni-variant--{{ config.extra.build_variant }}"
+        title="{{ variant_label }}"
+      >
+        <span class="anoni-variant__icon">
+          {% include ".icons/" ~ variant_icon ~ ".svg" %}
+        </span>
+        <span class="anoni-variant__label">{{ variant_label }}</span>
+      </a>
+    {% endif %}
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -57,6 +57,23 @@
   {% endif %}
 {% endblock %}
 
+{% block announce %}{% if config.extra.build_variant == "ipfs" %}{#-
+  IPFS 版專屬的橫幅。onion 與標準站不顯示，base.html 用 self.announce() 判斷有沒有
+  內容，這個 if 之外不能留任何字元，留了會在另外兩個版本渲染出一條空的橫幅。
+
+  為什麼只有 IPFS 版有：onion 的讀者是刻意走過來的，頁首的小標記確認一下就夠。
+  IPFS 的讀者可能是點到閘道連結才進來的，甚至不知道自己在讀鏡像，而閘道業者
+  看得到他的 IP 與每一個請求，那件事值得在讀者踩到的當下講一次。
+
+  主機名由下面那段 JS 填。鏡像可以掛在任何閘道上（見 replace_sitename_anoni_ipfs.sh），
+  寫死一個名字就等於把好不容易拆掉的耦合裝回去。JS 被關掉時句子照樣讀得通。
+-#}IPFS 镜像。你正在用的网关<span id="anoni-gateway-host"></span>看得到你的 IP 与你请求的每一个地址，走 IPFS 读不会让连接变匿名。<a href="{{ 'about/how-you-are-reading/' | url }}">三种阅读方式的差别</a><script>
+  (function () {
+    var el = document.getElementById("anoni-gateway-host");
+    if (el && location.hostname) el.textContent = "（" + location.hostname + "）";
+  })();
+</script>{% endif %}{% endblock %}
+
 {% block scripts %}
   {{ super() }}
 <!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->

--- a/docs/overrides_cn/partials/header.html
+++ b/docs/overrides_cn/partials/header.html
@@ -1,0 +1,1 @@
+../../overrides/partials/header.html

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -57,6 +57,23 @@
   {% endif %}
 {% endblock %}
 
+{% block announce %}{% if config.extra.build_variant == "ipfs" %}{#-
+  IPFS 版專屬的橫幅。onion 與標準站不顯示，base.html 用 self.announce() 判斷有沒有
+  內容，這個 if 之外不能留任何字元，留了會在另外兩個版本渲染出一條空的橫幅。
+
+  為什麼只有 IPFS 版有：onion 的讀者是刻意走過來的，頁首的小標記確認一下就夠。
+  IPFS 的讀者可能是點到閘道連結才進來的，甚至不知道自己在讀鏡像，而閘道業者
+  看得到他的 IP 與每一個請求，那件事值得在讀者踩到的當下講一次。
+
+  主機名由下面那段 JS 填。鏡像可以掛在任何閘道上（見 replace_sitename_anoni_ipfs.sh），
+  寫死一個名字就等於把好不容易拆掉的耦合裝回去。JS 被關掉時句子照樣讀得通。
+-#}IPFS mirror. The gateway you are using<span id="anoni-gateway-host"></span> sees your IP address and every address you request, and reading over IPFS does not make the connection anonymous. <a href="{{ 'about/how-you-are-reading/' | url }}">How the three editions differ</a><script>
+  (function () {
+    var el = document.getElementById("anoni-gateway-host");
+    if (el && location.hostname) el.textContent = " (" + location.hostname + ")";
+  })();
+</script>{% endif %}{% endblock %}
+
 {% block scripts %}
   {{ super() }}
 <!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->

--- a/docs/overrides_en/partials/header.html
+++ b/docs/overrides_en/partials/header.html
@@ -1,0 +1,1 @@
+../../overrides/partials/header.html

--- a/docs/run_en.sh
+++ b/docs/run_en.sh
@@ -22,6 +22,8 @@ export CATE_NAME='Categories'
 export LANGUAGE='en'
 export FONT_TEXT='Public Sans'
 export FONT_CODE='DM Mono'
+export VARIANT_LABEL_ONION='Onion edition'
+export VARIANT_LABEL_IPFS='IPFS mirror'
 export OVERRIDES='overrides_en'
 
 mkdocs build -v -s -f ./mkdocs_en.yml -d ./output/en

--- a/docs/run_zh-cn.sh
+++ b/docs/run_zh-cn.sh
@@ -18,6 +18,8 @@ export NAV_EVENT_PREPARE="筹备页面"
 export NAV_WATCHER='监控观察'
 export CATE_NAME='文章类型'
 export LANGUAGE='zh'
+export VARIANT_LABEL_ONION='Onion 版本'
+export VARIANT_LABEL_IPFS='IPFS 镜像'
 export OVERRIDES='overrides_cn'
 
 mkdocs build -v -s -f ./mkdocs_cn.yml -d ./output/zh-cn

--- a/docs/zh-CN/about/how-you-are-reading.md
+++ b/docs/zh-CN/about/how-you-are-reading.md
@@ -1,0 +1,63 @@
+---
+title: 你正在用哪一种方式阅读
+description: 文档站同时发布在标准网站、Tor Onion 与 IPFS。三份内容一样，送到你面前的路径不一样，过程中谁看得到什么也不一样。
+icon: material/routes
+---
+
+# :material-routes: 你正在用哪一种方式阅读
+
+文档站同时发布成三份，内容完全一样。差别在内容怎么送到你面前，以及过程中谁看得到什么。页首右上角的小标记会告诉你手上这一份是哪一种，标准网站不挂标记。
+
+## 三种方式对照
+
+| | 标准网站 | Onion | IPFS 镜像 |
+|---|---|---|---|
+| 地址 | `anoni.net/docs` | `docs.…onion` | `ipfs.anoni.net` 或其他网关 |
+| 谁看得到你的 IP | 我们的 CDN 与主机 | 没有人 | 你连上的网关运营方 |
+| 谁知道你读了哪几页 | 同上 | 没有人 | 同上 |
+| 你的网络运营商看得到 | 你连了 anoni.net | 你在用 Tor | 你连了那个网关 |
+| 网站被下架时 | 读不到 | 不受影响 | 不受影响 |
+| 需要什么 | 一般浏览器 | Tor Browser | 一般浏览器 |
+| 离线阅读 | 提供 | 不提供 | 不提供 |
+| 流量统计 | 有 | 没有 | 没有 |
+
+## 标准网站
+
+走一般的网络连到 `anoni.net`，速度最快，功能最完整，[离线阅读](../offline.md) 只有这一版提供。
+
+代价是我们的 CDN 与主机看得到你的 IP，站上也有一份不记录个人身份的流量统计。域名被封锁或被处理的时候，这一版就读不到了。
+
+## Onion
+
+网站直接运作在 Tor 网络里。访客与网站互相看不到 IP，中间不经过 DNS，也没有证书颁发机构。你的网络运营商只看得到你在用 Tor，看不到你连了哪个站、读了哪一页。
+
+`.onion` 地址没有证书颁发机构背书，核对地址本身就是唯一的验证手段。完整地址印在每一页的页尾，拿它跟地址栏比对，对得上就是我们的站。这一步值得养成习惯，因为相似地址的钓鱼站是真实存在的手法。
+
+这一版不加载任何分析脚本，也不注册后台的 Service Worker，所以没有离线阅读。延迟比标准网站高，那是 Tor 的常态。
+
+## IPFS 镜像
+
+内容用指纹（CID）寻址，任何节点都能提供同一份内容，没有单一可以被下架的位置。社群成员可以帮忙留存一份，做法见 [帮忙 pin 文档站的 IPFS 镜像](../community/pin-ipfs-mirror.md)。
+
+要注意的是走 IPFS 读不会让连接变匿名。你用的是一般浏览器连到一台网关，那台网关看得到你的 IP 与你请求的每一个地址，在网络上你看起来就是一个普通的 HTTPS 客户端。想同时要抗下架与连接匿名，用 Tor Browser 打开 Onion 版。
+
+完整的暴露面说明见 [常被误认为匿名的网络](../advanced/mistaken-for-anonymity.md)，发布端的设计取舍见 [去中心化网站发布](../advanced/dweb-ipfs-onion.md)。
+
+## 怎么选
+
+平常阅读用标准网站就好。
+
+在意连接被看到，或者人在会被监看的网络环境，用 Onion 版。
+
+标准网站连不上而手边没有 Tor Browser 的时候，IPFS 镜像是读得到内容的备援。别把它当成匿名手段。
+
+## :fontawesome-solid-diagram-project: 相关阅读
+
+<div class="grid cards" markdown>
+
+- [:material-web-box: 去中心化网站发布](../advanced/dweb-ipfs-onion.md)
+- [:material-incognito: 常被误认为匿名的网络](../advanced/mistaken-for-anonymity.md)
+- [:simple-ipfs: 帮忙 pin 文档站的 IPFS 镜像](../community/pin-ipfs-mirror.md)
+- [:material-download: 离线阅读](../offline.md)
+
+</div>

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -450,3 +450,61 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-typeset table:not([class]) {
   width: 100%;
 }
+
+/* ==========================================================================
+   部署版本小标记与 IPFS 横幅
+
+   页首那颗药丸标示这份产物是 onion 还是 IPFS 版，标准站不显示。三个语系共用同一支
+   partials/header.html（符号链接），文案走 config.extra。
+
+   外框用 currentcolor，跟着页首的前景色走，换主题色不用回来改这里。
+
+   窄屏幕只留图标：页首右侧已经有语言、搜索、源码三个按钮，再挤一段文字会把
+   站名压掉。
+   ========================================================================== */
+
+.anoni-variant {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin: 0 0.2rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  color: inherit;
+  font-size: 0.62rem;
+  line-height: 1.7;
+  white-space: nowrap;
+  opacity: 0.82;
+  transition: opacity 125ms;
+}
+
+.anoni-variant:hover,
+.anoni-variant:focus-visible {
+  opacity: 1;
+}
+
+.anoni-variant__icon {
+  display: inline-flex;
+}
+
+.anoni-variant__icon svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: currentcolor;
+}
+
+@media screen and (max-width: 76.1875em) {
+  .anoni-variant__label {
+    display: none;
+  }
+
+  .anoni-variant {
+    padding: 0.15rem 0.35rem;
+  }
+}
+
+.anoni-announce__host {
+  font-family: var(--md-code-font-family);
+  overflow-wrap: anywhere;
+}

--- a/docs/zh-TW/about/how-you-are-reading.md
+++ b/docs/zh-TW/about/how-you-are-reading.md
@@ -1,0 +1,63 @@
+---
+title: 你正在用哪一種方式閱讀
+description: 文件站同時發布在標準網站、Tor Onion 與 IPFS。三份內容一樣，送到你面前的路徑不一樣，過程中誰看得到什麼也不一樣。
+icon: material/routes
+---
+
+# :material-routes: 你正在用哪一種方式閱讀
+
+文件站同時發布成三份，內容完全一樣。差別在內容怎麼送到你面前，以及過程中誰看得到什麼。頁首右上角的小標記會告訴你手上這一份是哪一種，標準網站不掛標記。
+
+## 三種方式對照
+
+| | 標準網站 | Onion | IPFS 鏡像 |
+|---|---|---|---|
+| 位址 | `anoni.net/docs` | `docs.…onion` | `ipfs.anoni.net` 或其他閘道 |
+| 誰看得到你的 IP | 我們的 CDN 與主機 | 沒有人 | 你連上的閘道業者 |
+| 誰知道你讀了哪幾頁 | 同上 | 沒有人 | 同上 |
+| 你的網路業者看得到 | 你連了 anoni.net | 你在用 Tor | 你連了那個閘道 |
+| 網站被下架時 | 讀不到 | 不受影響 | 不受影響 |
+| 需要什麼 | 一般瀏覽器 | Tor Browser | 一般瀏覽器 |
+| 離線閱讀 | 提供 | 不提供 | 不提供 |
+| 流量統計 | 有 | 沒有 | 沒有 |
+
+## 標準網站
+
+走一般的網路連到 `anoni.net`，速度最快，功能最完整，[離線閱讀](../offline.md) 只有這一版提供。
+
+代價是我們的 CDN 與主機看得到你的 IP，站上也有一份不記錄個人身分的流量統計。網域被封鎖或被處理的時候，這一版就讀不到了。
+
+## Onion
+
+網站直接運作在 Tor 網路裡。訪客與網站互相看不到 IP，中間不經過 DNS，也沒有憑證機構。你的網路業者只看得到你在用 Tor，看不到你連了哪個站、讀了哪一頁。
+
+`.onion` 位址沒有憑證機構背書，核對位址本身就是唯一的驗證手段。完整位址印在每一頁的頁尾，拿它跟網址列比對，對得上就是我們的站。這一步值得養成習慣，因為相似位址的釣魚站是真實存在的手法。
+
+這一版不載入任何分析腳本，也不註冊背景的 Service Worker，所以沒有離線閱讀。延遲比標準網站高，那是 Tor 的常態。
+
+## IPFS 鏡像
+
+內容用指紋（CID）定址，任何節點都能提供同一份內容，沒有單一可以被下架的位置。社群成員可以幫忙留存一份，做法見 [幫忙 pin 文件站的 IPFS 鏡像](../community/pin-ipfs-mirror.md)。
+
+要注意的是走 IPFS 讀不會讓連線變匿名。你用的是一般瀏覽器連到一台閘道，那台閘道看得到你的 IP 與你要求的每一個位址，在網路上你看起來就是一個普通的 HTTPS 客戶端。想同時要抗下架與連線匿名，用 Tor Browser 開 Onion 版。
+
+完整的暴露面說明見 [常被誤認為匿名的網路](../advanced/mistaken-for-anonymity.md)，發布端的設計取捨見 [去中心化網站發布](../advanced/dweb-ipfs-onion.md)。
+
+## 怎麼選
+
+平常閱讀用標準網站就好。
+
+在意連線被看到，或者人在會被監看的網路環境，用 Onion 版。
+
+標準網站連不上而手邊沒有 Tor Browser 的時候，IPFS 鏡像是讀得到內容的備援。別把它當成匿名手段。
+
+## :fontawesome-solid-diagram-project: 相關閱讀
+
+<div class="grid cards" markdown>
+
+- [:material-web-box: 去中心化網站發布](../advanced/dweb-ipfs-onion.md)
+- [:material-incognito: 常被誤認為匿名的網路](../advanced/mistaken-for-anonymity.md)
+- [:simple-ipfs: 幫忙 pin 文件站的 IPFS 鏡像](../community/pin-ipfs-mirror.md)
+- [:material-download: 離線閱讀](../offline.md)
+
+</div>

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -451,3 +451,61 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-typeset table:not([class]) {
   width: 100%;
 }
+
+/* ==========================================================================
+   部署版本小標記與 IPFS 橫幅
+
+   頁首那顆藥丸標示這份產物是 onion 還是 IPFS 版，標準站不顯示。三個語系共用同一支
+   partials/header.html（符號連結），文案走 config.extra。
+
+   外框用 currentcolor，跟著頁首的前景色走，換主題色不用回來改這裡。
+
+   窄螢幕只留圖示：頁首右側已經有語言、搜尋、原始碼三個按鈕，再擠一段文字會把
+   站名壓掉。
+   ========================================================================== */
+
+.anoni-variant {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin: 0 0.2rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  color: inherit;
+  font-size: 0.62rem;
+  line-height: 1.7;
+  white-space: nowrap;
+  opacity: 0.82;
+  transition: opacity 125ms;
+}
+
+.anoni-variant:hover,
+.anoni-variant:focus-visible {
+  opacity: 1;
+}
+
+.anoni-variant__icon {
+  display: inline-flex;
+}
+
+.anoni-variant__icon svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: currentcolor;
+}
+
+@media screen and (max-width: 76.1875em) {
+  .anoni-variant__label {
+    display: none;
+  }
+
+  .anoni-variant {
+    padding: 0.15rem 0.35rem;
+  }
+}
+
+.anoni-announce__host {
+  font-family: var(--md-code-font-family);
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## 問題

文件站同時發布成標準網站、Onion 與 IPFS 三份，但三份頁面長得一模一樣，讀者要自己看網址列才知道手上這份是哪一種。頁尾雖然列了三個位址，那回答的是「還可以去哪裡讀」，不是「你現在在哪裡」。

## 為什麼兩個版本的呈現不對稱

**onion 的讀者是刻意走過來的。** 裝了 Tor Browser、忍受延遲才到這個位址。他們需要的是確認，尤其是核對位址：`.onion` 沒有憑證機構背書，核對位址本身就是唯一的驗證手段，而相似位址的釣魚站是真實存在的手法。給一個常駐的小標記就夠，不打斷閱讀。

**IPFS 的讀者可能是無意間到的。** 點到一個閘道連結就進來了，甚至不知道自己在讀鏡像，而閘道業者看得到他的 IP 與每一個請求。那件事值得在讀者踩到的當下講一次，所以多一條可關閉的橫幅。

**標準網站什麼都不加。** 讀者用一般瀏覽器連一般網站，沒有需要特別說的。

## 改動

### 變體判斷

`extra.build_variant` 由三支 build 腳本與 CI 的 matrix 帶入，建置時就決定。不靠 JS，也不靠 hostname 判斷，IPFS 的 hostname 本來就會變。

### 頁首小標記

`partials/header.html` 從 mkdocs-material 9.7.7 分支出來，三個語系用符號連結共用，文案走 `config.extra`，跟 `NAV_*` 是同一套做法。純 HTML 加 CSS，Tor Browser 把 JS 關到最嚴也看得到。窄螢幕只留圖示。

### IPFS 橫幅

寫在三份 `main.html` 的 `announce` block。`base.html` 用 `self.announce()` 判斷要不要渲染，所以 `if` 之外不能留任何字元，留了另外兩個版本會出現一條空橫幅。

橫幅裡的閘道主機名由一小段 JS 讀 `location.hostname` 填。鏡像可以掛在任何閘道上，寫死一個名字等於把 #356 拆掉的耦合裝回去。JS 關掉時句子照樣讀得通（「你正在用的閘道看得到你的 IP…」）。

### 新頁面

〈你正在用哪一種方式閱讀〉三語系，三種方式的對照表與各自的暴露面。現有的 `advanced/dweb-ipfs-onion.md` 是寫給發布者看的，視角不同。

## 驗證

三個變體各自建置：

- 標準版 `anoni-variant` 0 個、`md-banner` 0 個（確認沒有渲染出空橫幅）
- onion 版標記「Onion 版本」，無橫幅
- IPFS 版標記「IPFS 鏡像」／「IPFS mirror」／「IPFS 镜像」，橫幅含關閉鈕與主機名 span
- 小標記的連結在首頁、深層頁、三語系都解析正確（`about/…`、`../../about/…`、`how-you-are-reading/`）

headless Chrome 截 1280、820、420 三種寬度。桌面版藥丸落在站名與色彩切換之間，窄螢幕只留圖示。420px 下站名比原本再少顯示一個字，站名原本就已經在截斷。

`tools/docs_style_lint.py` 對三個新頁面 0 error 0 warn。

## 之後升級 mkdocs-material 要注意

多了一支要對照上游的 partial。`overrides/partials/header.html` 開頭有註記，只有 `anoni-variant` 那一段是我們加的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)