### PR TITLE
docs: README 依現行架構重整，補上 tools/ 授權與寫作規範套用範圍

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ CC BY-NC-SA 4.0（禁止商業使用）。清單見根目錄 [`NOTICE`](./NOTICE
 | 部署 | `cf_purge.py`、`test_cf_purge.py` | 建置完把產物映射回網址，分批並行清除 Cloudflare 快取（每批 30 條，同時 6 批）。測試由 [`tools-tests.yml`](./.github/workflows/tools-tests.yml) 在 PR 觸發 |
 | 部署 | `s3_restore_mtime.py`、`test_s3_restore_mtime.py` | 上傳前比對 MD5 與 S3 的 ETag，內容沒變的把時間戳調回遠端版本，讓 `aws s3 sync` 跳過。`sync` 只看大小與時間，不看內容 |
 | 地球儀資料 | `gen_*.py`、`publish_games_data.sh` | 產生 `docs/zh-TW/games/tor-network/` 的靜態 JSON。`snapshot.json`、`torusers.json`、`seacable.json` 會持續變動，由 `publish_games_data.sh` 在正式機重生並檢查後發布到 assets，其餘幾份變動以季或年計，跟文件站一起發布即可 |
-| 地球儀版面檢查 | `check_double_tap.mjs`、`check_focus.mjs`、`check_pinch_release.mjs`、`check_sub_gauge.mjs`、`fix_trunk_land.mjs`、`shoot_games.mjs` | headless Chrome 跑的互動與版面檢查，由 `games-checks.yml` 在 PR 觸發 |
-| PWA 與離線 | `check_precache.mjs`、`test_sw_offline.mjs`、`test_lang_preference.mjs`、`test_offline_index.py`、`test_offline_library.mjs` | `check_precache.mjs` 比對預快取清單與 `docs/output` 的實際檔案，並驗索引頁連出去的網址形狀命中得了快取的 key（需先建置）。其餘四支把原始碼原地抽出來單元測試，不需要建置：`test_sw_offline.mjs` 測 `docs/zh-TW/sw.js` 的離線路徑，`test_lang_preference.mjs` 測 `docs/overrides/base.html` 的語言導向，`test_offline_index.py` 測 `docs/hooks/offline_index.py` 的分組，`test_offline_library.mjs` 餵一組最小 DOM 替身把 `docs/zh-TW/js/offline-library.js` 整份跑起來，驗它畫出來的結構與送給 service worker 的指令（版面與樣式驗不到，那要靠實機）。由 [`tools-tests.yml`](./.github/workflows/tools-tests.yml) 在 PR 觸發，`check_precache.mjs` 需要建置產物所以沒進 CI，改 `docs/zh-TW/sw.js` 時手動跑一次 |
+| 地球儀版面檢查 | `check_double_tap.mjs`、`check_focus.mjs`、`check_pinch_release.mjs`、`check_sub_gauge.mjs`、`fix_trunk_land.mjs`、`shoot_games.mjs` | headless Chrome 執行的互動與版面檢查，由 `games-checks.yml` 在 PR 觸發 |
+| PWA 與離線 | `check_precache.mjs`、`test_sw_offline.mjs`、`test_lang_preference.mjs`、`test_offline_index.py`、`test_offline_library.mjs` | `check_precache.mjs` 比對預快取清單與 `docs/output` 的實際檔案，並驗索引頁連出去的網址形狀命中得了快取的 key（需先建置）。其餘四支把原始碼原地抽出來單元測試，不需要建置：`test_sw_offline.mjs` 測 `docs/zh-TW/sw.js` 的離線路徑，`test_lang_preference.mjs` 測 `docs/overrides/base.html` 的語言導向，`test_offline_index.py` 測 `docs/hooks/offline_index.py` 的分組，`test_offline_library.mjs` 餵一組最小 DOM 替身把 `docs/zh-TW/js/offline-library.js` 整份執行起來，驗它畫出來的結構與送給 service worker 的指令（版面與樣式驗不到，那要靠實機）。由 [`tools-tests.yml`](./.github/workflows/tools-tests.yml) 在 PR 觸發，`check_precache.mjs` 需要建置產物所以沒進 CI，改 `docs/zh-TW/sw.js` 時手動執行一次 |
 
 ## 開發環境設置
 
@@ -250,29 +250,29 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 
 - **build_docs.yml**: 建置多語系文件並發布
   - 觸發條件: push to `docs` branch 且變更落在會改變產物的路徑（`docs/**`、根目錄的 `BECOME_ANONI*.md`、`tools/cf_purge.py` 與其測試、workflow 自己），或手動觸發
-  - 只動 `tools/` 其他檔案或 CI 設定時推 `docs` 不會建置，那是刻意的，產物沒有變。真的需要重跑從 Actions 頁面用 `workflow_dispatch`
+  - 只動 `tools/` 其他檔案或 CI 設定時推 `docs` 不會建置，那是刻意的，產物沒有變。真的需要重新建置時，從 Actions 頁面用 `workflow_dispatch`
   - 建置所有語言版本（zh-TW, zh-CN, en）
   - 處理 Open Graph 圖片
   - 以 `aws s3 sync --delete` 上傳至 S3：clearnet 產物在 `docs/`，onion 產物在同一個 bucket 的 `docs-onion/`。單一步覆寫，站上任何時刻都有完整的一份，不再有先清空再上傳造成的空窗
   - 上傳後由 `tools/cf_purge.py` 清除這次產出網址的 Cloudflare 快取，範圍限 `/docs/`，不動 zone 內其他服務
 
-  **S3 是正式站的讀取來源**，所以推 `docs` 分支且這個 workflow 跑完，內容就已經上線，不需要額外的手動發布步驟。發布指令：
+  **S3 是正式站的讀取來源**，所以推 `docs` 分支且這個 workflow 執行完，內容就已經上線，不需要額外的手動發布步驟。發布指令：
 
   ```bash
   git push origin origin/main:refs/heads/docs
   ```
 
-- **docs-style-lint.yml**: 對 PR 變更到的中文 Markdown 與小工具區的 UI 字串跑 `tools/docs_style_lint.py`
+- **docs-style-lint.yml**: 對 PR 變更到的中文 Markdown 與小工具區的 UI 字串執行 `tools/docs_style_lint.py`
   - 觸發路徑：`docs/zh-TW/**/*.md`、`docs/zh-CN/**/*.md`、`docs/en/**/*.md` 與 linter 本身
   - 只掃這次 PR 變更的檔案，避免舊文的遺留違規擋住新貢獻
-  - 這個 job 會擋 merge。error 級規則讓 linter 回 exit 1，job 就紅；warn 級規則仍只以 annotation 標在變更行上，不影響 exit code
+  - 這個 job 會擋 merge。error 級規則讓 linter 回 exit 1，job 就紅。warn 級規則仍只以 annotation 標在變更行上，不影響 exit code
   - 待辦：repo 設定尚未把這個 check 列為 branch protection 必過，所以目前擋得住 PR 的紅燈，擋不住有權限的人直接合併
 
-- **tools-tests.yml**: 跑 `tools/` 底下那幾支零相依的測試
+- **tools-tests.yml**: 執行 `tools/` 底下那幾支零相依的測試
   - 觸發路徑：`tools/**`、`docs/zh-TW/sw.js`、`docs/overrides/base.html`、`docs/hooks/**`
   - 內容：`test_sw_offline.mjs`（service worker 的離線行為）、`test_lang_preference.mjs`（語言偏好導向）、`test_offline_index.py`（離線內容索引的分組與排序）、`test_offline_library.mjs`（離線內容管理頁的介面）、`test_passphrase.mjs`（密語與密碼產生器的取樣與熵）、`test_qrcode.mjs`（QR code 的編碼往返）、`test_leaks.mjs`（指紋示範頁不送資料）、`test_cf_purge.py`（快取清除映射）
-  - 不需要建置產物，跑完不到十秒。`test_docs_style_lint.py` 不在這裡，由 `docs-style-lint.yml` 跑
-  - `check_precache.mjs` 需要 `docs/output`，沒進 CI，改 `sw.js` 時手動跑一次
+  - 不需要建置產物，執行完不到十秒。`test_docs_style_lint.py` 不在這裡，由 `docs-style-lint.yml` 執行
+  - `check_precache.mjs` 需要 `docs/output`，沒進 CI，改 `sw.js` 時手動執行一次
 
 - **check-ripe.yml** 與 **lookback-ooni.yml**: `asn_coverage/` 的資料抓取
   - 觸發路徑：`asn_coverage/**` 與各自的 workflow。原本任何 main 的 push 都觸發，2026-08-19 一天被 docs 的 PR 觸發 18 次，每次四個 job（2 OS × 2 Python），把並行額度佔滿，連 BuildDocs 都排不進去
@@ -284,9 +284,9 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
   - 檢查項目：捏合放開不彈開、擋掉 iOS Safari 雙擊放大、網址關注區域的取景、變電所容量計版面（280 座 × 三語系 × 寬窄視窗）
 
 - **check-ripe.yml**: 檢查 RIPE ASN 資料（`asn_coverage/`）
-  - **push** 僅在 **`main`** 分支觸發；`workflow_dispatch` 與 `schedule` 維持可用
+  - **push** 僅在 **`main`** 分支觸發。`workflow_dispatch` 與 `schedule` 維持可用
 - **lookback-ooni.yml**: 定期回溯 OONI 資料（`asn_coverage/`）
-  - **push** 僅在 **`main`** 分支觸發；`workflow_dispatch` 與 `schedule` 維持可用
+  - **push** 僅在 **`main`** 分支觸發。`workflow_dispatch` 與 `schedule` 維持可用
 
 ## 專案特定注意事項
 
@@ -297,7 +297,9 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 - 使用 YAML front matter 設定文章 metadata（title, date, categories）
 - 支援 Vega-Lite 圖表（使用 ````vegalite` code fence）
 - 寫作風格的單一來源是[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)（原始檔 `docs/zh-TW/community/contributor-handbook.md`）的「寫作風格規範」一節。要新增或修改規則先改那裡
-- 送 PR 前可先跑 `python3 tools/docs_style_lint.py <path>` 自檢，CI 會對變更的中文 Markdown 跑同一支
+- 寫作風格規範的套用範圍不限於 `docs/` 的內容。repo 根目錄的說明文件（`README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`NOTICE`、各子目錄的 `README.md`）同樣要遵守。這幾個檔案不在 CI 的觸發路徑內，改完自己執行一次 linter。`NOTICE` 沒有 `.md` 副檔名，linter 只收 `.md` 與 `.js`，那一份要人工看
+  - 例外是 `tools/README.md` 的規則表與規則說明那兩段。那裡逐條寫出被禁用的標點與句型，linter 掃自己的規則描述必然全紅，屬於正當引用，不要照著「修正」，會把規則表寫壞
+- 送 PR 前可先執行 `python3 tools/docs_style_lint.py <path>` 自檢，CI 會對變更的中文 Markdown 執行同一支
 - 語系的資料夾與對外 URL 規則不同：`docs/zh-TW/` 對應 `https://anoni.net/docs/`（預設語系不帶語系區段），`docs/zh-CN/` 對應 `/docs/zh-cn/`（URL 小寫），`docs/en/` 對應 `/docs/en/`
 - `/docs/zh-tw/` 是已停用的舊網址，由 Cloudflare Redirect Rule 301 導回 `/docs/`。它曾經是 `run_zh-tw.sh` 建出來的第二棵樹，內容與根路徑完全相同，兩邊各自 self-canonical 又各自進 sitemap，等於自製重複內容。語言選單的 zh-TW 項填 `/docs/` 就夠，不要再加回那份建置
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,17 @@ cd docs
 # 啟動開發伺服器 (預設 zh-TW 版本)
 source .venv/bin/activate
 mkdocs serve
+```
 
-# 或使用腳本啟動不同語言版本
+三語系的建置驗證用 `run_*.sh`。三支都是 `mkdocs build`，各自 export 該語系需要的環境變數再建置到 `output/`：
+
+```bash
 sh run.sh          # zh-TW（預設語系，建在根路徑）
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```
+
+直接執行 `mkdocs build -f mkdocs_en.yml` 會因為 `DOCS_DIR` 之類的環境變數落回預設值而產生假警報，驗證三語系一律走這三支腳本。
 
 ### 建置文件
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 - 支援 Vega-Lite 圖表（使用 ````vegalite` code fence）
 - 寫作風格的單一來源是[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)（原始檔 `docs/zh-TW/community/contributor-handbook.md`）的「寫作風格規範」一節。要新增或修改規則先改那裡
 - 寫作風格規範的套用範圍不限於 `docs/` 的內容。repo 根目錄的說明文件（`README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`NOTICE`、各子目錄的 `README.md`）同樣要遵守。這幾個檔案不在 CI 的觸發路徑內，改完自己執行一次 linter。`NOTICE` 沒有 `.md` 副檔名，linter 只收 `.md` 與 `.js`，那一份要人工看
-  - 例外是 `tools/README.md` 的規則表與規則說明那兩段。那裡逐條寫出被禁用的標點與句型，linter 掃自己的規則描述必然全紅，屬於正當引用，不要照著「修正」，會把規則表寫壞
+  - 規則文件本身逐條寫出被禁用的標點與句型，掃自己的規則描述必然全紅。貢獻者百科與這份投影靠 linter 的 `RULE_DOCS` 依檔名豁免，`tools/README.md` 的規則表與已知邊界兩段改用 `<!-- docs-style-lint: disable -->` 與 `enable` 包住。往後寫規則說明時照同一個做法，不要改掉引用的例子
 - 送 PR 前可先執行 `python3 tools/docs_style_lint.py <path>` 自檢，CI 會對變更的中文 Markdown 執行同一支
 - 語系的資料夾與對外 URL 規則不同：`docs/zh-TW/` 對應 `https://anoni.net/docs/`（預設語系不帶語系區段），`docs/zh-CN/` 對應 `/docs/zh-cn/`（URL 小寫），`docs/en/` 對應 `/docs/en/`
 - `/docs/zh-tw/` 是已停用的舊網址，由 Cloudflare Redirect Rule 301 導回 `/docs/`。它曾經是 `run_zh-tw.sh` 建出來的第二棵樹，內容與根路徑完全相同，兩邊各自 self-canonical 又各自進 sitemap，等於自製重複內容。語言選單的 zh-TW 項填 `/docs/` 就夠，不要再加回那份建置

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@
 | `docs/` 網站內容 | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
 | `pulse/` 程式碼 | [MIT](pulse/LICENSE) |
 | `asn_coverage/` 程式碼 | [GPL-3.0](asn_coverage/LICENSE) |
+| `tools/` 腳本與測試 | [MIT](tools/LICENSE)（不含 `tools/data/`，見 [`NOTICE`](./NOTICE)）|
 
 說明與根目錄 `LICENSE`、`LICENSE-asn_coverage` 的關係見 [README.md](./README.md)（〈授權〉一節）。
 
@@ -50,4 +51,4 @@
 This monorepo contains the **docs site**, **Pulse**, and **asn_coverage** tools. See the table above for where to edit. Use [CLAUDE.md](./CLAUDE.md) for `uv`, Docker, and API details.
 
 - **Branches / CI**: site build runs on pushes to the **`docs`** branch (`build_docs.yml`). **`asn_coverage` workflows** run on **`push` to `main` only** (manual and scheduled runs still available).  
-- **Licensing**: docs content is **CC-BY 4.0**; **Pulse** code is **MIT**; **asn_coverage** code is **GPL-3.0**. See [README.md](./README.md).
+- **Licensing**: docs content is **CC-BY 4.0**; **Pulse** and `tools/` code is **MIT** (`tools/data/` excluded, see [NOTICE](./NOTICE)); **asn_coverage** code is **GPL-3.0**. See [README.md](./README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 # 貢獻指南 | Contributing
 
-本儲存庫為單一 Git 專案，內含 **MkDocs 文件站**、**Pulse（Tor 中繼監控）**、**ASN Coverage（OONI 分析 CLI）** 三塊子專案。依你關心的範圍挑選目錄即可，不必一次熟悉全部。
+本儲存庫為單一 Git 專案，內含 **MkDocs 文件站**、**Pulse（Tor 中繼監控）**、**ASN Coverage（OONI 分析 CLI）** 三塊子專案，以及支撐它們的共用腳本 **tools**。依你關心的範圍挑選目錄即可，不必一次熟悉全部。
 
 ## 專案與目錄
 
 | 目錄 | 說明 | 新手最常動到 |
 |------|------|----------------|
-| [`docs/`](docs/) | 多語系文件站（MkDocs Material） | `docs/zh-TW/`、`zh-CN/`、`en/` 下的 Markdown；部落格在 `blog/posts/` |
+| [`docs/`](docs/) | 多語系文件站（MkDocs Material） | `docs/zh-TW/`、`zh-CN/`、`en/` 下的 Markdown，部落格在 `blog/posts/` |
 | [`pulse/`](pulse/) | Tor 中繼資料收集、FastAPI、PostgreSQL、Docker Compose | `pulse/backend/`、`docker-compose.yml` |
 | [`asn_coverage/`](asn_coverage/) | 從 OONI S3 下載並分析涵蓋率、RIPE ASN 列表等 CLI | `ooni.py`、`ripe.py` |
+| [`tools/`](tools/) | 共用腳本與 CI 檢查：編輯標準掃描、前端測試、資料產生、部署 | `docs_style_lint.py`，細節見 [`tools/README.md`](tools/README.md) |
 
 詳細開發指令（`uv`、Docker、API 端點）見 [CLAUDE.md](./CLAUDE.md)。
 
@@ -18,7 +19,7 @@
 |------|------|
 | **`main`** | 預設開發與合併目標分支。 |
 | **Push 到 `docs` 分支** | 觸發 [`.github/workflows/build_docs.yml`](.github/workflows/build_docs.yml)：建置多語系文件並部署（需設定之 secrets）。 |
-| **`asn_coverage` 相關 workflow** | [check-ripe.yml](.github/workflows/check-ripe.yml)、[lookback-ooni.yml](.github/workflows/lookback-ooni.yml)：**`push` 僅在 `main` 會跑**；`workflow_dispatch`（手動）與 `schedule`（排程）仍可使用。 |
+| **`asn_coverage` 相關 workflow** | [check-ripe.yml](.github/workflows/check-ripe.yml)、[lookback-ooni.yml](.github/workflows/lookback-ooni.yml)：**`push` 僅在 `main` 觸發**。`workflow_dispatch`（手動）與 `schedule`（排程）仍可使用。 |
 
 若你的預設分支名稱不是 `main`，請以團隊約定為準，並同步調整 workflow 檔案中的 `branches:`。
 
@@ -26,8 +27,8 @@
 
 1. 搜尋或開 [GitHub Issue](https://github.com/anoni-net/docs/issues/new/choose) 說明要改什麼。新人可直接用 issue 表單分流：翻譯認領、內容提案、來源建議、文件錯誤。
 2. Fork 本儲存庫，從 `main` 開分支（命名清楚即可，例如 `fix/docs-typo-zh-tw`）。
-3. 只改與主題相關的檔案；大改動可開 **Draft PR** 先收集意見。
-4. 送出 Pull Request；維護者會依時間回覆。
+3. 只改與主題相關的檔案。大改動可開 **Draft PR** 先收集意見。
+4. 送出 Pull Request，維護者會依時間回覆。
 
 互動請遵循[行為準則](./CODE_OF_CONDUCT.md)。第一次參與的完整入門見[如何參與與認領主題](https://anoni.net/docs/community/how-to-contribute/)。
 
@@ -48,7 +49,7 @@
 
 ## English (short)
 
-This monorepo contains the **docs site**, **Pulse**, and **asn_coverage** tools. See the table above for where to edit. Use [CLAUDE.md](./CLAUDE.md) for `uv`, Docker, and API details.
+This monorepo contains the **docs site**, **Pulse**, **asn_coverage**, and the shared **tools** scripts. See the table above for where to edit. Use [CLAUDE.md](./CLAUDE.md) for `uv`, Docker, and API details.
 
 - **Branches / CI**: site build runs on pushes to the **`docs`** branch (`build_docs.yml`). **`asn_coverage` workflows** run on **`push` to `main` only** (manual and scheduled runs still available).  
 - **Licensing**: docs content is **CC-BY 4.0**; **Pulse** and `tools/` code is **MIT** (`tools/data/` excluded, see [NOTICE](./NOTICE)); **asn_coverage** code is **GPL-3.0**. See [README.md](./README.md).

--- a/NOTICE
+++ b/NOTICE
@@ -103,6 +103,8 @@ CC BY-NC-SA 3.0 版本收回，改成年費授權。網路上還找得到那個�
 （哪條纜線連哪兩地），事實不受著作權保護。座標的彙整與精度判斷是本專案自己做的。
 
 每一筆的出處逐條記在 `tools/data/tw_landing.toml`，產生器是 `tools/gen_tw_landing.py`。
+那個 toml 是這份資料的來源檔，授權跟著 `tw-landing.json` 走，不受 `tools/LICENSE`
+的 MIT 涵蓋，`tools/LICENSE` 已在檔頭把 `tools/data/` 排除。
 輸出的 `precision` 欄位標示每一筆的可信程度，從「站址」到「鄉鎮」分五級，引用時要
 一併看那個欄位。這份是 v1，已知缺口寫在 toml 的檔頭。
 

--- a/README.md
+++ b/README.md
@@ -2,61 +2,91 @@
 
 > 推廣與翻譯匿名網路 Tor、Tails 與 OONI 觀測工具
 
-此專案是「匿名網路社群 anoni.net」的核心文件系統，致力於推廣網路自由與隱私保護工具。專案包含多語系文件網站、Tor 中繼監控系統，以及 OONI 觀測資料分析工具。
+「匿名網路社群 anoni.net」的核心文件系統。倉庫裡有四個目錄：對外的多語系文件網站、Tor 中繼監控後端、OONI 觀測資料分析 CLI，以及支撐前三者的共用腳本與 CI 檢查。
 
 ## 📚 專案結構
 
 ```
 anoni-net-docs/
-├── docs/           # MkDocs 多語系文件網站（zh-TW, zh-CN, en）
+├── docs/           # MkDocs 多語系文件網站（zh-TW、zh-CN、en）
 ├── pulse/          # Tor 中繼監控系統（FastAPI + PostgreSQL）
-└── asn_coverage/   # OONI 觀測資料與 ASN 涵蓋率分析工具
+├── asn_coverage/   # OONI 觀測資料與 ASN 涵蓋率分析 CLI
+└── tools/          # 共用腳本：編輯標準掃描、前端測試、資料產生、部署
 ```
 
-### 1. Docs - 文件網站
+四個目錄各有自己的 README，授權也不同，見下方「授權」一節。
 
-基於 [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) 的多語系文件系統，提供繁體中文、簡體中文與英文三種語言版本。
+### 1. docs：文件網站
 
-**主要內容：**
-- Tor、Tails、OONI 教學與翻譯文件
-- 社群活動資訊與工作坊內容
-- 網路審查觀測報告
-- 參與專案的指南
+基於 [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) 的多語系網站，提供正體中文、簡體中文與英文三個版本。
+
+**網站分區：**
+
+| 分區 | 內容 |
+|------|------|
+| 指南 | 概念、工具、場景、進階、報告五組。工具依「連線層」、「環境層」、「觀測層」、「日常隱私基本功」分類 |
+| 在地脈絡 | 台灣的觀測資料與法規制度（個資法、VASP、揭弊者保護） |
+| 小工具 | 在瀏覽器內執行的隱私工具：威脅模型盤點、密語產生、QR code 產生與讀取、metadata 清除、網址清理、隱形字元偵測、瀏覽器指紋示範 |
+| 互動與呈現 | 洋蔥路由與會合點的動畫，以及 Tor 中繼地球儀 |
+| 資訊更新 | 部落格與 Tor、Tails、Arti、OONI 的軟體更新日誌 |
+| 社群 | 參與方式、翻譯流程、貢獻者百科、架設中繼與 onion 服務、讀懂觀測資料 |
+| 關於我們 | 專案介紹、聯絡方式、離線內容管理 |
 
 **技術特點：**
-- 多語系支援（zh-TW / zh-CN / en）
-- 內建部落格系統與 RSS 訂閱
-- Vega-Lite 資料視覺化圖表
-- 支援標準網站、IPFS、Tor Onion 多種部署方式
 
-### 2. Pulse - Tor 中繼監控系統
+- 三語系內容分別存放於 `docs/zh-TW/`、`docs/zh-CN/`、`docs/en/`，各有一份 mkdocs 設定檔。預設語系 zh-TW 建在根路徑
+- 外掛：`blog`、`rss`、`charts`（Vega-Lite）、`social`（Open Graph 卡片）、`privacy`（建置時把 CDN 資源取回本地）、`git-revision-date-localized`、`redirects`
+- 小工具區的運算全部在瀏覽器內完成，不送出使用者輸入。對應的守門測試放在 `tools/`
+- PWA 與離線閱讀：`docs/zh-TW/sw.js` 提供離線路徑，建置時由 `docs/hooks/offline_index.py` 產出各語系的 `offline-index.json`，離線內容管理頁據此列出可下載的章節
+- 三種部署目標：Clearnet（S3 加 Cloudflare）、Tor Onion（同一個 bucket 的另一個 prefix）、IPFS（IPNS 名稱指向最新版本）
 
-即時監控與統計 Tor 網路中繼資料的系統，提供 API 供前端查詢與視覺化。
+### 2. pulse：Tor 中繼監控系統
+
+定期收集與統計 Tor 網路中繼資料的系統，提供 API 供前端查詢與視覺化。
 
 **功能特點：**
-- 定期收集指定國家（TW、JP、KR、HK）的 Tor 中繼資料
+
+- 每小時收集指定國家（TW、JP、KR、HK）的 Tor 中繼資料
 - PostgreSQL 資料庫儲存歷史紀錄
 - FastAPI REST API 與 Vega-Lite 圖表端點
+- 健康檢查分兩個端點：`/api/healthz` 只回版本，`/api/readyz` 每次呼叫都連資料庫
 - Docker Compose 一鍵部署
 
 **技術架構：**
+
 - Backend: Python 3.12+ / FastAPI / psycopg 3
 - Database: PostgreSQL 17
 - Scheduler: Alpine crond
 - Deployment: Docker + Docker Compose
 
-### 3. ASN Coverage - OONI 涵蓋率分析
+### 3. asn_coverage：OONI 涵蓋率分析
 
 分析 OONI 觀測資料在各區域 ASN 的涵蓋狀況，協助識別測量盲點。
 
 **資料來源：**
+
 - OONI AWS S3 公開資料集（`ooni-data-eu-fra`）
 - 支援回溯歷史資料與指定時間區間分析
 
 **主要功能：**
+
 - 統計各 ASN 的 OONI 測量次數
 - 多執行緒平行下載與處理
 - 輸出 CSV 格式分析報告
+
+### 4. tools：共用腳本與檢查
+
+跨子專案的腳本，多數零外部相依，由 GitHub Actions 在 PR 觸發。
+
+| 群組 | 內容 |
+|------|------|
+| 編輯標準 | `docs_style_lint.py` 把[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)「寫作風格規範」可機器判斷的部分做成檢查。三語系都掃，中英各一組規則。細節見 [`tools/README.md`](./tools/README.md) |
+| 前端守門測試 | 小工具區每一支 js 的行為驗證：取樣與熵、QR code 編碼往返、指紋示範頁不送出資料、網址清理不誤刪必要參數、隱形字元偵測的誤判案例。分析事件另有白名單測試，擋住搜尋詞之類的內容被送出 |
+| 離線與 PWA | service worker 的離線路徑、語言偏好導向、離線索引分組、離線內容管理頁的介面，以及預快取清單與建置產物的比對 |
+| 建置一致性 | `check_theme_assets.py` 比對 `overrides/base.html` 與 `sw.js` 寫死的主題資產雜湊與實際安裝的版本，升級 mkdocs-material 漏同步時會擋下來 |
+| 地球儀資料 | `gen_*.py` 產生 `docs/zh-TW/games/tor-network/` 的靜態 JSON，`publish_games_data.sh` 在正式機重生並發布會持續變動的那幾份 |
+| 互動與版面檢查 | headless Chrome 執行的手勢、取景與版面檢查 |
+| 部署 | `cf_purge.py` 分批並行清除 Cloudflare 快取，`s3_restore_mtime.py` 讓內容沒變的檔案被 `aws s3 sync` 跳過 |
 
 ## 🚀 快速開始
 
@@ -65,6 +95,7 @@ anoni-net-docs/
 - **Python**: 3.12+
 - **套件管理**: [uv](https://github.com/astral-sh/uv)
 - **Docker**: 用於 Pulse 系統部署（可選）
+- **Node.js**: 用於 `tools/` 的前端測試（可選，僅需標準庫）
 
 ### 安裝 uv
 
@@ -80,10 +111,18 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 cd docs
 uv sync
 source .venv/bin/activate
-mkdocs serve  # 預設啟動 zh-TW 版本
+mkdocs serve       # 預設語系 zh-TW，http://127.0.0.1:8000
 ```
 
-開啟瀏覽器訪問 `http://127.0.0.1:8000`
+三語系的建置驗證用 `run_*.sh`，各自 export 該語系需要的環境變數再建置到 `output/`：
+
+```bash
+sh run.sh          # zh-TW（預設語系，建在根路徑）
+sh run_zh-cn.sh    # zh-CN
+sh run_en.sh       # en
+```
+
+直接執行 `mkdocs build -f mkdocs_en.yml` 會因為 `DOCS_DIR` 之類的環境變數落回預設值而產生假警報，驗證三語系請走這三支腳本。`build_docs_anoni*.sh` 是正式機的部署腳本，內含伺服器專用路徑，本機不要執行。
 
 #### Pulse 監控系統
 
@@ -107,50 +146,47 @@ uv sync
 uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-### 本地建置排錯
-
-#### 圖表在本地是空白的，線上卻正常
-
-先看頁面原始碼裡載入 vega-embed 的那行。壞掉時長這樣：
-
-```
-../../../../https:/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
-```
-
-正常時會指向本地副本：
-
-```
-../../../../assets/external/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
-```
-
-Material 的 privacy plugin 會把 `mkdocs.yml` 裡 `extra_javascript` 的 CDN 資源下載到 `docs/.cache/plugin/privacy/`。當某個資源的 URL 從無子路徑改成有子路徑時，舊快取會擋住新的目錄：
-
-```yaml
-- https://cdn.jsdelivr.net/npm/vega-embed@6                          # 舊：快取存成一個檔案
-- https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js  # 新：快取需要一個同名目錄
-```
-
-同名的舊檔案佔住路徑，目錄建不起來，下載落空，URL 也就沒被改寫成本地路徑，`https://` 被當成相對路徑接在頁面路徑後面。CI 每次都是乾淨 checkout，不會有舊快取，所以只有本地會壞。`mkdocs build` 的產出同樣會壞，不只是 `mkdocs serve`。
-
-刪掉擋路的那一項後重建：
+### 送 PR 之前
 
 ```bash
-rm docs/.cache/plugin/privacy/assets/external/cdn.jsdelivr.net/npm/vega-embed@6
+# 編輯標準自檢，CI 對變更的 Markdown 執行同一支
+python3 tools/docs_style_lint.py docs/zh-TW/<變更的檔案>.md
+
+# 改到小工具或 service worker 時，一併執行對應測試
+node tools/test_sw_offline.mjs
 ```
 
-不確定是哪一項時，整包刪掉重建也可以，代價是下次建置要重新下載：
+## 🔁 建置與發布
+
+### 分支模型
+
+`main` 是開發分支，`docs` 是建置觸發分支。PR 合併進 `main` 只代表內容進了倉庫，正式站讀取的來源是 S3，需要推 `docs` 分支才會建置並上傳：
 
 ```bash
-rm -rf docs/.cache/plugin/privacy
+git push origin origin/main:refs/heads/docs
 ```
 
-`docs/.cache/` 已列入 `docs/.gitignore`，屬於本地快取，刪掉不影響版本控制。往後任何 `extra_javascript` 的 CDN 網址改變路徑結構，都可能再遇到，處理方式相同。
+workflow 執行完，clearnet 與 onion 兩份產物就上線。沒有自動把 `main` 同步到 `docs` 的機制，屬於刻意設計：要發布哪些內容、什麼時候發布，由人決定。
+
+推了 `docs` 也不一定會建置。觸發路徑限定在會改變產物的檔案（`docs/**`、根目錄的 `BECOME_ANONI*.md`、`tools/cf_purge.py` 與 `tools/s3_restore_mtime.py` 及兩者的測試、`.github/workflows/build_docs.yml` 自己）。只動 `tools/` 其他檔案時推 `docs` 不會建置，需要重新建置時從 Actions 頁面用 `workflow_dispatch` 手動觸發。
+
+### CI workflow
+
+| Workflow | 觸發 | 內容 |
+|----------|------|------|
+| `BuildDocs` | push `docs` 分支、手動 | 建置三語系、處理 Open Graph 圖片、以 `aws s3 sync --delete` 上傳 clearnet 與 onion 產物、由 `cf_purge.py` 清除這次產出網址的 Cloudflare 快取 |
+| `docs-style-lint` | PR | 對變更到的 Markdown 與小工具 UI 字串執行編輯標準掃描。error 級擋 merge，warn 級只標 annotation |
+| `invisible-chars` | PR | 全站隱形字元掃描。零寬字元、BOM、Markdown 裡的不斷行空白會擋 merge |
+| `tools-tests` | PR | `tools/` 底下零相依的測試，執行完不到十秒 |
+| `games-checks` | PR | Tor 中繼地球儀的互動與版面檢查（headless Chrome） |
+| `RIPE ASN name lists`、`Lookback OONI Data` | push `main`、每日排程、手動 | `asn_coverage/` 的資料抓取 |
 
 ## 📖 文件與資源
 
 - **線上文件**: [https://anoni.net/docs/](https://anoni.net/docs/)
 - **GitHub Repo**: [https://github.com/anoni-net/docs](https://github.com/anoni-net/docs)
 - **Tor Onion**: `docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion`
+- **IPFS 閘道**: [https://ipfs.anoni.net/](https://ipfs.anoni.net/)（社群自架，pin 的做法見[鏡像文件](https://anoni.net/docs/community/pin-ipfs-mirror/)）
 - **詳細開發指南**: 請參閱 [CLAUDE.md](./CLAUDE.md)
 
 ## 🤝 貢獻
@@ -162,7 +198,7 @@ rm -rf docs/.cache/plugin/privacy
 - **想提新主題、補在地案例，或推薦來源** → 用[內容提案](https://github.com/anoni-net/docs/issues/new?template=content.yml)或[來源建議](https://github.com/anoni-net/docs/issues/new?template=source-suggestion.yml) Issue。
 - **想參與推廣、活動或維運** → 到 Matrix [社群 Public Space](https://matrix.to/#/#community:im.anoni.net) 打聲招呼。
 
-工具操作與安全情境類內容（tools、scenarios、advanced）由維護者技術審核才合併，其餘內容輕量審核。完整入門見[如何參與與認領主題](https://anoni.net/docs/community/how-to-contribute/)與[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)。流程、分支與 CI、授權見 [CONTRIBUTING.md](./CONTRIBUTING.md)，互動規範見[行為準則](./CODE_OF_CONDUCT.md)。
+工具操作與安全情境類內容（tools、scenarios、advanced）由維護者技術審核才合併，其餘內容輕量審核。寫作風格的單一來源是[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)的「寫作風格規範」一節，送 PR 前可先執行 `tools/docs_style_lint.py` 自檢。完整入門見[如何參與與認領主題](https://anoni.net/docs/community/how-to-contribute/)。流程、分支與 CI、授權見 [CONTRIBUTING.md](./CONTRIBUTING.md)，互動規範見[行為準則](./CODE_OF_CONDUCT.md)。
 
 **找人**：Matrix [Public Space](https://matrix.to/#/#community:im.anoni.net)（帳號申請來信 whisper@anoni.net）、[GitHub Discussions](https://github.com/anoni-net/docs/discussions)、加密共筆 [Cryptpad](https://cryptpad.anoni.net/)。
 
@@ -175,9 +211,13 @@ rm -rf docs/.cache/plugin/privacy
 | `docs/` 網站內容（Markdown 等） | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
 | [`pulse/`](pulse/) 程式碼 | [MIT](pulse/LICENSE) |
 | [`asn_coverage/`](asn_coverage/) 程式碼 | [GPL-3.0](asn_coverage/LICENSE) |
+| [`tools/`](tools/) 腳本與測試 | [MIT](tools/LICENSE)（不含 `tools/data/`）|
+| `docs/zh-TW/games/tor-network/` 的外部資料 | 各自沿用原始授權，清單見 [`NOTICE`](./NOTICE) |
 
 - 根目錄 [`LICENSE`](LICENSE) 為 **CC-BY 4.0** 全文，作為文件與網站內容之預設授權標示。
-- 根目錄 [`LICENSE-asn_coverage`](LICENSE-asn_coverage) 為 **`asn_coverage` 子專案 GPL-3.0** 全文之副本，便於在根目錄瀏覽；以 [`asn_coverage/LICENSE`](asn_coverage/LICENSE) 為準。
+- 根目錄 [`LICENSE-asn_coverage`](LICENSE-asn_coverage) 為 **`asn_coverage` 子專案 GPL-3.0** 全文之副本，便於在根目錄瀏覽。以 [`asn_coverage/LICENSE`](asn_coverage/LICENSE) 為準。
+- 地球儀的外部資料中，`ooni.json` 為 CC BY-NC-SA 4.0，**禁止商業使用**，重製前請先看 [`NOTICE`](./NOTICE)。
+- `tools/data/` 放的是資料來源檔，座標部分取自 OpenStreetMap 採 ODbL，不在 `tools/` 的 MIT 範圍內，見 [`NOTICE`](./NOTICE)。
 
 ---
 
@@ -189,7 +229,7 @@ rm -rf docs/.cache/plugin/privacy
 
 > Promoting and translating Tor, Tails, and OONI measurement tools for anonymous networks
 
-This project is the core documentation system for the "Anonymous Network Community anoni.net", dedicated to promoting internet freedom and privacy protection tools. The project includes a multilingual documentation website, a Tor relay monitoring system, and OONI measurement data analysis tools.
+The core documentation system for the "Anonymous Network Community anoni.net". The repository holds four directories: the public multilingual documentation site, the Tor relay monitoring backend, the OONI measurement analysis CLI, and the shared scripts and CI checks that support the first three.
 
 ## 📚 Project Structure
 
@@ -197,53 +237,83 @@ This project is the core documentation system for the "Anonymous Network Communi
 anoni-net-docs/
 ├── docs/           # MkDocs multilingual documentation site (zh-TW, zh-CN, en)
 ├── pulse/          # Tor relay monitoring system (FastAPI + PostgreSQL)
-└── asn_coverage/   # OONI measurement data and ASN coverage analysis tool
+├── asn_coverage/   # OONI measurement data and ASN coverage analysis CLI
+└── tools/          # Shared scripts: style linting, frontend tests, data generation, deployment
 ```
 
-### 1. Docs - Documentation Website
+Each directory has its own README and its own license. See the License section below.
 
-A multilingual documentation system based on [MkDocs Material](https://squidfunk.github.io/mkdocs-material/), providing Traditional Chinese, Simplified Chinese, and English versions.
+### 1. docs: Documentation Website
 
-**Main Content:**
-- Tor, Tails, and OONI tutorials and translated documentation
-- Community activity information and workshop content
-- Internet censorship observation reports
-- Guides for project participation
+A multilingual site built on [MkDocs Material](https://squidfunk.github.io/mkdocs-material/), published in Traditional Chinese, Simplified Chinese, and English.
 
-**Technical Features:**
-- Multilingual support (zh-TW / zh-CN / en)
-- Built-in blog system with RSS feed
-- Vega-Lite data visualization charts
-- Support for standard web, IPFS, and Tor Onion deployment
+**Site sections:**
 
-### 2. Pulse - Tor Relay Monitoring System
+| Section | Content |
+|---------|---------|
+| Guides | Concepts, tools, scenarios, advanced topics, and reports. Tools are grouped by connection layer, environment layer, measurement layer, and everyday privacy basics |
+| Local Context | Taiwan-specific measurement data and regulation (PDPA, VASP, whistleblower protection) |
+| Utilities | Privacy tools that run entirely in the browser: threat-model inventory, passphrase generator, QR code generator and reader, metadata stripper, URL cleaner, invisible-character detector, browser fingerprint demo |
+| Interactive | Onion routing and rendezvous animations, plus the Tor relay globe |
+| Updates | Blog plus changelogs for Tor, Tails, Arti, and OONI |
+| Community | How to participate, translation workflow, contributor handbook, running relays and onion services, reading measurement data |
+| About | Project introduction, contact, offline content manager |
 
-A system for real-time monitoring and statistics of Tor network relay data, providing APIs for frontend queries and visualization.
+**Technical features:**
 
-**Key Features:**
-- Periodically collect Tor relay data from specified countries (TW, JP, KR, HK)
-- PostgreSQL database for historical records
+- Content for the three locales lives in `docs/zh-TW/`, `docs/zh-CN/`, and `docs/en/`, each with its own mkdocs config. The default locale zh-TW is built at the site root
+- Plugins: `blog`, `rss`, `charts` (Vega-Lite), `social` (Open Graph cards), `privacy` (fetches CDN assets locally at build time), `git-revision-date-localized`, `redirects`
+- Everything in the utilities section computes in the browser and sends no user input anywhere. The matching guard tests live under `tools/`
+- PWA and offline reading: `docs/zh-TW/sw.js` handles the offline path, and `docs/hooks/offline_index.py` emits a per-locale `offline-index.json` at build time that the offline content manager reads to list downloadable sections
+- Three deployment targets: clearnet (S3 plus Cloudflare), Tor Onion (a second prefix in the same bucket), and IPFS (an IPNS name pointing at the latest build)
+
+### 2. pulse: Tor Relay Monitoring System
+
+Collects and aggregates Tor relay data on a schedule, exposing APIs for frontend queries and visualization.
+
+**Key features:**
+
+- Hourly collection of Tor relay data for selected countries (TW, JP, KR, HK)
+- PostgreSQL for historical records
 - FastAPI REST API with Vega-Lite chart endpoints
-- One-click deployment with Docker Compose
+- Two health endpoints: `/api/healthz` returns the version only, `/api/readyz` hits the database on every call
+- One-command deployment with Docker Compose
 
-**Technical Stack:**
+**Technical stack:**
+
 - Backend: Python 3.12+ / FastAPI / psycopg 3
 - Database: PostgreSQL 17
 - Scheduler: Alpine crond
 - Deployment: Docker + Docker Compose
 
-### 3. ASN Coverage - OONI Coverage Analysis
+### 3. asn_coverage: OONI Coverage Analysis
 
-Analyze OONI measurement data coverage across regional ASNs to help identify measurement blind spots.
+Analyzes OONI measurement coverage across regional ASNs to help identify measurement blind spots.
 
-**Data Source:**
+**Data source:**
+
 - OONI AWS S3 public dataset (`ooni-data-eu-fra`)
-- Support for historical data lookback and specified time range analysis
+- Supports historical lookback and explicit time ranges
 
-**Main Features:**
-- Statistics on OONI measurements per ASN
+**Main features:**
+
+- Measurement counts per ASN
 - Multi-threaded parallel download and processing
-- Output analysis reports in CSV format
+- CSV analysis reports
+
+### 4. tools: Shared Scripts and Checks
+
+Cross-subproject scripts, mostly dependency-free, triggered by GitHub Actions on pull requests.
+
+| Group | Content |
+|-------|---------|
+| Style linting | `docs_style_lint.py` turns the machine-checkable parts of the [contributor handbook's](https://anoni.net/docs/community/contributor-handbook/) writing style rules into a linter. It scans all three locales with separate Chinese and English rule sets. See [`tools/README.md`](./tools/README.md) |
+| Frontend guard tests | Behavioral checks for every script in the utilities section: sampling and entropy, QR code encode/decode round-trip, the fingerprint demo sending nothing, the URL cleaner not stripping required parameters, false-positive cases for invisible-character detection. Analytics events have their own allowlist test that keeps content such as search terms from being sent |
+| Offline and PWA | Service worker offline paths, language preference routing, offline index grouping, the offline content manager UI, and a precache-list comparison against build output |
+| Build consistency | `check_theme_assets.py` compares the theme asset hashes hardcoded in `overrides/base.html` and `sw.js` against the installed version, catching a missed sync after a mkdocs-material upgrade |
+| Globe data | `gen_*.py` produces the static JSON under `docs/zh-TW/games/tor-network/`, and `publish_games_data.sh` regenerates and publishes the files that keep changing |
+| Interaction and layout checks | Gesture, framing, and layout checks driven by headless Chrome |
+| Deployment | `cf_purge.py` purges Cloudflare cache in parallel batches, and `s3_restore_mtime.py` lets `aws s3 sync` skip files whose content has not changed |
 
 ## 🚀 Quick Start
 
@@ -251,7 +321,8 @@ Analyze OONI measurement data coverage across regional ASNs to help identify mea
 
 - **Python**: 3.12+
 - **Package Manager**: [uv](https://github.com/astral-sh/uv)
-- **Docker**: For Pulse system deployment (optional)
+- **Docker**: For Pulse deployment (optional)
+- **Node.js**: For the frontend tests in `tools/` (optional, standard library only)
 
 ### Install uv
 
@@ -267,10 +338,18 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 cd docs
 uv sync
 source .venv/bin/activate
-mkdocs serve  # Default: zh-TW version
+mkdocs serve       # default locale zh-TW, http://127.0.0.1:8000
 ```
 
-Open browser and visit `http://127.0.0.1:8000`
+To verify all three locales, use the `run_*.sh` scripts. Each exports the environment variables that locale needs and builds into `output/`:
+
+```bash
+sh run.sh          # zh-TW (default locale, built at the site root)
+sh run_zh-cn.sh    # zh-CN
+sh run_en.sh       # en
+```
+
+Running `mkdocs build -f mkdocs_en.yml` directly lets variables such as `DOCS_DIR` fall back to their defaults and raises spurious warnings, so verify locales through these three scripts. The `build_docs_anoni*.sh` scripts are for the production host and contain server-specific paths; do not run them locally.
 
 #### Pulse Monitoring System
 
@@ -294,50 +373,47 @@ uv sync
 uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-### Local Build Troubleshooting
-
-#### Charts are blank locally but fine in production
-
-Check the script tag that loads vega-embed in the page source. When broken, it looks like this:
-
-```
-../../../../https:/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
-```
-
-When working, it points at the local copy:
-
-```
-../../../../assets/external/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
-```
-
-Material's privacy plugin downloads the CDN resources listed under `extra_javascript` in `mkdocs.yml` into `docs/.cache/plugin/privacy/`. When a resource's URL changes from having no sub-path to having one, the stale cache entry blocks the new directory:
-
-```yaml
-- https://cdn.jsdelivr.net/npm/vega-embed@6                          # old: cached as a file
-- https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js  # new: cache needs a directory of the same name
-```
-
-The old file occupies the path, the directory cannot be created, the download silently fails, and the URL is never rewritten to a local path — so `https://` gets appended to the page path as if it were relative. CI always starts from a clean checkout and has no stale cache, so only local builds break. This affects `mkdocs build` output as well, not just `mkdocs serve`.
-
-Delete the blocking entry and rebuild:
+### Before Opening a PR
 
 ```bash
-rm docs/.cache/plugin/privacy/assets/external/cdn.jsdelivr.net/npm/vega-embed@6
+# Style self-check; CI runs the same linter on changed Markdown
+python3 tools/docs_style_lint.py docs/zh-TW/<changed-file>.md
+
+# When touching a utility script or the service worker, run its test
+node tools/test_sw_offline.mjs
 ```
 
-If you are not sure which entry is at fault, dropping the whole cache is safe — the cost is re-downloading on the next build:
+## 🔁 Build and Publish
+
+### Branch Model
+
+`main` is the development branch and `docs` is the build trigger. Merging a PR into `main` only means the content landed in the repository. The production site reads from S3, so publishing requires pushing the `docs` branch:
 
 ```bash
-rm -rf docs/.cache/plugin/privacy
+git push origin origin/main:refs/heads/docs
 ```
 
-`docs/.cache/` is already listed in `docs/.gitignore`, so removing it has no effect on version control. Any future `extra_javascript` CDN URL that changes its path structure can hit the same issue, with the same fix.
+Once the workflow finishes, both the clearnet and onion builds are live. There is no automatic sync from `main` to `docs`, by design: a human decides what ships and when.
+
+Pushing `docs` does not always trigger a build. The trigger paths are limited to files that change the output (`docs/**`, `BECOME_ANONI*.md` at the repo root, `tools/cf_purge.py` and `tools/s3_restore_mtime.py` with their tests, and `.github/workflows/build_docs.yml` itself). Touching other files under `tools/` will not build; use `workflow_dispatch` from the Actions page when a rebuild is genuinely needed.
+
+### CI Workflows
+
+| Workflow | Trigger | Content |
+|----------|---------|---------|
+| `BuildDocs` | push to `docs`, manual | Builds all three locales, processes Open Graph images, uploads clearnet and onion output with `aws s3 sync --delete`, then purges the Cloudflare cache for the produced URLs via `cf_purge.py` |
+| `docs-style-lint` | PR | Runs the style linter over changed Markdown and utility UI strings. Error-level rules block merge, warn-level rules only annotate |
+| `invisible-chars` | PR | Repository-wide invisible-character scan. Zero-width characters, BOM, and non-breaking spaces in Markdown block merge |
+| `tools-tests` | PR | The dependency-free tests under `tools/`, finishing in under ten seconds |
+| `games-checks` | PR | Interaction and layout checks for the Tor relay globe (headless Chrome) |
+| `RIPE ASN name lists`, `Lookback OONI Data` | push to `main`, daily schedule, manual | Data fetching for `asn_coverage/` |
 
 ## 📖 Documentation & Resources
 
 - **Online Documentation**: [https://anoni.net/docs/](https://anoni.net/docs/)
 - **GitHub Repo**: [https://github.com/anoni-net/docs](https://github.com/anoni-net/docs)
 - **Tor Onion**: `docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion`
+- **IPFS Gateway**: [https://ipfs.anoni.net/](https://ipfs.anoni.net/) (community-run; see the [mirror guide](https://anoni.net/docs/en/community/pin-ipfs-mirror/) for pinning)
 - **Detailed Development Guide**: See [CLAUDE.md](./CLAUDE.md)
 
 ## 🤝 Contributing
@@ -349,20 +425,24 @@ We welcome contributions of all kinds. Pick your starting point:
 - **Propose a topic, add a local case, or suggest a source** → use the [content](https://github.com/anoni-net/docs/issues/new?template=content.yml) or [source](https://github.com/anoni-net/docs/issues/new?template=source-suggestion.yml) issue forms.
 - **Help with outreach, events, or ops** → say hi in the Matrix [community Public Space](https://matrix.to/#/#community:im.anoni.net).
 
-Tool and operational-security content (tools, scenarios, advanced) is reviewed by maintainers before merge; everything else is lighter. See [CONTRIBUTING.md](./CONTRIBUTING.md) for workflow, branches, CI, and licensing, and the [Code of Conduct](./CODE_OF_CONDUCT.md). Reach us via Matrix Public Space (account requests: whisper@anoni.net), [GitHub Discussions](https://github.com/anoni-net/docs/discussions), or [Cryptpad](https://cryptpad.anoni.net/).
+Tool and operational-security content (tools, scenarios, advanced) is reviewed by maintainers before merge; everything else is lighter. The single source of truth for writing style is the writing style section of the [contributor handbook](https://anoni.net/docs/community/contributor-handbook/), and `tools/docs_style_lint.py` is available for a local self-check. See [CONTRIBUTING.md](./CONTRIBUTING.md) for workflow, branches, CI, and licensing, and the [Code of Conduct](./CODE_OF_CONDUCT.md). Reach us via Matrix Public Space (account requests: whisper@anoni.net), [GitHub Discussions](https://github.com/anoni-net/docs/discussions), or [Cryptpad](https://cryptpad.anoni.net/).
 
 ## 📝 License
 
-This repository contains multiple licenses. Use the table below and each subdirectory’s `LICENSE` file (**not** all code is MIT).
+This repository contains multiple licenses. Use the table below and each subdirectory's `LICENSE` file (**not** all code is MIT).
 
 | Scope | License |
 |-------|---------|
 | `docs/` site content (Markdown, etc.) | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
 | [`pulse/`](pulse/) code | [MIT](pulse/LICENSE) |
 | [`asn_coverage/`](asn_coverage/) code | [GPL-3.0](asn_coverage/LICENSE) |
+| [`tools/`](tools/) scripts and tests | [MIT](tools/LICENSE) (excluding `tools/data/`) |
+| Third-party data under `docs/zh-TW/games/tor-network/` | Retains its original license; see [`NOTICE`](./NOTICE) |
 
 - The root [`LICENSE`](LICENSE) file is the full **CC-BY 4.0** text used as the default license notice for documentation and site content.
 - Root [`LICENSE-asn_coverage`](LICENSE-asn_coverage) is a **duplicate copy** of the GPL-3.0 text for `asn_coverage`; [`asn_coverage/LICENSE`](asn_coverage/LICENSE) is authoritative.
+- Among the globe datasets, `ooni.json` is CC BY-NC-SA 4.0 and **prohibits commercial use**. Read [`NOTICE`](./NOTICE) before redistributing.
+- `tools/data/` holds source data files whose coordinates come partly from OpenStreetMap under ODbL. They fall outside the MIT license covering `tools/`; see [`NOTICE`](./NOTICE).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,15 +27,15 @@ source .venv/bin/activate
 mkdocs serve   # 預設 zh-TW
 ```
 
-或使用腳本啟動不同語言版本：
+開啟瀏覽器訪問 `http://127.0.0.1:8000`。
+
+要驗證三個語系，用 `run_*.sh` 建置到 `output/`。三支腳本各自 export 該語系需要的環境變數，直接執行 `mkdocs build -f mkdocs_en.yml` 會因為 `DOCS_DIR` 之類的變數落回預設值而產生假警報：
 
 ```bash
 sh run.sh          # zh-TW（預設語系，建在根路徑）
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```
-
-開啟瀏覽器訪問 `http://127.0.0.1:8000`。
 
 ## 建置文件
 
@@ -46,6 +46,45 @@ sh build_docs_anoni_onion.sh  # Onion 版
 ```
 
 注意：`build_docs_anoni.sh` 與 `build_docs_anoni_onion.sh` 內含伺服器專用路徑，僅供特定部署環境使用。`replace_sitename_anoni_ipfs.sh` 會對產出與來源做 `sed -i` 修改，請僅在乾淨建置環境執行。
+
+## 本地建置排錯
+
+### 圖表在本地是空白的，線上卻正常
+
+先看頁面原始碼裡載入 vega-embed 的那行。壞掉時長這樣：
+
+```
+../../../../https:/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
+```
+
+正常時會指向本地副本：
+
+```
+../../../../assets/external/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
+```
+
+Material 的 privacy plugin 會把 `mkdocs.yml` 裡 `extra_javascript` 的 CDN 資源下載到 `.cache/plugin/privacy/`。當某個資源的 URL 從無子路徑改成有子路徑時，舊快取會擋住新的目錄：
+
+```yaml
+- https://cdn.jsdelivr.net/npm/vega-embed@6                          # 舊：快取存成一個檔案
+- https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js  # 新：快取需要一個同名目錄
+```
+
+同名的舊檔案佔住路徑，目錄建不起來，下載落空，URL 也就沒被改寫成本地路徑，`https://` 被當成相對路徑接在頁面路徑後面。CI 每次都是乾淨 checkout，不會有舊快取，所以只有本地會壞。`mkdocs build` 的產出同樣會壞，不只是 `mkdocs serve`。
+
+刪掉擋路的那一項後重建：
+
+```bash
+rm .cache/plugin/privacy/assets/external/cdn.jsdelivr.net/npm/vega-embed@6
+```
+
+不確定是哪一項時，整包刪掉重建也可以，代價是下次建置要重新下載：
+
+```bash
+rm -rf .cache/plugin/privacy
+```
+
+`.cache/` 已列入 `.gitignore`，屬於本地快取，刪掉不影響版本控制。往後任何 `extra_javascript` 的 CDN 網址改變路徑結構，都可能再遇到，處理方式相同。
 
 ## 多語系架構
 
@@ -100,15 +139,15 @@ source .venv/bin/activate
 mkdocs serve   # Default: zh-TW
 ```
 
-Or use scripts to serve a specific language:
+Open `http://127.0.0.1:8000` in your browser.
+
+To verify all three locales, build into `output/` with the `run_*.sh` scripts. Each exports the environment variables that locale needs; running `mkdocs build -f mkdocs_en.yml` directly lets variables such as `DOCS_DIR` fall back to their defaults and raises spurious warnings:
 
 ```bash
-sh run.sh          # zh-TW (default language, built at the site root)
+sh run.sh          # zh-TW (default locale, built at the site root)
 sh run_zh-cn.sh    # zh-CN
 sh run_en.sh       # en
 ```
-
-Open `http://127.0.0.1:8000` in your browser.
 
 ## Building the Docs
 
@@ -119,6 +158,45 @@ sh build_docs_anoni_onion.sh  # Onion build
 ```
 
 Note: `build_docs_anoni.sh` and `build_docs_anoni_onion.sh` contain server-specific paths and are intended for a specific deployment environment only. `replace_sitename_anoni_ipfs.sh` modifies output and source with `sed -i`; run only in a clean build environment.
+
+## Local Build Troubleshooting
+
+### Charts are blank locally but fine in production
+
+Check the script tag that loads vega-embed in the page source. When broken, it looks like this:
+
+```
+../../../../https:/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
+```
+
+When working, it points at the local copy:
+
+```
+../../../../assets/external/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
+```
+
+Material's privacy plugin downloads the CDN resources listed under `extra_javascript` in `mkdocs.yml` into `.cache/plugin/privacy/`. When a resource's URL changes from having no sub-path to having one, the stale cache entry blocks the new directory:
+
+```yaml
+- https://cdn.jsdelivr.net/npm/vega-embed@6                          # old: cached as a file
+- https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js  # new: cache needs a directory of the same name
+```
+
+The old file occupies the path, the directory cannot be created, the download silently fails, and the URL is never rewritten to a local path, so `https://` gets appended to the page path as if it were relative. CI always starts from a clean checkout and has no stale cache, so only local builds break. This affects `mkdocs build` output as well, not just `mkdocs serve`.
+
+Delete the blocking entry and rebuild:
+
+```bash
+rm .cache/plugin/privacy/assets/external/cdn.jsdelivr.net/npm/vega-embed@6
+```
+
+If you are not sure which entry is at fault, dropping the whole cache is safe. The cost is re-downloading on the next build:
+
+```bash
+rm -rf .cache/plugin/privacy
+```
+
+`.cache/` is already listed in `.gitignore`, so removing it has no effect on version control. Any future `extra_javascript` CDN URL that changes its path structure can hit the same issue, with the same fix.
 
 ## Multilingual Structure
 

--- a/docs/en/community/contributor-handbook.md
+++ b/docs/en/community/contributor-handbook.md
@@ -27,7 +27,21 @@ Every one of these starts with saying hello on Matrix. The community works async
 
 Traditional Chinese (`docs/zh-TW`) is the source of truth for the site, and its style rules cover Chinese punctuation, classifier repetition, register, and translated terminology. Those rules do not transfer, and several are actively wrong when applied to English. Em dashes, for example, are banned in Chinese body text and are ordinary English typography.
 
-What follows is the English rule set. If you are writing or reviewing Chinese, use the [Chinese contributor handbook](https://anoni.net/docs/community/contributor-handbook/){target="_blank"} (in Chinese) instead, which is the authority for `zh-TW` and `zh-CN`. The automated style linter in CI only covers `docs/zh-TW` and `docs/zh-CN`, so the English rules below rest on human review.
+What follows is the English rule set. If you are writing or reviewing Chinese, use the [Chinese contributor handbook](https://anoni.net/docs/community/contributor-handbook/){target="_blank"} (in Chinese) instead, which is the authority for `zh-TW` and `zh-CN`. Since 2026-08 the automated style linter in CI also covers `docs/en`, though only three of the English rules are mechanised so far (`bold-lead-sentence`, `title-colon`, `machine-field`). The rest of the English rules below rest on human review.
+
+### What these rules cover
+
+The rules apply to the documentation under `docs/` in all three locales, and to the repository's own explanatory files: `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and `NOTICE` at the root, plus the `README.md` in each subdirectory. Readers meet the project through those files, so they follow the same standard as the site.
+
+The `docs-style-lint` job only fires on Markdown changes under `docs/zh-TW`, `docs/zh-CN`, and `docs/en`. After editing an explanatory file, run the linter yourself:
+
+```bash
+python3 tools/docs_style_lint.py README.md CONTRIBUTING.md
+```
+
+`NOTICE` has no `.md` extension and the linter only accepts `.md` and `.js`, so that one needs a human read.
+
+Rule documents spell out every banned punctuation mark and sentence pattern, so the linter flags its own rule descriptions. This handbook and the workspace projection are exempted by filename through the linter's `RULE_DOCS`, and the rule table and known-limits section in `tools/README.md` are wrapped in `<!-- docs-style-lint: disable -->` and `enable`. Follow the same approach when writing rule documentation, and leave the quoted examples as they are.
 
 ### Voice and positioning
 

--- a/docs/zh-CN/community/contributor-handbook.md
+++ b/docs/zh-CN/community/contributor-handbook.md
@@ -23,6 +23,20 @@ icon: material/book-open-variant
 
 ## 写作风格规范
 
+### 适用范围
+
+规范适用于 `docs/` 底下三个语系的文件内容，也适用于 repo 自己的说明文件：根目录的 `README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`NOTICE`，以及各子目录的 `README.md`。读者会从那些文件认识项目，写法跟站上的文件同一套。
+
+CI 的 `docs-style-lint` 只在 `docs/zh-TW`、`docs/zh-CN`、`docs/en` 的 Markdown 变更时触发。说明文件改完需要自己执行一次：
+
+```bash
+python3 tools/docs_style_lint.py README.md CONTRIBUTING.md
+```
+
+`NOTICE` 没有 `.md` 扩展名，linter 只收 `.md` 与 `.js`，那一份要人工看。
+
+规则文件本身逐条写出被禁用的标点与句型，扫自己的规则描述必然全红。这份百科与工作区的投影文件靠 linter 的 `RULE_DOCS` 依文件名豁免，`tools/README.md` 的规则表与已知边界两段用 `<!-- docs-style-lint: disable -->` 与 `enable` 包住。写规则说明时照同一个做法，引用的例子要保持原样。
+
 ### 禁用句型与标点
 
 - 不使用 `——`（双破折号）作为句中插入语。需要补充说明时，改用冒号、逗号，或拆成两句

--- a/docs/zh-TW/community/contributor-handbook.md
+++ b/docs/zh-TW/community/contributor-handbook.md
@@ -23,6 +23,20 @@ icon: material/book-open-variant
 
 ## 寫作風格規範
 
+### 套用範圍
+
+規範適用於 `docs/` 底下三個語系的文件內容，也適用於 repo 自己的說明文件：根目錄的 `README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`NOTICE`，以及各子目錄的 `README.md`。讀者會從那些檔案認識專案，寫法跟站上的文件同一套。
+
+CI 的 `docs-style-lint` 只在 `docs/zh-TW`、`docs/zh-CN`、`docs/en` 的 Markdown 變更時觸發。說明文件改完需要自己執行一次：
+
+```bash
+python3 tools/docs_style_lint.py README.md CONTRIBUTING.md
+```
+
+`NOTICE` 沒有 `.md` 副檔名，linter 只收 `.md` 與 `.js`，那一份要人工看。
+
+規則文件本身逐條寫出被禁用的標點與句型，掃自己的規則描述必然全紅。這份百科與工作區的投影檔靠 linter 的 `RULE_DOCS` 依檔名豁免，`tools/README.md` 的規則表與已知邊界兩段用 `<!-- docs-style-lint: disable -->` 與 `enable` 包住。寫規則說明時照同一個做法，引用的例子要保持原樣。
+
 ### 禁用句型與標點
 
 - 不使用 `——`（雙破折號）作為句中插入語。需要補充說明時，改用冒號、逗號，或拆成兩句

--- a/tools/LICENSE
+++ b/tools/LICENSE
@@ -1,0 +1,25 @@
+Scope: this license covers the scripts and tests under tools/. It does not
+cover tools/data/, which holds hand-maintained source data derived in part from
+OpenStreetMap under ODbL; see the NOTICE file at the repository root.
+
+MIT License
+
+Copyright (c) 2023-2026 Anoni.net Docs Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 把公開[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)「寫作風格規範」裡可機器判斷的硬規則做成檢查，輸出 `file:line` 與規則代碼。
 
-編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。三個語系都掃，但套用的規則不同。中文那組是標點與句型，套用在 zh-TW 與 zh-CN。英文那組獨立（破折號與分號在英文是正常標點），2026-08 起納入 docs/en，目前實作 `bold-lead-sentence`、`title-colon` 與 `machine-field` 三條。linter 依路徑自動選規則集，見 `is_english_doc`。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動跑。error 級擋 merge，warn 級只提醒。
+編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。三個語系都掃，但套用的規則不同。中文那組是標點與句型，套用在 zh-TW 與 zh-CN。英文那組獨立（破折號與分號在英文是正常標點），2026-08 起納入 docs/en，目前實作 `bold-lead-sentence`、`title-colon` 與 `machine-field` 三條。linter 依路徑自動選規則集，見 `is_english_doc`。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動執行。error 級擋 merge，warn 級只提醒。
 
 ## 用法
 
@@ -23,9 +23,9 @@ python3 tools/docs_style_lint.py --format json <path>
 
 ## CI：GitHub Action（只掃變更檔）
 
-舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的 Markdown（`docs/zh-TW`、`docs/zh-CN`、`docs/en`），跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
+舊文有不少遺留違規（見下方試行結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的 Markdown（`docs/zh-TW`、`docs/zh-CN`、`docs/en`），以 `--format github` 把問題以 annotation 標在 PR 的變更行上。
 
-**這個 job 會擋 merge**：有任一 error 時 linter 回 exit 1，job 就紅。warn 級規則只標 annotation，不影響 exit code，因為改法要看語境，機器不宜代勞。要讓 warn 也擋，得先把對應規則升成 error。
+**這個 job 會擋 merge**：有任一 error 時 linter 回 exit 1，job 就紅。warn 級規則只標 annotation，不影響 exit code，因為改法要看語境，機器不宜代勞。要讓 warn 也擋，需先把對應規則升成 error。
 
 repo 設定還沒把這個 check 列為 branch protection 必過，所以它擋得住 PR 的紅燈，擋不住有權限的人直接合併。
 
@@ -94,7 +94,7 @@ git diff --name-only --diff-filter=ACM origin/main... \
 
   同一行結尾放 `<!-- docs-style-lint: disable-line -->` 可只關閉該行。
 
-## 試跑結果（2026-06，全 zh-TW）
+## 試行結果（2026-06，全 zh-TW）
 
 | 規則 | 數量 |
 |---|---|
@@ -110,7 +110,7 @@ git diff --name-only --diff-filter=ACM origin/main... \
 
 ## 上線進程
 
-1. 私有試跑穩定。✅
-2. 移入公開 `anoni-net/docs`，GitHub Action 對變更檔跑「warn 不擋」。✅
+1. 私有試行穩定。✅
+2. 移入公開 `anoni-net/docs`，GitHub Action 對變更檔執行「warn 不擋」。✅
 3. 升為 blocking gate。已拿掉 `continue-on-error`，error 級會擋。← 現在，尚缺 repo 設定的 branch protection 必過。
 4. 視需要做一次全庫清理 pass，把舊文遺留違規補掉。

--- a/tools/README.md
+++ b/tools/README.md
@@ -41,6 +41,8 @@ git diff --name-only --diff-filter=ACM origin/main... \
 
 ## Tier 1：本工具會自動檢查
 
+<!-- docs-style-lint: disable -->
+
 | 規則代碼 | 嚴重度 | 內容 |
 |---|---|---|
 | `em-dash` | error | 破折號「—」當插入語（表格空資料格 `| — |` 放行）|
@@ -63,6 +65,8 @@ git diff --name-only --diff-filter=ACM origin/main... \
 | `machine-field` | warn | 機器欄位名直接出現在內文（如 `web_connectivity`）|
 | `title-missing` / `frontmatter-summary` | warn | blog 無 H1 標題 / 無 summary |
 
+<!-- docs-style-lint: enable -->
+
 ## Tier 2：本工具「不」檢查，需 AI 或人工複審
 
 這些規則需要語意判斷，正則做不準，刻意不在此掃，避免假裝涵蓋了。校稿或 review 時仍要靠人或 AI 輔助：
@@ -76,10 +80,14 @@ git diff --name-only --diff-filter=ACM origin/main... \
 
 ## 已知邊界（會誤報或需人判斷）
 
+<!-- docs-style-lint: disable -->
+
 - `em-dash`：若破折號出現在外部專有名詞的連結文字（例 `[Cloudflare Radar — Iran](...)`），會被標記。必要時改寫標籤或人工放行。表格空資料格 `| — |`（整格只有一個破折號）已自動放行，破折號跟其他文字混在同一格仍會被標記。
 - `colloquial-jiang`、`definition-phrasing`：列為 warn 而非 error，因為「講清楚」、「指的是什麼呢」等仍有正當用法，只當提醒。
 - `zhe-repeat`：刻意的排比句會被標記，例如「這個 ASN、這個時段、這個網站」。多數情況把後面幾個「這個」拿掉會更好讀，真的要保留就用 `disable-line`。距離門檻 8 個字是對全 429 篇校準的，放寬會開始收進正當用法。
 - `colloquial-*` 系列：一律 warn 而非 error，因為替換詞要看語境（「跑」依情況是執行、架設、運作或營運），機器不宜直接改。照錄他人說法時（例：把讀者感受寫成「跑很慢」）屬正當用法，已列入例外，其餘情況請人工判斷後改寫。
+
+<!-- docs-style-lint: enable -->
 
 ## 關閉特定檢查
 


### PR DESCRIPTION
## 為什麼

README 停在三個子專案的時代。`tools/`、CI/CD 與發布流程、小工具區、互動與呈現、PWA 離線閱讀都沒有出現，而「本地開發」那節照著做還會撲空。

順著查下去帶出兩個一直沒補的洞：`tools/` 從來沒有授權標示，寫作規範也只講規則本身、沒講管到哪些檔案，於是 repo 自己的說明文件長期不受約束。

## 改了什麼

### README 重整（`d5e16e4`）

- 專案結構改成四個目錄，新增 `tools/` 一節，六個群組各自說明
- `docs/` 補上網站分區表、PWA 與離線閱讀、三種部署目標
- 新增「建置與發布」：分支模型、發布指令、七支 workflow 的觸發與內容
- vega-embed 快取排錯移進 `docs/README.md`，屬子專案細節

修正一處實質錯誤：`run.sh`、`run_en.sh`、`run_zh-cn.sh` 最後一行都是 `mkdocs build`，舊文寫成「啟動不同語言版本」再叫人開 `127.0.0.1:8000`，照著做什麼都沒有。`README.md`、`docs/README.md`、`CLAUDE.md` 三處一併改成「`mkdocs serve` 預覽 zh-TW，`run_*.sh` 是三語系建置驗證」。

### `tools/` 補上 MIT（`d5e16e4`）

`tools/` 底下沒有 `LICENSE`，`CONTRIBUTING.md` 的授權表也只列三項。有人想引用 `docs_style_lint.py` 或 `cf_purge.py` 找不到依據。

新增 `tools/LICENSE`，MIT 全文與 `pulse/LICENSE` 逐字一致。`tools/data/` 在檔頭排除：那是人工維護的海纜登陸點來源檔，座標來自 OSM 採 ODbL，`NOTICE` 裡 `tw-landing.json` 那一列記的就是它的產物。README 與 `CONTRIBUTING.md` 兩張授權表、`NOTICE` 同步。

### 寫作規範寫明套用範圍（`991f0f0`）

三語系貢獻者百科各補一節「套用範圍」：`docs/` 以外的 `README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`NOTICE` 與各子目錄 `README.md` 同樣適用，這些檔案不在 CI 觸發路徑內，改完要自己執行 linter，`NOTICE` 沒有 `.md` 副檔名要人工看。

`tools/README.md` 的規則表與已知邊界兩段逐條寫出被禁用的標點與句型，linter 掃自己的規則描述必然全紅，原本沒有豁免。改用既有的 `<!-- docs-style-lint: disable -->` 包住，該檔從 10 error 34 warn 降到 0，規則表也不會再被誤修。貢獻者百科走的是 `RULE_DOCS` 依檔名豁免。

順帶修正 en 版一句過時敘述：linter 自 2026-08 起也掃 `docs/en`，機械化了三條規則，不再是「只涵蓋 zh-TW 與 zh-CN」。

### 依新範圍自我修正（`875f3fa`、`a636551`）

`CLAUDE.md` 清掉 3 處全形分號與 12 處口語「跑」，`CONTRIBUTING.md` 清掉 4 處分號與 1 處「跑」，兩者的開頭與目錄表都補上 `tools/`。

## 驗證

- `docs_style_lint.py` 對 `README.md`、`CONTRIBUTING.md`、`CLAUDE.md`、`docs/README.md`、`tools/README.md` 全部 0 error 0 warn
- `check_invisible_chars.mjs` 七個檔案乾淨
- 三語系 `run*.sh` 建置通過（strict 模式，0 warning），新段落都進了產物

🤖 Generated with [Claude Code](https://claude.com/claude-code)