### PR TITLE
feat(social): 社群分享卡改用自訂版型，三語系共用一份

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,10 @@ sh build_docs_anoni_onion.sh  # Onion 版本
   - `blog`: 部落格功能
   - `rss`: RSS feed
   - `charts`: Vega-Lite 圖表支援（用於數據視覺化）
-  - `social`: Open Graph 社交卡片生成
+  - `social`: Open Graph 社群分享卡。版型是 `docs/layouts/anoni.yml`，三個語系共用一份，
+    語系差異（字型、卡片上的站名）寫在各自的 `mkdocs*.yml`。`cards_layout_dir` 相對於
+    執行 mkdocs 的目錄，所以建置一律在 `docs/` 底下跑。設計說明見
+    `docs/zh-TW/community/brand-assets.md` 的「社群分享卡」一節
 - **特殊功能**: 使用 `custom_dir` 設定客製化的 overrides（針對不同語言有不同的 overrides 目錄）
 
 ## Pulse 監控系統

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 - 多語系：zh-TW / zh-CN / en
 - 主題：[MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
 - 部落格、RSS、Vega-Lite 圖表
+- 社群分享卡：`layouts/anoni.yml`，三語系共用的自訂版型
 - 三種部署：標準網站、IPFS、Tor Onion
 
 ## 本地開發

--- a/docs/en/community/brand-assets.md
+++ b/docs/en/community/brand-assets.md
@@ -352,6 +352,36 @@ Align derivative work to these values. The site's `extra.css` already defines th
 - `Event` uses `--accent-action`
 - `Updated` uses `--cat-privacy`, sharing a colour with the privacy track, where the weak visual association is acceptable
 
+## :material-share-variant-outline: Social cards (Open Graph)
+
+Paste any page of the docs into Mastodon, LinkedIn, X, Bluesky or a chat room, and the preview image comes straight from the build. One card per page per language, no manual artwork.
+
+The card uses the palette from this page. cyan-900 is the background, and a three-part bar runs down the left edge in cyan-300, cyan-500 and cyan-700, matching the three hexagons of the logo. The mono white logo and the site name sit at the top left, the page title in the middle, and the page description and URL below it. When a page sets `icon` in its front matter, that icon is enlarged into a 10% white watermark on the right. Pages without one get `material/hexagon-multiple-outline`, the icon the logo was derived from.
+
+The background is cyan-900 rather than the brand colour cyan-500, so that the text stays readable. White on cyan-500 has a contrast ratio of 2.5:1, which turns to mush at the size social platforms display. On cyan-900 it is 11.5:1. The description uses cyan-100 at 8.4:1, and the footer URL cyan-300 at 5.6:1.
+
+The layout lives in `docs/layouts/anoni.yml`, shared by all three languages. The only per-language differences are the font (Noto Sans TC, Noto Sans SC, Public Sans) and the site name printed on the card, set in `mkdocs.yml`, `mkdocs_cn.yml` and `mkdocs_en.yml`. Change the shared layout instead of forking it per language.
+
+### Line breaking for Chinese titles
+
+The plugin that draws the cards breaks lines at whitespace only. A Chinese sentence has none, so it counts as a single word, and anything past the first line used to be cut off at the edge of the canvas without even an ellipsis. Before this change, the longest post title on the site showed only its first half.
+
+The layout now adds a space after the full-width comma, enumeration comma, colon, full stop, exclamation mark and question mark, which gives the line breaker somewhere to break. A space that lands at the end of a line disappears. The cost is an occasional extra gap inside a sentence. In return, every title and description across the three languages now fits. Titles of 14 characters or fewer are left alone, as they fit on one line anyway.
+
+### Overriding a single page
+
+To give one page a different title, description or background colour, override it in that page's front matter:
+
+```yaml
+social:
+  cards_layout_options:
+    title: The title to print on the card
+    description: The description to print on the card
+    background_color: "#003e57"
+```
+
+Pages that need artwork of their own (event key visuals, the interactive section) take a different route: set `og.enabled: true` and `og.image` in the front matter, and the site template uses that image and skips the generated one. The COSCUP event pages and the interactive section work this way.
+
 ## :material-alert-octagon-outline: What not to do
 
 **Logo**

--- a/docs/layouts/anoni.yml
+++ b/docs/layouts/anoni.yml
@@ -1,0 +1,309 @@
+# anoni.net Docs 的社群分享卡版型（Open Graph、1200x630）
+#
+# 由 mkdocs-material 的 social 外掛渲染，三個語系共用這一份。語系差異只走
+# mkdocs*.yml 的 cards_layout_options（字型、版面上顯示的站名），版型本身改這裡，
+# 不要各語系各存一份。
+#
+# 配色取自貢獻者百科的品牌素材頁（community/brand-assets.md）。底色是 cyan-900，
+# 左緣三段色塊由上而下是 cyan-300、cyan-500、cyan-700，對應 logo 三個六角形的層次。
+# 白字放在 cyan-900 上對比 11.5:1，之前的 cyan-500 底配白字只有 2.5:1，縮到社群平台
+# 的預覽尺寸幾乎讀不出來。
+#
+# 版面數值由實測得出。外掛的字級由圖層高度與行數反推（social/plugin.py 的
+# _metrics），標題框 170px 配兩行對應 Noto Sans TC 58px、Public Sans 71px。58px 是
+# 三個語系全部標題的上限：目前最長的一段不可斷字串是 zh-CN 的
+# 「土库曼斯坦如何将网络审查变成一门生意」，18 個字在 58px 下佔 1044px，還放得進
+# 1056px 的標題框。字級再往上，那一類標題就會被切在畫布邊緣。
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+definitions:
+
+  # 品牌色票（brand-assets.md 的 token，改色請先改那一頁）
+  - &brand_cyan_300 "#4dbfff"
+  - &brand_cyan_500 "#00aeff"
+  - &brand_cyan_700 "#0089bf"
+
+  # 背景。預設 cyan-900，單頁可用 front matter 的 social.cards_layout_options 換掉
+  - &background_color >-
+    {%- if layout.background_color -%}
+      {{ layout.background_color }}
+    {%- else -%}
+      #003e57
+    {%- endif -%}
+
+  - &background_image >-
+    {{ layout.background_image | x }}
+
+  # 主要文字（站名、標題）
+  - &color >-
+    {%- if layout.color -%}
+      {{ layout.color }}
+    {%- else -%}
+      #ffffff
+    {%- endif -%}
+
+  # 次要文字（描述）。cyan-100，跟標題拉開層次又保有足夠對比
+  - &muted_color >-
+    {%- if layout.muted_color -%}
+      {{ layout.muted_color }}
+    {%- else -%}
+      #b3e3ff
+    {%- endif -%}
+
+  # 頁尾網址。cyan-300
+  - &accent_color >-
+    {%- if layout.accent_color -%}
+      {{ layout.accent_color }}
+    {%- else -%}
+      #4dbfff
+    {%- endif -%}
+
+  # 底圖用的頁面圖示顏色。白色 10% 透明，八位數 hex 的最後兩碼是 alpha
+  - &watermark_color >-
+    {%- if layout.watermark_color -%}
+      {{ layout.watermark_color }}
+    {%- else -%}
+      #ffffff1a
+    {%- endif -%}
+
+  # 字型。zh-TW 用 Noto Sans TC、zh-CN 用 Noto Sans SC、en 用 Public Sans，
+  # 三個值由各自的 mkdocs*.yml 帶進來，跟站上內文字型同一套
+  - &font_family >-
+    {%- if layout.font_family -%}
+      {{ layout.font_family }}
+    {%- elif config.theme.font is mapping -%}
+      {{ config.theme.font.get("text", "Roboto") }}
+    {%- else -%}
+      Roboto
+    {%- endif -%}
+
+  - &font_variant >-
+    {%- if layout.font_variant -%}
+      {{ layout.font_variant }}
+    {%- endif -%}
+
+  # 版面上的站名。en 的 site_name 是一整句副標，全部塞進來會被截斷，
+  # 所以 mkdocs_en.yml 用 site_name 這個選項換成短版
+  - &site_name >-
+    {%- if layout.site_name -%}
+      {{ layout.site_name }}
+    {%- else -%}
+      {{ config.site_name }}
+    {%- endif -%}
+
+  # 頁尾網址。site_url 去掉協定與結尾斜線，onion 版建置時 site_url 已被
+  # replace_sitename_anoni_onion.sh 換成 onion 位址，這裡跟著換，不必特別處理
+  - &site_url >-
+    {%- if layout.footer -%}
+      {{ layout.footer }}
+    {%- else -%}
+      {%- set url = config.site_url | replace("https://", "") | replace("http://", "") -%}
+      {%- if url.endswith("/") -%}
+        {{ url[:-1] }}
+      {%- else -%}
+        {{ url }}
+      {%- endif -%}
+    {%- endif -%}
+
+  # 標題。中文詞與詞之間沒有空白，而外掛的換行只斷在空白處（plugin.py 用
+  # re.split(r"\s+") 切詞），一整句中文會被當成一個詞，超過一行就直接切在畫布
+  # 邊緣，連刪節號都不會有。這裡在全形標點後面補一個半形空白，給換行演算法
+  # 可以斷的位置，補完的空白落在行尾就會被吃掉。
+  #
+  # 14 字以內不處理：那個長度本來就放得下一行，補了只會在句子中間看到多餘的空隙。
+  #
+  # 首頁的 front matter 標題是導覽列用的「首頁」「Home」，拿來當卡片標題等於沒說，
+  # 所以首頁改用站名，跟 og:title 的處理一致。
+  - &page_title >-
+    {%- if layout.title -%}
+      {%- set text = layout.title -%}
+    {%- elif page.is_homepage -%}
+      {%- set text = config.site_name -%}
+    {%- else -%}
+      {%- set text = page.meta.get("title", page.title) -%}
+    {%- endif -%}
+    {%- if text | length > 14 -%}
+      {{ text
+        | replace("：", "： ") | replace("，", "， ") | replace("、", "、 ")
+        | replace("；", "； ") | replace("。", "。 ") | replace("！", "！ ")
+        | replace("？", "？ ") | replace("）", "） ") | replace("」", "」 ")
+        | replace("》", "》 ") | replace("（", " （") | replace("「", " 「")
+        | replace("《", " 《")
+      }}
+    {%- else -%}
+      {{ text }}
+    {%- endif -%}
+
+  # 描述。理由同標題，描述一定夠長，不用判斷長度
+  - &page_description >-
+    {%- set text = layout.description or page.meta.get("description", config.site_description) | x -%}
+    {{ text
+      | replace("：", "： ") | replace("，", "， ") | replace("、", "、 ")
+      | replace("；", "； ") | replace("。", "。 ") | replace("！", "！ ")
+      | replace("？", "？ ") | replace("）", "） ") | replace("」", "」 ")
+      | replace("》", "》 ") | replace("（", " （") | replace("「", " 「")
+      | replace("《", " 《")
+    }}
+
+  # 底下兩個給 meta 標籤用，補空白的版本只給畫面，標籤要原文
+  - &meta_title >-
+    {%- if not page.is_homepage -%}
+      {{ page.meta.get("title", page.title) }} - {{ config.site_name }}
+    {%- else -%}
+      {{ config.site_name }}
+    {%- endif -%}
+
+  - &meta_description >-
+    {%- if layout.description -%}
+      {{ layout.description }}
+    {%- else -%}
+      {{ page.meta.get("description", config.site_description) | x }}
+    {%- endif -%}
+
+  # 頁面圖示。front matter 沒寫就退回 hexagon-multiple-outline，logo 就是從
+  # 這個圖示衍生定色而成，退回它不會讓卡片看起來像少了東西
+  - &page_icon >-
+    {%- if page.meta and page.meta.icon -%}
+      {{ page.meta.icon }}
+    {%- elif layout.icon -%}
+      {{ layout.icon }}
+    {%- else -%}
+      material/hexagon-multiple-outline
+    {%- endif -%}
+
+  # 社群 logo。mono white 版本，用在品牌色塊上對比最高
+  - &logo >-
+    {%- if layout.logo -%}
+      {{ layout.logo }}
+    {%- elif config.theme.logo -%}
+      {{ config.docs_dir }}/{{ config.theme.logo }}
+    {%- endif -%}
+
+  - &logo_icon >-
+    {%- if not layout.logo and config.theme.icon -%}
+      {{ config.theme.icon.logo | x }}
+    {%- endif -%}
+
+# Meta 標籤。內容與外掛預設版型一致，換版型不會動到 og 與 twitter 的值。
+# front matter 寫了 og.enabled 的頁面由 overrides/main.html 自己出標籤，
+# 那些頁面會跳過這一段。
+tags:
+  og:type: website
+  og:title: *meta_title
+  og:description: *meta_description
+  og:image: "{{ image.url }}"
+  og:image:type: "{{ image.type }}"
+  og:image:width: "{{ image.width }}"
+  og:image:height: "{{ image.height }}"
+  og:url: "{{ page.canonical_url }}"
+
+  twitter:card: summary_large_image
+  twitter:title: *meta_title
+  twitter:description: *meta_description
+  twitter:image: "{{ image.url }}"
+
+# -----------------------------------------------------------------------------
+# Specification
+# -----------------------------------------------------------------------------
+
+size: { width: 1200, height: 630 }
+layers:
+
+  # 底色
+  - background:
+      image: *background_image
+      color: *background_color
+
+  # 左緣三段色塊，對應 logo 由上而下三個六角形
+  - size: { width: 16, height: 210 }
+    offset: { x: 0, y: 0 }
+    background:
+      color: *brand_cyan_300
+  - size: { width: 16, height: 210 }
+    offset: { x: 0, y: 210 }
+    background:
+      color: *brand_cyan_500
+  - size: { width: 16, height: 210 }
+    offset: { x: 0, y: 420 }
+    background:
+      color: *brand_cyan_700
+
+  # 頁面圖示放大當底紋，壓在文字底下。10% 白色，標題照樣清楚
+  - size: { width: 400, height: 400 }
+    offset: { x: 752, y: 108 }
+    icon:
+      value: *page_icon
+      color: *watermark_color
+
+  # logo
+  - size: { width: 56, height: 56 }
+    offset: { x: 72, y: 56 }
+    background:
+      image: *logo
+    icon:
+      value: *logo_icon
+      color: *color
+
+  # 站名，跟 logo 垂直置中對齊
+  - size: { width: 660, height: 34 }
+    offset: { x: 148, y: 67 }
+    typography:
+      content: *site_name
+      align: start center
+      color: *color
+      font:
+        family: *font_family
+        variant: *font_variant
+        style: Bold
+
+  # 標題。往下對齊，一行的標題與兩行的標題距離底下那條分隔線一樣遠
+  - size: { width: 1056, height: 170 }
+    offset: { x: 72, y: 150 }
+    typography:
+      content: *page_title
+      align: start bottom
+      overflow: shrink
+      color: *color
+      line:
+        amount: 2
+        height: 1.25
+      font:
+        family: *font_family
+        variant: *font_variant
+        style: Bold
+
+  # 標題與描述之間的短分隔線
+  - size: { width: 96, height: 5 }
+    offset: { x: 72, y: 358 }
+    background:
+      color: *brand_cyan_500
+
+  # 描述
+  - size: { width: 1056, height: 120 }
+    offset: { x: 72, y: 390 }
+    typography:
+      content: *page_description
+      align: start top
+      color: *muted_color
+      line:
+        amount: 3
+        height: 1.5
+      font:
+        family: *font_family
+        variant: *font_variant
+        style: Regular
+
+  # 頁尾網址
+  - size: { width: 900, height: 30 }
+    offset: { x: 72, y: 538 }
+    typography:
+      content: *site_url
+      align: start top
+      color: *accent_color
+      font:
+        family: *font_family
+        variant: *font_variant
+        style: Medium

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -335,11 +335,16 @@ plugins:
         'blog/2026/02/ooni-全新的匿名凭证系统.md': 'blog/index.md'
         'regional.md': 'taiwan/index.md'
         'regional/tor-relay-watcher.md': 'taiwan/index.md'
+  # 社群分享卡。版型在 layouts/anoni.yml，三個語系共用同一份，這裡只帶語系差異。
+  # 配色、間距、圖層都寫在版型裡，不要在這裡覆蓋單一顏色，那會讓三個語系慢慢長歪。
+  #
+  # cards_layout_dir 用預設值 layouts，它相對於執行 mkdocs 的目錄而不是設定檔位置，
+  # 所以 run.sh、run_en.sh、run_zh-cn.sh 與 CI 都必須在 docs/ 底下執行（現況如此）。
+  # 位置不對時外掛會直接讓建置失敗，不會安靜地退回預設版型。
   - social:
+      cards_layout: anoni
       cards_layout_options:
         font_family: Noto Sans TC
-        color: "#ffffff"
-        background_color: "#00aeff"
   - privacy:
       assets_exclude:
         - aa.anoni.net/*

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -319,11 +319,11 @@ plugins:
         'reports/interseclab-network-coup/index_6.md': 'reports/index.md'
         'reports/interseclab-network-coup/index_7.md': 'reports/index.md'
         'reports/interseclab-network-coup/index_8.md': 'reports/index.md'
+  # 社群分享卡，說明見 mkdocs.yml 的同一段
   - social:
+      cards_layout: anoni
       cards_layout_options:
         font_family: Noto Sans SC
-        color: "#ffffff"
-        background_color: "#00aeff"
   - privacy:
       assets_exclude:
         - aa.anoni.net/*

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -346,11 +346,14 @@ plugins:
         'taiwan/tor-relay-watcher.md': 'regional/tor-relay-watcher.md'
         'taiwan/vasp-2026.md': 'regional/taiwan-vasp-2026.md'
         'taiwan/whistleblower-law.md': 'regional/taiwan-whistleblower-law.md'
+  # 社群分享卡，說明見 mkdocs.yml 的同一段。
+  # site_name 是版面用的短站名：en 的 site_name 是一整句副標，直接放進卡片會被
+  # 截成半句，og 與 twitter 標籤照樣用完整的 site_name。
   - social:
+      cards_layout: anoni
       cards_layout_options:
         font_family: Public Sans
-        color: "#ffffff"
-        background_color: "#00aeff"
+        site_name: anoni.net Docs
   - privacy:
       assets_exclude:
         - aa.anoni.net/*

--- a/docs/zh-CN/community/brand-assets.md
+++ b/docs/zh-CN/community/brand-assets.md
@@ -352,6 +352,36 @@ wordmark 的文字已经转成路径，打开的设备有没有装字体都长�
 - `活动` → `--accent-action`（橘）
 - `更新` → `--cat-privacy`（绿，跟个人隐私指引同色，视觉关联弱可接受）
 
+## :material-share-variant-outline: 社群分享卡（Open Graph）
+
+把文件站的任何一页贴到 Mastodon、LinkedIn、X、Bluesky 或聊天室，对方看到的预览图由构建流程自动生成，三个语系各一份，不需要人工做图。
+
+版面沿用这一页的色票。cyan-900 当底色，左缘三段色块由上而下是 cyan-300、cyan-500、cyan-700，对应 logo 三个六角形的层次。左上角是 mono white logo 与站名，中间是页面标题，下方依序是页面描述与网址。页面 front matter 有 `icon` 时，那个图示会放大成 10% 透明的底纹摆在右侧，没有的话用 `material/hexagon-multiple-outline`，也就是 logo 的来源图示。
+
+底色没有用品牌主色 cyan-500，理由是读得到字。白字放在 cyan-500 上对比只有 2.5:1，缩到社交平台的预览尺寸就糊成一团，换到 cyan-900 之后是 11.5:1。描述用 cyan-100，对比 8.4:1，页尾网址用 cyan-300，对比 5.6:1。
+
+版式文件是 `docs/layouts/anoni.yml`，三个语系共用同一份。语系差异只有字体（Noto Sans TC、Noto Sans SC、Public Sans）与版面上显示的站名，分别写在 `mkdocs.yml`、`mkdocs_cn.yml`、`mkdocs_en.yml`。要调整版面就改那一份版式，不要各语系各存一份。
+
+### 中文标题的换行
+
+生成卡片的插件只在空白处换行。一整句中文没有空白，会被当成一个词，超过一行就切在画布边缘，连省略号都不会有。改版之前，站上最长的那个文章标题只显示得出前半段。
+
+现在的作法是在全角逗号、顿号、冒号、句号、感叹号、问号后面补一个半角空白，给换行算法可以断的位置，补上的空白落在行尾就会被吃掉。代价是句子中间偶尔看得到多出来的空隙，换来的是三个语系目前每一则标题与描述都完整显示。标题 14 字以内不处理，那个长度本来就放得下一行。
+
+### 单页换掉卡片内容
+
+某一页需要不一样的标题、描述或底色时，在该页 front matter 覆写：
+
+```yaml
+social:
+  cards_layout_options:
+    title: 卡片上要显示的标题
+    description: 卡片上要显示的描述
+    background_color: "#003e57"
+```
+
+整张图要自己做的场合（活动主视觉、互动区）走另一种写法，front matter 填 `og.enabled: true` 与 `og.image`，文件站的模板会改用指定的图片，并跳过自动生成的那一张。COSCUP 活动页与互动区目前就是这样做。
+
 ## :material-alert-octagon-outline: 不要这样用
 
 **Logo**

--- a/docs/zh-TW/community/brand-assets.md
+++ b/docs/zh-TW/community/brand-assets.md
@@ -352,6 +352,36 @@ wordmark 的文字已經轉成路徑，開啟的裝置有沒有裝字型都長�
 - `活動` → `--accent-action`（橘）
 - `更新` → `--cat-privacy`（綠，跟個人隱私指引同色，視覺關聯弱可接受）
 
+## :material-share-variant-outline: 社群分享卡（Open Graph）
+
+把文件站的任何一頁貼到 Mastodon、LinkedIn、X、Bluesky 或聊天室，對方看到的預覽圖由建置流程自動產生，三個語系各一份，不需要人工做圖。
+
+版面沿用這一頁的色票。cyan-900 當底色，左緣三段色塊由上而下是 cyan-300、cyan-500、cyan-700，對應 logo 三個六角形的層次。左上角是 mono white logo 與站名，中間是頁面標題，下方依序是頁面描述與網址。頁面 front matter 有 `icon` 時，那個圖示會放大成 10% 透明的底紋擺在右側，沒有的話用 `material/hexagon-multiple-outline`，也就是 logo 的來源圖示。
+
+底色沒有用品牌主色 cyan-500，理由是讀得到字。白字放在 cyan-500 上對比只有 2.5:1，縮到社群平台的預覽尺寸就糊成一團，換到 cyan-900 之後是 11.5:1。描述用 cyan-100，對比 8.4:1，頁尾網址用 cyan-300，對比 5.6:1。
+
+版型檔案是 `docs/layouts/anoni.yml`，三個語系共用同一份。語系差異只有字型（Noto Sans TC、Noto Sans SC、Public Sans）與版面上顯示的站名，分別寫在 `mkdocs.yml`、`mkdocs_cn.yml`、`mkdocs_en.yml`。要調整版面就改那一份版型，不要各語系各存一份。
+
+### 中文標題的換行
+
+產卡片的外掛只在空白處換行。一整句中文沒有空白，會被當成一個詞，超過一行就切在畫布邊緣，連刪節號都不會有。改版之前，站上最長的那個文章標題只顯示得出前半段。
+
+現在的作法是在全形逗號、頓號、冒號、句號、驚嘆號、問號後面補一個半形空白，給換行演算法可以斷的位置，補上的空白落在行尾就會被吃掉。代價是句子中間偶爾看得到多出來的空隙，換來的是三個語系目前每一則標題與描述都完整顯示。標題 14 字以內不處理，那個長度本來就放得下一行。
+
+### 單頁換掉卡片內容
+
+某一頁需要不一樣的標題、描述或底色時，在該頁 front matter 覆寫：
+
+```yaml
+social:
+  cards_layout_options:
+    title: 卡片上要顯示的標題
+    description: 卡片上要顯示的描述
+    background_color: "#003e57"
+```
+
+整張圖要自己做的場合（活動主視覺、互動區）走另一種寫法，front matter 填 `og.enabled: true` 與 `og.image`，文件站的模板會改用指定的圖片，並跳過自動產生的那一張。COSCUP 活動頁與互動區目前就是這樣做。
+
 ## :material-alert-octagon-outline: 不要這樣用
 
 **Logo**


### PR DESCRIPTION
把 Open Graph 分享卡從外掛預設版型換成社群自己的版型，設計依 [品牌素材](https://anoni.net/docs/community/brand-assets/) 的色票與 logo 結構，zh-TW、zh-CN、en 三個語系共用同一份。

## 版面

- 底色 cyan-900 `#003e57`，左緣三段色塊由上而下 cyan-300、cyan-500、cyan-700，對應 logo 三個六角形的層次
- 左上 mono white logo 加站名，中間標題，cyan-500 短分隔線，cyan-100 描述，cyan-300 頁尾網址
- 頁尾網址由 `site_url` 推導，onion 與 IPFS 版建置時自動跟著換，不必另外處理
- 頁面 front matter 的 `icon` 放大成 10% 白色底紋擺右側，沒寫就退回 `material/hexagon-multiple-outline`，也就是 logo 的來源圖示

底色沒有用品牌主色 cyan-500，理由是讀得到字。白字在 cyan-500 上對比只有 2.5:1，縮到社群平台的預覽尺寸糊成一團，換到 cyan-900 之後是 11.5:1。描述用 cyan-100（8.4:1），頁尾網址用 cyan-300（5.6:1）。

## 順帶修掉中文標題被切掉

social 外掛只在空白處換行（`plugin.py` 用 `re.split(r"\s+")` 切詞），一整句中文沒有空白，會被當成一個詞，超過一行就直接切在畫布邊緣，連刪節號都不會有。改版前站上最長的文章標題只顯示得出前半段。

版型改成在全形逗號、頓號、冒號、句號、驚嘆號、問號後面補一個半形空白，給換行演算法可以斷的位置，補上的空白落在行尾會被吃掉。標題 14 字以內不處理，那個長度本來就放得下一行。

字級由實測得出。外掛的字級由圖層高度與行數反推，標題框 170px 配兩行對應 Noto Sans TC 58px、Public Sans 71px。58px 是掃過三語系全部標題得到的上限：最長的一段不可斷字串是 zh-CN 的「土库曼斯坦如何将网络审查变成一门生意」18 個字，58px 下佔 1044px，還放得進 1056px 的標題框。三語系 576 個標題與描述現在全部完整顯示。

## 另外兩處

- 首頁卡片原本吃 front matter 的「首頁」「Home」，改用站名，跟 `og:title` 的處理一致
- en 版面用短站名 `anoni.net Docs`，原本的 `site_name` 是一整句副標，直接放進卡片會被截半句。`og` 與 `twitter` 標籤照樣用完整的 `site_name`

## 驗證

- `run.sh`、`run_zh-cn.sh`、`run_en.sh` 三支全綠，共 670 張卡，無新增警告
- `og:` 與 `twitter:` 標籤的值與改版前逐字相同，比對過 `output/` 的 HTML
- 單頁 front matter 覆寫（`social.cards_layout_options` 的 `title`、`description`、`background_color`）實測有效
- `tools/docs_style_lint.py` 掃三語系品牌素材頁：0 error、0 warn

## 文件

- 三語系品牌素材頁各補一節「社群分享卡（Open Graph）」，寫版面、中文換行的作法與限制、單頁覆寫的兩種寫法
- `CLAUDE.md` 與 `docs/README.md` 補上版型檔位置，以及 `cards_layout_dir` 相對於執行目錄這件事

🤖 Generated with [Claude Code](https://claude.com/claude-code)