### PR TITLE
fix(social): 分享卡給了底圖就自動壓遮罩

### DIFF
--- a/docs/en/community/brand-assets.md
+++ b/docs/en/community/brand-assets.md
@@ -380,6 +380,8 @@ social:
     background_color: "#003e57"
 ```
 
+A background image uses the same option. The path in `background_image` is relative to the directory mkdocs runs in, which is `docs/`, so write it as `zh-TW/assets/images/xxx.png`. A missing file fails the build. Give the image on its own and the background colour becomes an 80% cyan-900 scrim, which keeps white text readable over any image. For the raw image, add `background_color: transparent`, at the cost of losing the title and the footer URL on a light image.
+
 Pages that need artwork of their own (event key visuals, the interactive section) take a different route: set `og.enabled: true` and `og.image` in the front matter, and the site template uses that image and skips the generated one. The COSCUP event pages and the interactive section work this way.
 
 ## :material-alert-octagon-outline: What not to do

--- a/docs/layouts/anoni.yml
+++ b/docs/layouts/anoni.yml
@@ -26,14 +26,24 @@ definitions:
   - &brand_cyan_500 "#00aeff"
   - &brand_cyan_700 "#0089bf"
 
-  # 背景。預設 cyan-900，單頁可用 front matter 的 social.cards_layout_options 換掉
+  # 背景。預設 cyan-900，單頁可用 front matter 的 social.cards_layout_options 換掉。
+  #
+  # 有給底圖時預設值改成半透明的 cyan-900。外掛畫背景的順序是先貼圖再填色
+  # （social/plugin.py 的 _render_background），不透明的底色會把圖整張蓋掉，
+  # 只給 background_image 的人會拿到一張跟平常一模一樣的卡片，而且沒有任何錯誤
+  # 訊息。壓一層 80% 的遮罩則是讓白字在任何一張底圖上都讀得到，淺色圖直出的話
+  # 標題與頁尾網址會消失。要原圖直出就明寫 background_color: transparent。
   - &background_color >-
     {%- if layout.background_color -%}
       {{ layout.background_color }}
+    {%- elif layout.background_image -%}
+      #003e57cc
     {%- else -%}
       #003e57
     {%- endif -%}
 
+  # 底圖路徑相對於執行 mkdocs 的目錄，也就是 docs/，寫成 zh-TW/assets/images/x.png
+  # 這種形式。檔案找不到時外掛會讓建置失敗。
   - &background_image >-
     {{ layout.background_image | x }}
 

--- a/docs/zh-CN/community/brand-assets.md
+++ b/docs/zh-CN/community/brand-assets.md
@@ -380,6 +380,8 @@ social:
     background_color: "#003e57"
 ```
 
+底图也走同一个选项。`background_image` 的路径相对于执行 mkdocs 的目录，也就是 `docs/`，写成 `zh-TW/assets/images/xxx.png` 这种形式，文件找不到时构建会失败。只填底图的话，底色自动变成 80% 的 cyan-900 遮罩，白字在任何一张图上都读得到。想要原图直出就多填一行 `background_color: transparent`，代价是浅色的图会让标题与页尾网址消失。
+
 整张图要自己做的场合（活动主视觉、互动区）走另一种写法，front matter 填 `og.enabled: true` 与 `og.image`，文件站的模板会改用指定的图片，并跳过自动生成的那一张。COSCUP 活动页与互动区目前就是这样做。
 
 ## :material-alert-octagon-outline: 不要这样用

--- a/docs/zh-TW/community/brand-assets.md
+++ b/docs/zh-TW/community/brand-assets.md
@@ -380,6 +380,8 @@ social:
     background_color: "#003e57"
 ```
 
+底圖也走同一個選項。`background_image` 的路徑相對於執行 mkdocs 的目錄，也就是 `docs/`，寫成 `zh-TW/assets/images/xxx.png` 這種形式，檔案找不到時建置會失敗。只填底圖的話，底色自動變成 80% 的 cyan-900 遮罩，白字在任何一張圖上都讀得到。想要原圖直出就多填一行 `background_color: transparent`，代價是淺色的圖會讓標題與頁尾網址消失。
+
 整張圖要自己做的場合（活動主視覺、互動區）走另一種寫法，front matter 填 `og.enabled: true` 與 `og.image`，文件站的模板會改用指定的圖片，並跳過自動產生的那一張。COSCUP 活動頁與互動區目前就是這樣做。
 
 ## :material-alert-octagon-outline: 不要這樣用


### PR DESCRIPTION
承 #366。試著只用 `social.cards_layout_options.background_image` 換底圖時發現版型少了一步，圖會被底色整張蓋掉。

## 問題

外掛畫背景的順序是先貼圖、再填底色（`social/plugin.py` 的 `_render_background`，註解寫著填色放在後面是為了讓人壓半透明的 tint）。版型的預設底色 cyan-900 是不透明的，所以：

| 寫法 | 改動前 | 改動後 |
|---|---|---|
| 只給 `background_image` | 圖完全看不到，卡片跟平常一模一樣，沒有錯誤訊息 | 圖透出來，上面壓 80% 的 cyan-900 |
| 給 `background_image` 加 `background_color: "#003e57cc"` | 正常 | 不變 |
| 給 `background_image` 加 `background_color: transparent` | 原圖直出 | 不變 |

第一種是最直覺的寫法，卻是唯一失敗的一種，而且失敗的樣子跟成功長得一樣，寫的人只會覺得自己路徑打錯。

## 改動

`background_color` 的預設值改成有底圖時用 `#003e57cc`。壓一層遮罩而不是直接原圖，是因為淺色的底圖會讓白色標題與 cyan-300 的頁尾網址消失，實測拿工作坊那張淺藍插圖試過。要原圖直出照樣可以明寫 `transparent`。

三語系品牌素材頁的「單頁換掉卡片內容」補上底圖的寫法，以及 `background_image` 的路徑相對於執行 mkdocs 的目錄（`docs/`），要寫成 `zh-TW/assets/images/xxx.png` 這種形式，檔案找不到會讓建置失敗。

## 驗證

- 三種寫法各建一張卡實測，行為與上表相符
- `run.sh`、`run_zh-cn.sh`、`run_en.sh` 三支全綠，無新增警告
- `tools/docs_style_lint.py` 掃三語系品牌素材頁：0 error、0 warn
- 站上沒有頁面使用 `background_image`，現有卡片的畫面不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)