### PR TITLE
fix(docs): 語言切換器不再列出目前語系，並修掉英文版首頁的偏好轉址

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -45,6 +45,9 @@ on:
       # overrides 的 main.html 是 test_before_send.mjs 的來源，送出前的白名單寫在裡面
       - "docs/overrides/base.html"
       - "docs/overrides/main.html"
+      # 語言切換器的樣板。改壞的方式是「目前語系整筆跳過」，畫面照樣好看，
+      # 壞掉的是首頁的偏好轉址與底部的語言選擇卡片
+      - "docs/overrides/partials/alternate.html"
       - "docs/overrides_cn/main.html"
       - "docs/overrides_en/main.html"
       - "docs/hooks/**"
@@ -77,6 +80,10 @@ jobs:
       # 語言偏好只在預設語系的首頁套用，其餘一律不動
       - name: 語言偏好導向規則
         run: node tools/test_lang_preference.mjs
+
+      # 語言切換器不列出目前語系，但那一筆要留在 DOM 裡給偏好轉址與語言選擇卡片用
+      - name: 語言切換器藏起目前語系
+        run: python3 tools/test_lang_switcher.py
 
       # 離線內容管理頁的章節分組與排序，照 nav 而不是檔案的字母序
       - name: 離線內容索引

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -255,6 +255,10 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 這份產物是哪一個語系。語言切換器拿它把「目前語系」那一項藏起來，選單上只留切得
+  # 過去的語言。值取自底下 alternate 的 lang，不要填 theme.language：簡體那份的
+  # theme.language 是 material 語言包代號 zh，跟 alternate 的 zh-CN 對不起來。
+  current_lang: zh-TW
   alternate:
     # zh-TW 填 /docs/，不填 /docs/zh-tw/。zh-TW 是網站預設語系，run.sh 直接把它建在
     # 根路徑，沒有獨立的語系區段。填 /docs/ 讓 hreflang 有 self-reference（Google 要求

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -255,6 +255,10 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 建在根路徑、網址上沒有語系區段的那一個語系。三份設定填的是同一個值，因為講的是
+  # 這個部署長什麼樣，跟正在建哪一份無關。base.html 的偏好轉址只在這個語系的首頁動手，
+  # /docs/en/ 那種網址上已經指定過語系的入口不受偏好影響。
+  default_lang: zh-TW
   # 這份產物是哪一個語系。語言切換器拿它把「目前語系」那一項藏起來，選單上只留切得
   # 過去的語言。值取自底下 alternate 的 lang，不要填 theme.language：簡體那份的
   # theme.language 是 material 語言包代號 zh，跟 alternate 的 zh-CN 對不起來。

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -234,6 +234,9 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 這份產物是哪一個語系，語言切換器拿它把「目前語系」那一項藏起來。值對齊底下
+  # alternate 的 lang，理由見 mkdocs.yml 的註解。
+  current_lang: zh-CN
   alternate:
     # zh-TW 是網站預設語系，建在根路徑，沒有獨立語系區段。理由見 mkdocs.yml 的註解。
     - name: 臺灣正體（zh-TW）

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -234,6 +234,8 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 建在根路徑、網址上沒有語系區段的那一個語系，三份設定同一個值，理由見 mkdocs.yml。
+  default_lang: zh-TW
   # 這份產物是哪一個語系，語言切換器拿它把「目前語系」那一項藏起來。值對齊底下
   # alternate 的 lang，理由見 mkdocs.yml 的註解。
   current_lang: zh-CN

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -236,6 +236,9 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 這份產物是哪一個語系，語言切換器拿它把「目前語系」那一項藏起來。值對齊底下
+  # alternate 的 lang，理由見 mkdocs.yml 的註解。
+  current_lang: en
   alternate:
     - name: English (en-US)
       link: /docs/en/

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -236,6 +236,9 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 建在根路徑、網址上沒有語系區段的那一個語系，三份設定同一個值，理由見 mkdocs.yml。
+  # 底下 alternate 把 English 排第一是選單的版面安排，跟這裡無關。
+  default_lang: zh-TW
   # 這份產物是哪一個語系，語言切換器拿它把「目前語系」那一項藏起來。值對齊底下
   # alternate 的 lang，理由見 mkdocs.yml 的註解。
   current_lang: en

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -551,10 +551,16 @@
           var ASKED_KEY = "anoni-docs-lang-asked";
           var IS_HOME = {{ 'true' if page and page.is_homepage else 'false' }};
           {#
-            建在根路徑、網址上沒有語系區段的那一個語系，取 extra.alternate 的第一筆。
-            調整 alternate 的順序時這裡會跟著變，兩者本來就該一致。
+            建在根路徑、網址上沒有語系區段的那一個語系。三份 mkdocs 設定各自寫明，
+            值是同一個。
+
+            這裡原本取 extra.alternate 的第一筆，前提是「第一筆就是根路徑那個語系」。
+            mkdocs_en.yml 把 English 排在第一筆（英文版的選單先列自己），前提就不成立了，
+            en 建置出來的 DEFAULT_LANG 變成 en，於是偏好為 zh-TW 的讀者打開 /docs/en/
+            首頁會被轉走，跟底下 langRedirectTo 想守的「網址上已經有語系區段就是明確
+            指定過」相反。選單順序是版面決定，根路徑是誰是部署決定，兩件事分開寫。
           #}
-          var DEFAULT_LANG = {{ ((config.extra.alternate | first).lang if config.extra.alternate else "zh-TW") | tojson }};
+          var DEFAULT_LANG = {{ (config.extra.default_lang or "zh-TW") | tojson }};
 
           var STRINGS = {
             "zh-TW": { ask: "選擇你的閱讀語言", later: "稍後" },

--- a/docs/overrides/partials/alternate.html
+++ b/docs/overrides/partials/alternate.html
@@ -1,4 +1,11 @@
 {#- Language switcher: language root + page.url. -#}
+{#-
+  目前語系那一項加 hidden，選單上只留讀者切得過去的語言。連結本身照樣渲染出來，
+  因為 base.html 的語言偏好 JS 是從這份清單讀各語系的實際網址（建置時算好，
+  clearnet、onion 與本機 serve 各自都對），首頁的偏好轉址靠它認出「目前這一頁是
+  哪個語系」，底部的語言選擇卡片也要列出目前語系，讀者才存得下這個偏好。
+  tools/test_lang_switcher.py 守著這個分界。
+-#}
 <div class="md-header__option">
   <div class="md-select">
     {% set icon = config.theme.icon.alternate or "material/translate" %}
@@ -8,7 +15,7 @@
     <div class="md-select__inner">
       <ul class="md-select__list">
         {% for alt in config.extra.alternate %}
-          <li class="md-select__item">
+          <li class="md-select__item"{% if alt.lang == config.extra.current_lang %} hidden{% endif %}>
             {% if page is defined and page %}
               {% set base = alt.link.rstrip('/') %}
               <a href="{{ (base ~ '/' ~ page.url) | url }}" hreflang="{{ alt.lang }}" class="md-select__link">

--- a/tools/test_lang_switcher.py
+++ b/tools/test_lang_switcher.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""語言切換器：目前語系不出現在選單上，但仍留在 DOM 裡。
+
+=== 為什麼需要這支 ===
+
+選單不列出目前語系，最直覺的寫法是在 {% for %} 裡跳過那一筆。那樣寫畫面上看起來
+一模一樣，壞掉的是看不見的兩件事：
+
+  - overrides/base.html 的語言偏好 JS 從這份清單認出「目前這一頁是哪個語系」
+    （比對 link.pathname 與 location.pathname）。認不出來的話首頁的偏好轉址整條
+    失效，讀者選過的語言從此沒有作用
+  - 底部的語言選擇卡片也是從同一份清單長出來的。少了目前語系那一顆按鈕，讀者
+    就沒有辦法把「我要讀正體中文」這個偏好存下來，卡片每次都會再問一次
+
+所以正確的做法是照樣渲染，只在目前語系那一項加 hidden。這支測試守的就是這個分界。
+
+順便驗 current_lang 有沒有寫錯。值對不上任何一筆 alternate 的 lang 時不會有錯誤
+訊息，只是三個語系的選單都恢復成列出自己，那種壞法沒有人會注意到。
+
+不碰網路，不需要建置產物，零外部相依。
+
+用法：
+  python3 tools/test_lang_switcher.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PARTIAL = ROOT / "docs" / "overrides" / "partials" / "alternate.html"
+CONFIGS = [
+    ROOT / "docs" / "mkdocs.yml",
+    ROOT / "docs" / "mkdocs_cn.yml",
+    ROOT / "docs" / "mkdocs_en.yml",
+]
+
+failures: list[str] = []
+
+
+def fail(message: str) -> None:
+    failures.append(message)
+
+
+def alternate_langs(text: str) -> list[str]:
+    """取出 extra.alternate 底下每一筆的 lang，順序照原檔。"""
+    block = re.search(r"\n  alternate:\n((?:    .*\n|\n)*)", text)
+    if not block:
+        return []
+    return re.findall(r"^\s+lang:\s*(\S+)\s*$", block.group(1), re.M)
+
+
+def test_menu_renders_every_language() -> None:
+    """迴圈裡不准跳過任何一筆，每一筆都要有自己的 <li> 與帶 hreflang 的連結。"""
+    text = PARTIAL.read_text(encoding="utf-8")
+    body = re.search(r"\{%\s*for\s+alt\s+in\s+config\.extra\.alternate\s*%\}(.*?)\{%\s*endfor\s*%\}", text, re.S)
+    if not body:
+        fail(f"{PARTIAL.name}: 找不到跑 config.extra.alternate 的迴圈")
+        return
+    inner = body.group(1)
+
+    items = re.findall(r'<li class="md-select__item"', inner)
+    if len(items) != 1:
+        fail(f"{PARTIAL.name}: 迴圈裡應該只有一個 md-select__item，實際有 {len(items)} 個")
+
+    head, _, _ = inner.partition("<li class=\"md-select__item\"")
+    if re.search(r"\{%\s*(if|for)\b", head):
+        fail(
+            f"{PARTIAL.name}: <li> 前面出現了條件式，目前語系會整筆消失。"
+            " 要藏起來請在 <li> 上加 hidden，不要跳過那一筆，理由見本檔檔頭。"
+        )
+
+    if 'hreflang="{{ alt.lang }}"' not in inner:
+        fail(f"{PARTIAL.name}: 連結沒有帶 hreflang=\"{{{{ alt.lang }}}}\"，JS 靠它認語系")
+
+
+def test_current_language_is_hidden() -> None:
+    """目前語系那一項要帶 hidden，判斷條件讀 config.extra.current_lang。"""
+    text = PARTIAL.read_text(encoding="utf-8")
+    marker = re.search(
+        r'<li class="md-select__item"\{%\s*if\s+alt\.lang\s*==\s*config\.extra\.current_lang\s*%\}\s*hidden\{%\s*endif\s*%\}>',
+        text,
+    )
+    if not marker:
+        fail(
+            f"{PARTIAL.name}: 目前語系那一項沒有加 hidden。"
+            " 少了它選單會列出讀者已經在讀的語言，選了會回到原地。"
+        )
+
+
+def test_current_lang_matches_an_alternate() -> None:
+    """三份設定各自的 current_lang 都要對得上自己 alternate 裡的一筆 lang。"""
+    for path in CONFIGS:
+        text = path.read_text(encoding="utf-8")
+        found = re.search(r"^  current_lang:\s*(\S+)\s*$", text, re.M)
+        if not found:
+            fail(f"{path.name}: extra 底下缺 current_lang，這一份的選單會列出自己")
+            continue
+        langs = alternate_langs(text)
+        if not langs:
+            fail(f"{path.name}: 讀不到 extra.alternate 的 lang 清單")
+            continue
+        if found.group(1) not in langs:
+            fail(
+                f"{path.name}: current_lang 是 {found.group(1)}，"
+                f" 對不上 alternate 的任何一筆（{', '.join(langs)}）"
+            )
+
+
+def test_every_language_is_current_somewhere() -> None:
+    """三份設定合起來要蓋到全部語系，漏掉的那一個永遠看得到自己。"""
+    declared = set()
+    langs: set[str] = set()
+    for path in CONFIGS:
+        text = path.read_text(encoding="utf-8")
+        found = re.search(r"^  current_lang:\s*(\S+)\s*$", text, re.M)
+        if found:
+            declared.add(found.group(1))
+        langs.update(alternate_langs(text))
+    missing = langs - declared
+    if missing:
+        fail(f"沒有任何一份設定把這些語系標成 current_lang：{', '.join(sorted(missing))}")
+
+
+def main() -> int:
+    for fn in [
+        test_menu_renders_every_language,
+        test_current_language_is_hidden,
+        test_current_lang_matches_an_alternate,
+        test_every_language_is_current_somewhere,
+    ]:
+        fn()
+    if failures:
+        print(f"FAILED ({len(failures)})")
+        for f in failures:
+            print("  " + f)
+        return 1
+    print("lang switcher tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_lang_switcher.py
+++ b/tools/test_lang_switcher.py
@@ -17,6 +17,12 @@
 順便驗 current_lang 有沒有寫錯。值對不上任何一筆 alternate 的 lang 時不會有錯誤
 訊息，只是三個語系的選單都恢復成列出自己，那種壞法沒有人會注意到。
 
+一併守 default_lang，也就是「建在根路徑、網址上沒有語系區段的那一個語系」。
+base.html 原本取 extra.alternate 的第一筆，而 mkdocs_en.yml 把 English 排第一是為了
+選單版面，兩件事被綁在一起之後，en 建置出來的 DEFAULT_LANG 成了 en，偏好為 zh-TW
+的讀者打開 /docs/en/ 首頁會被轉走。三份設定各自寫明同一個值，這支測試盯著它們一致，
+而且那個語系的 link 真的是站台根。
+
 不碰網路，不需要建置產物，零外部相依。
 
 用法：
@@ -31,6 +37,7 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PARTIAL = ROOT / "docs" / "overrides" / "partials" / "alternate.html"
+BASE = ROOT / "docs" / "overrides" / "base.html"
 CONFIGS = [
     ROOT / "docs" / "mkdocs.yml",
     ROOT / "docs" / "mkdocs_cn.yml",
@@ -44,12 +51,28 @@ def fail(message: str) -> None:
     failures.append(message)
 
 
-def alternate_langs(text: str) -> list[str]:
-    """取出 extra.alternate 底下每一筆的 lang，順序照原檔。"""
+def alternate_entries(text: str) -> list[tuple[str, str]]:
+    """取出 extra.alternate 底下每一筆的 (lang, link)，順序照原檔。"""
     block = re.search(r"\n  alternate:\n((?:    .*\n|\n)*)", text)
     if not block:
         return []
-    return re.findall(r"^\s+lang:\s*(\S+)\s*$", block.group(1), re.M)
+    entries: list[tuple[str, str]] = []
+    link = None
+    for line in block.group(1).splitlines():
+        found_link = re.match(r"^\s+link:\s*(\S+)\s*$", line)
+        if found_link:
+            link = found_link.group(1)
+            continue
+        found_lang = re.match(r"^\s+lang:\s*(\S+)\s*$", line)
+        if found_lang and link is not None:
+            entries.append((found_lang.group(1), link))
+            link = None
+    return entries
+
+
+def alternate_langs(text: str) -> list[str]:
+    """只要 lang，順序照原檔。"""
+    return [lang for lang, _ in alternate_entries(text)]
 
 
 def test_menu_renders_every_language() -> None:
@@ -124,12 +147,71 @@ def test_every_language_is_current_somewhere() -> None:
         fail(f"沒有任何一份設定把這些語系標成 current_lang：{', '.join(sorted(missing))}")
 
 
+def test_default_lang_is_the_same_everywhere() -> None:
+    """default_lang 講的是這個部署長什麼樣，三份設定要填同一個值。"""
+    seen: dict[str, str] = {}
+    for path in CONFIGS:
+        text = path.read_text(encoding="utf-8")
+        found = re.search(r"^  default_lang:\s*(\S+)\s*$", text, re.M)
+        if not found:
+            fail(f"{path.name}: extra 底下缺 default_lang，首頁的偏好轉址會判錯語系")
+            continue
+        seen[path.name] = found.group(1)
+    if len(set(seen.values())) > 1:
+        detail = "、".join(f"{k} 是 {v}" for k, v in seen.items())
+        fail(f"三份設定的 default_lang 對不起來（{detail}）")
+
+
+def test_default_lang_sits_at_the_site_root() -> None:
+    """default_lang 那一筆的 link 要是站台根，也就是其餘語系 link 的共同前綴。"""
+    for path in CONFIGS:
+        text = path.read_text(encoding="utf-8")
+        found = re.search(r"^  default_lang:\s*(\S+)\s*$", text, re.M)
+        if not found:
+            continue
+        entries = alternate_entries(text)
+        target = [link for lang, link in entries if lang == found.group(1)]
+        if not target:
+            fail(
+                f"{path.name}: default_lang 是 {found.group(1)}，"
+                f" 對不上 alternate 的任何一筆（{', '.join(lang for lang, _ in entries)}）"
+            )
+            continue
+        others = [link for lang, link in entries if lang != found.group(1)]
+        strays = [link for link in others if not link.startswith(target[0])]
+        if strays:
+            fail(
+                f"{path.name}: default_lang 指向 {target[0]}，"
+                f" 但 {', '.join(strays)} 不在它底下，那就不是站台根"
+            )
+
+
+def test_base_html_reads_default_lang() -> None:
+    """base.html 的 DEFAULT_LANG 要讀設定，不要回頭去取 alternate 的第一筆。"""
+    text = BASE.read_text(encoding="utf-8")
+    found = re.search(r"var DEFAULT_LANG = \{\{(.*?)\}\};", text, re.S)
+    if not found:
+        fail(f"{BASE.name}: 找不到 DEFAULT_LANG 的賦值")
+        return
+    expr = found.group(1)
+    if "config.extra.default_lang" not in expr:
+        fail(f"{BASE.name}: DEFAULT_LANG 沒有讀 config.extra.default_lang")
+    if "alternate" in expr:
+        fail(
+            f"{BASE.name}: DEFAULT_LANG 又跟 extra.alternate 的順序綁在一起了。"
+            " 選單順序是版面決定，根路徑是誰是部署決定，理由見本檔檔頭。"
+        )
+
+
 def main() -> int:
     for fn in [
         test_menu_renders_every_language,
         test_current_language_is_hidden,
         test_current_lang_matches_an_alternate,
         test_every_language_is_current_somewhere,
+        test_default_lang_is_the_same_everywhere,
+        test_default_lang_sits_at_the_site_root,
+        test_base_html_reads_default_lang,
     ]:
         fn()
     if failures:


### PR DESCRIPTION
語言切換器不再列出讀者當下就在讀的語言，順手修掉一個相鄰的 bug：英文版首頁的語言偏好轉址判錯了根路徑語系。

## 1. 切換器藏起目前語系

選單原本三個語系都列，其中一個選了會回到原地。現在 zh-TW 的頁面只看得到簡體中文與 English，另外兩個語系同理。

做法是在 `<li>` 上加 `hidden`，不在 `{% for %}` 裡跳過那一筆。連結本身要留在 DOM 裡，因為 `overrides/base.html` 的語言偏好 JS 從這份清單讀東西：

| 讀來做什麼 | 跳過那一筆的後果 |
|---|---|
| 比對 `link.pathname === location.pathname`，認出目前這一頁是哪個語系 | 首頁的偏好轉址認不出當前語言，讀者選過的語言不再有作用 |
| 長出底部的語言選擇卡片 | 少一顆按鈕，讀者沒辦法把「我要讀正體中文」這個偏好存下來，卡片每次都再問一次 |

各語系是哪一個由新增的 `extra.current_lang` 決定。沒有用 `theme.language`，因為簡體那份填的是 material 語言包代號 `zh`，跟 `alternate` 的 `zh-CN` 對不起來。

`hreflang` 的 self-reference 不受影響，三個語系的 `<link rel="alternate">` 照樣三筆都在。

## 2. 英文版首頁的偏好轉址

`base.html` 的 `DEFAULT_LANG` 取 `extra.alternate` 的第一筆，前提是「第一筆就是建在根路徑、網址上沒有語系區段的那個語系」。`mkdocs_en.yml` 把 English 排第一（英文版的選單先列自己），前提就不成立，en 建置出來的 `DEFAULT_LANG` 是 `en`。

後果是偏好為 zh-TW 的讀者打開 `/docs/en/` 首頁會被轉去 `/docs/`，跟 `langRedirectTo` 想守的規則相反：網址上已經有語系區段就是讀者或分享的連結明確指定過，不該被偏好蓋掉。zh-TW 與 zh-CN 兩份的第一筆剛好是 zh-TW，所以只有英文版會這樣。

選單順序是版面決定，根路徑是誰是部署決定，兩件事分開寫。新增 `extra.default_lang`，三份設定各自填 `zh-TW`，`base.html` 改讀它。`mkdocs_en.yml` 的 `alternate` 順序維持原樣。

## 測試

新增 `tools/test_lang_switcher.py`，零外部相依，不需要建置產物，已掛進 `tools-tests.yml`。守的都是畫面上看不出來的分界：

- 迴圈裡不准跳過任何一筆，目前語系那一項要帶 `hidden`
- `current_lang` 對得上該份設定 `alternate` 的某一筆 `lang`，三份合起來蓋到全部語系
- 三份設定的 `default_lang` 一致，而且那個語系的 `link` 是其餘語系 `link` 的共同前綴
- `base.html` 沒有退回去把 `DEFAULT_LANG` 綁在 `alternate` 的順序上

做過突變測試，七種壞法全部紅燈：改成跳過整筆、拿掉 `hidden`、`current_lang` 拼錯、`base.html` 退回舊寫法、en 單獨填 `default_lang: en`、三份一致但填 `en`、缺 `default_lang`。

## 驗證

三支 `run_*.sh` 建置成功，零 mkdocs warning。

| 產物 | `DEFAULT_LANG` | 切換器藏起的 hreflang | 可見項目 | `<link rel="alternate">` |
|---|---|---|---|---|
| `/docs/` | `zh-TW` | `zh-TW` | 2 | 3 |
| `/docs/en/` | `zh-TW` | `en` | 2 | 3 |
| `/docs/zh-cn/` | `zh-TW` | `zh-CN` | 2 | 3 |

`tools/test_lang_preference.mjs`、`tools/test_lang_switcher.py`、`tools/test_theme_assets.py` 皆通過。

Onion 版不受影響，`replace_sitename_anoni_onion.sh` 只改寫 `link: /docs/`，兩個新設定值是語系代號，碰不到。

## 待確認

`hidden` 的項目仍在 DOM 裡，螢幕閱讀器會跳過，鍵盤也 tab 不到，這是預期行為。若之後想改成完全不渲染，記得同時把 `base.html` 的語言清單改成從別的地方讀，那正是 `tools/test_lang_switcher.py` 擋著的那一刀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
