### PR TITLE
docs(home): 近期公告移到「從這裡開始」之後並去掉提示框

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -59,6 +59,12 @@ If one of civil society, a newsroom, independent journalism, open-source develop
 
 </div>
 
+## :material-bullhorn-outline: Recent updates
+
+<!-- latest-posts:5 -->
+
+More at [:material-bullhorn-outline: Updates](./blog/index.md).
+
 ## :material-map-outline: What we observe
 
 Our standing varies by jurisdiction. We don't claim equal depth across the region; the section below is honest about where we have direct experience versus where we are following, often through second-hand sources. Conceptual frame: [Why networked freedom matters](./basics/internet-freedom.md).
@@ -192,14 +198,6 @@ Seven more cover activists, election observers, domestic violence survivors, LGB
     [:octicons-arrow-right-24: Use them](./utils/index.md)
 
 </div>
-
-## :material-bullhorn-outline: Recent updates
-
-!!! tip "Latest"
-
-    <!-- latest-posts:5 -->
-
-    More at [:material-bullhorn-outline: Updates](./blog/index.md).
 
 ---
 

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -57,6 +57,12 @@ hide:
 
 </div>
 
+## :material-bullhorn-outline: 近期公告
+
+<!-- latest-posts:5 -->
+
+更多请见 [:material-bullhorn-outline: 全部公告](./blog/index.md)。
+
 ## :material-account-switch-outline: 换个处境看看
 
 同一套工具在不同处境下的用法差很多。这几篇从具体的人与具体的风险写起，读完会比较知道自己需要保护什么。
@@ -120,14 +126,6 @@ hide:
     [:octicons-arrow-right-24: 直接使用](./utils/index.md)
 
 </div>
-
-## :material-bullhorn-outline: 近期公告
-
-!!! tip "最新动态"
-
-    <!-- latest-posts:5 -->
-
-    更多公告请见 [:material-bullhorn-outline: 近期公告](./blog/index.md)。
 
 ---
 

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -57,6 +57,12 @@ hide:
 
 </div>
 
+## :material-bullhorn-outline: 近期公告
+
+<!-- latest-posts:5 -->
+
+更多請見 [:material-bullhorn-outline: 全部公告](./blog/index.md)。
+
 ## :material-account-switch-outline: 換個處境看看
 
 同一套工具在不同處境下的用法差很多。這幾篇從具體的人與具體的風險寫起，讀完會比較知道自己需要保護什麼。
@@ -120,14 +126,6 @@ hide:
     [:octicons-arrow-right-24: 直接使用](./utils/index.md)
 
 </div>
-
-## :material-bullhorn-outline: 近期公告
-
-!!! tip "最新動態"
-
-    <!-- latest-posts:5 -->
-
-    更多公告請見 [:material-bullhorn-outline: 近期公告](./blog/index.md)。
 
 ---
 


### PR DESCRIPTION
## 為什麼

首頁唯一的動態內容排在整頁最後，前面隔著十張卡片。首頁 front matter 有 `hide: toc`，讀者沒有目錄可跳，實際上看不到站上的近況。

`docs/hooks/latest_posts.py` 當初改成建置時生成，docstring 寫的理由是手動清單過期會讓讀者以為站上沒有動靜。訊號留在頁尾等於白做。

## 改了什麼

三語系首頁各一處，把「近期公告」整段搬到「從這裡開始」之後，英文版對應放在 `Four ways to use this site` 之後。第一屏仍然留給定位與四張入口卡，第一次到站的人先完成分流，回訪的人捲一次就看到近況。

同時去掉 `!!! tip` 的框，改成標題底下直接列清單。夾在兩組卡片之間時，多一層 admonition 容器會跟卡片搶視覺層級。中文兩版的結尾連結文字改成「更多請見 全部公告」，避免與區塊標題重複，英文版原本就是 `More at Updates`，維持不動。

新的區塊順序：

```
從這裡開始（4 張卡）
近期公告（5 條，hook 生成）
換個處境看看（4 張卡）
實際操作看看（2 張卡）
--- 緊急求救
```

## 驗證

- 三語系 `run.sh`、`run_en.sh`、`run_zh-cn.sh` 建置（`-s` strict）全部 exit 0，無 warning
- 檢查產出的 `index.html`，H2 順序正確、`<!-- latest-posts:5 -->` 正常展開成五條清單、blog 連結解析無誤
- `tools/docs_style_lint.py` 掃三個檔零違規
- 站內沒有連結指向 `#近期公告` 錨點，搬動不會斷連結

`tools/test_offline_index.py` 裡的「近期公告」指的是 nav 的 `blog/index.md` 章節，跟首頁區塊無關，不受本次改動影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)