### PR TITLE
fix(pwa): SW 的請求繞過瀏覽器 HTTP 快取，PWA 才拿得到新發布的內容

### DIFF
--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -533,6 +533,26 @@
                 }
               });
             });
+
+            // 回到前景時自己問一次有沒有新版。
+            //
+            // 瀏覽器的 soft update 靠 navigation 觸發，分頁裡怎麼逛都會碰到。
+            // standalone 的 PWA 常駐在背景，回到前景不產生新的 navigation，於是
+            // 那個觸發點永遠等不到，換版提示不出現，讀者連更新按鈕都看不到。
+            //
+            // 節流是因為切換 app 很頻繁，每次 update() 都是一個對 sw.js 的請求。
+            // 半小時一次夠了，內容本身的新鮮度由 sw.js 的 network-first 負責，
+            // 這裡管的只是換版提示。
+            var UPDATE_CHECK_INTERVAL = 30 * 60 * 1000;
+            var lastUpdateCheck = Date.now();
+            document.addEventListener("visibilitychange", function () {
+              if (document.visibilityState !== "visible") return;
+              if (Date.now() - lastUpdateCheck < UPDATE_CHECK_INTERVAL) return;
+              lastUpdateCheck = Date.now();
+              registration.update().catch(function () {
+                // 離線或抓不到 sw.js，下次回到前景再試
+              });
+            });
           });
         })();
       </script>

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -66,6 +66,22 @@ const AUTO_PRECACHE_URL = "/__anoni-settings/auto-precache";
 // 十一 MB 變成十八 MB，而多數讀者在行動網路上。想要完整離線閱讀的人自己打開。
 const PRECACHE_IMAGES_URL = "/__anoni-settings/precache-images";
 
+// 這個 SW 發出去的每一個請求都要繞過瀏覽器自己的 HTTP 快取。
+//
+// Cloudflare 上有一條 browser_ttl 為 override_origin 的 Cache Rule，送給讀者的
+// HTML 一律是 max-age=14400。沒帶 cache 選項的 fetch 在那四小時內根本不出門，
+// 拿回來的是裝置上的舊副本，network-first 看起來問過網路，實際上問的是自己，
+// 而那份舊回應還會被寫回 RUNTIME_PAGES，讓舊內容更久留在裝置上。
+//
+// 分頁裡的 Safari 讀者感覺不到，因為從網址列進站或下拉重新整理的 cache mode 是
+// reload，本來就繞過 HTTP 快取。standalone 的 PWA 冷啟動與站內點連結都是
+// default，加上 iOS 的 home screen app 有獨立的 storage 分區，Safari 那邊抓到
+// 新內容也傳不過來，於是只有 PWA 一直卡在舊版。
+//
+// no-cache 這個名字容易誤會，它的意思是每次都跟伺服器確認一次，內容沒變時回
+// 304，成本是一個往返。快取照樣留著。
+const NO_HTTP_CACHE = { credentials: "same-origin", cache: "no-cache" };
+
 // SW scope 在正式站是 /docs/，本地開發（mkdocs serve）是 /
 const SCOPE_PATH = new URL(self.registration.scope).pathname;
 
@@ -353,9 +369,10 @@ function precacheUrlsFor(prefix) {
 // 讀者自己勾的頁面走的是另一條，由管理頁把資產一起送進 LIBRARY_ASSETS。
 async function corePageAssets(prefix) {
   try {
-    const response = await fetch(SCOPE_PATH + prefix + "offline-index.json", {
-      credentials: "same-origin",
-    });
+    const response = await fetch(
+      SCOPE_PATH + prefix + "offline-index.json",
+      NO_HTTP_CACHE
+    );
     if (!response.ok) return [];
     const index = await response.json();
     const core = new Set(CORE_PAGES_BY_PREFIX[prefix] || CORE_PAGES_ZH);
@@ -442,7 +459,7 @@ async function precacheFor(prefix, wantFull) {
   await Promise.allSettled(
     urls.map(async (url) => {
       if (await cache.match(url)) return;
-      const response = await fetch(url, { credentials: "same-origin" });
+      const response = await fetch(url, NO_HTTP_CACHE);
       if (response.ok) await cache.put(url, response);
     })
   );
@@ -620,7 +637,7 @@ async function addToLibrary(prefix, paths, assets, refresh, report) {
       if (!refresh && (await target.cache.match(url))) {
         ok += 1;
       } else {
-        const response = await fetch(url, { credentials: "same-origin" });
+        const response = await fetch(url, NO_HTTP_CACHE);
         if (response.ok) {
           await target.cache.put(url, response);
           ok += 1;
@@ -907,8 +924,13 @@ async function trimCache(cacheName, maxEntries) {
 const NAVIGATE_TIMEOUT_MS = 3000;
 
 async function networkFirst(request, event) {
-  // 先把網路那條發出去，不管後面走哪一條，它拿到的東西都要寫進快取
-  const network = fetch(request).then(async (response) => {
+  // 先把網路那條發出去，不管後面走哪一條，它拿到的東西都要寫進快取。
+  //
+  // cache 選項的理由見 NO_HTTP_CACHE，這裡傳的是 Request，credentials 由它自己帶。
+  // 帶 init 去複製一個 mode 為 navigate 的 Request，規格會把 mode 降成
+  // same-origin。這裡的請求在 fetch handler 入口已經濾成同源，站內連結也都是
+  // mkdocs 產出的完整目錄形狀，走不到跨站轉址那條路。
+  const network = fetch(request, { cache: "no-cache" }).then(async (response) => {
     if (response.ok && (await autoPrecacheEnabled())) {
       const cache = await caches.open(RUNTIME_PAGES);
       await cache.put(request, response.clone());
@@ -947,7 +969,10 @@ async function networkFirst(request, event) {
 
 async function staleWhileRevalidate(request, event) {
   const cached = await caches.match(request);
-  const fetchPromise = fetch(request)
+  // 背景那條同樣繞過 HTTP 快取（見 NO_HTTP_CACHE）。theme 資產帶 hash 檔名不會
+  // 變，會變的是自寫的 js 與圖，那些在 mkdocs 產出時沒有 hash。這裡回應先給快取，
+  // revalidate 在背景跑，讀者感覺不到多出來的那個往返。
+  const fetchPromise = fetch(request, { cache: "no-cache" })
     .then(async (response) => {
       if (response.ok && (await autoPrecacheEnabled())) {
         const cache = await caches.open(RUNTIME_ASSETS);

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -68,15 +68,19 @@ const PRECACHE_IMAGES_URL = "/__anoni-settings/precache-images";
 
 // 這個 SW 發出去的每一個請求都要繞過瀏覽器自己的 HTTP 快取。
 //
-// Cloudflare 上有一條 browser_ttl 為 override_origin 的 Cache Rule，送給讀者的
-// HTML 一律是 max-age=14400。沒帶 cache 選項的 fetch 在那四小時內根本不出門，
-// 拿回來的是裝置上的舊副本，network-first 看起來問過網路，實際上問的是自己，
-// 而那份舊回應還會被寫回 RUNTIME_PAGES，讓舊內容更久留在裝置上。
+// 沒帶 cache 選項的 fetch 會先問裝置上的 HTTP 快取，命中就直接回，網路那條根本
+// 不出門。network-first 於是看起來問過網路，實際上問的是自己，而那份舊回應還會
+// 被寫回 RUNTIME_PAGES，讓舊內容更久留在裝置上。
 //
-// 分頁裡的 Safari 讀者感覺不到，因為從網址列進站或下拉重新整理的 cache mode 是
+// 2026-08-28 就是這樣：Cloudflare 上一條 browser_ttl 為 override_origin 的 Cache
+// Rule 把送給讀者的 HTML 一律設成 max-age=14400，新發布的內容有四小時進不了
+// PWA。分頁裡的 Safari 讀者感覺不到，從網址列進站或下拉重新整理的 cache mode 是
 // reload，本來就繞過 HTTP 快取。standalone 的 PWA 冷啟動與站內點連結都是
 // default，加上 iOS 的 home screen app 有獨立的 storage 分區，Safari 那邊抓到
 // 新內容也傳不過來，於是只有 PWA 一直卡在舊版。
+//
+// 那條規則後來加了一條蓋過去，/docs/ 的頁面現在不給瀏覽器快取。這裡照樣帶著
+// no-cache，兩層各自獨立：CDN 的設定會被人改，改的人未必知道 SW 靠它吃飯。
 //
 // no-cache 這個名字容易誤會，它的意思是每次都跟伺服器確認一次，內容沒變時回
 // 304，成本是一個往返。快取照樣留著。

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -79,8 +79,12 @@ const PRECACHE_IMAGES_URL = "/__anoni-settings/precache-images";
 // default，加上 iOS 的 home screen app 有獨立的 storage 分區，Safari 那邊抓到
 // 新內容也傳不過來，於是只有 PWA 一直卡在舊版。
 //
-// 那條規則後來加了一條蓋過去，/docs/ 的頁面現在不給瀏覽器快取。這裡照樣帶著
-// no-cache，兩層各自獨立：CDN 的設定會被人改，改的人未必知道 SW 靠它吃飯。
+// 同一天收尾成兩層。m6 的 nginx 對 /docs/ 的頁面與兩份索引送 no-cache（見
+// anoninet.conf 的 map $docs_cache_control），Cloudflare 那條規則的 browser_ttl
+// 改成 respect origin 讓它傳下來，edge 照樣快取 24 小時，由 cf_purge.py 清。
+//
+// 這裡照樣帶著 no-cache，兩層各自獨立。上游的設定會被人改，改的人未必知道 SW
+// 靠它吃飯，而症狀是讀者拿不到剛發布的內容，在瀏覽器上點來點去看不出來。
 //
 // no-cache 這個名字容易誤會，它的意思是每次都跟伺服器確認一次，內容沒變時回
 // 304，成本是一個往返。快取照樣留著。

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -1128,10 +1128,11 @@ test('換版不動同一個 origin 上別人的快取', async (load) => {
 });
 
 test('每一條網路請求都繞過瀏覽器自己的 HTTP 快取', async (load) => {
-  // Cloudflare 上有一條 browser_ttl 為 override_origin 的 Cache Rule，送給讀者的
-  // HTML 一律是 max-age=14400。少了 cache 選項的 fetch 在那四小時內根本不出門，
-  // network-first 拿回來的是裝置上的舊副本，standalone 的 PWA 於是一直停在舊版，
-  // 而同一個人用 Safari 分頁看就是新的，因為那邊的 cache mode 是 reload。
+  // 少了 cache 選項的 fetch 會先問裝置上的 HTTP 快取，命中就不出門，network-first
+  // 拿回來的是舊副本。2026-08-28 的實例是 Cloudflare 一條 browser_ttl 為
+  // override_origin 的 Cache Rule 把 HTML 設成 max-age=14400，新發布的內容有四小時
+  // 進不了 standalone 的 PWA，而同一個人用 Safari 分頁看就是新的，因為那邊的
+  // cache mode 是 reload。
   //
   // 這一條守著 sw.js 裡每一個 fetch。少掉任何一個的 no-cache，症狀都是讀者拿不到
   // 剛發布的內容，而那在瀏覽器上點來點去看不出來。

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -99,6 +99,7 @@ class FakeCacheStorage {
 }
 
 const harness = `
+  ${grab(/^const NO_HTTP_CACHE = .*$/m)}
   ${grab(/^const VERSION = .*$/m)}
   ${grab(/^const PRECACHE = .*$/m)}
   ${grab(/^const LANG_PREFIXES = \[[^\]]*\];/m)}
@@ -175,6 +176,8 @@ const harness = `
 const load = (opts = {}) => {
   const caches = new FakeCacheStorage();
   const fetched = [];
+  // 每次 fetch 的第二個參數。用來驗每一條都繞過瀏覽器自己的 HTTP 快取。
+  const fetchInits = [];
   const net = { offline: !!opts.offline };
   // 真的 Response 有 clone()，networkFirst 存快取時會用到。headers 與 blob 是給
   // cacheUsage 量大小用的：線上多數項目有 content-length，少數沒有的走 blob。
@@ -192,9 +195,10 @@ const load = (opts = {}) => {
     blob: async () => ({ size: bytesOf(url) }),
     clone: () => makeResponse(url, ok),
   });
-  const fetchStub = async (input) => {
+  const fetchStub = async (input, init) => {
     const url = typeof input === 'string' ? input : input.url;
     fetched.push(url);
+    fetchInits.push(init);
     if (net.offline) throw new TypeError("Failed to fetch");
     // 「連得上但很慢」。networkFirst 的逾時要比這個短才有得比。
     if (opts.networkDelay) await new Promise((r) => setTimeout(r, opts.networkDelay));
@@ -223,7 +227,7 @@ const load = (opts = {}) => {
   const sw = new Function(
     'caches', 'SCOPE_PATH', 'fetch', 'self', 'navigator', 'setTimeout', harness
   )(caches, SCOPE_PATH, fetchStub, selfStub, navigatorStub, setTimeoutStub);
-  return { sw, caches, fetched, net };
+  return { sw, caches, fetched, fetchInits, net };
 };
 
 const req = (pathname) => ({ url: ORIGIN + pathname });
@@ -1121,6 +1125,29 @@ test('換版不動同一個 origin 上別人的快取', async (load) => {
 
   assert.equal(await caches.has('anoni-site-shell'), true);
   assert.equal(await (await caches.open('anoni-site-shell')).match('/index.html'), 'HOME');
+});
+
+test('每一條網路請求都繞過瀏覽器自己的 HTTP 快取', async (load) => {
+  // Cloudflare 上有一條 browser_ttl 為 override_origin 的 Cache Rule，送給讀者的
+  // HTML 一律是 max-age=14400。少了 cache 選項的 fetch 在那四小時內根本不出門，
+  // network-first 拿回來的是裝置上的舊副本，standalone 的 PWA 於是一直停在舊版，
+  // 而同一個人用 Safari 分頁看就是新的，因為那邊的 cache mode 是 reload。
+  //
+  // 這一條守著 sw.js 裡每一個 fetch。少掉任何一個的 no-cache，症狀都是讀者拿不到
+  // 剛發布的內容，而那在瀏覽器上點來點去看不出來。
+  const { sw, fetchInits } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.setPrecacheImages(true);
+  await sw.installPrecache();
+  await sw.precacheOnNavigation('', true);
+  await sw.corePageAssets('');
+  await sw.networkFirst(req('/docs/basics/threat-model/'));
+  await sw.staleWhileRevalidate(req('/docs/assets/images/logo-white.svg'));
+  await sw.addToLibrary('', ['taiwan/'], ['assets/images/logo-white.svg'], true, () => {});
+
+  assert.ok(fetchInits.length > 0, '這一輪一個 fetch 都沒發出去，測試本身沒驗到東西');
+  for (const init of fetchInits) {
+    assert.equal(init && init.cache, 'no-cache');
+  }
 });
 
 for (const [name, fn] of tests) {


### PR DESCRIPTION
## 症狀

新發布的內容在 Safari 分頁馬上看得到，從 home screen 開的 PWA 卻一直是舊的。回報時的例子是 `basics/threat-model/` 新增的段落。

## 根因

Cloudflare 上有一條 Cache Rule 蓋掉了 origin 送的標頭：

```
規則：Cache anoni.net main site (mkdocs static)
條件：http.host eq "anoni.net"
browser_ttl: { default: 14400, mode: "override_origin" }
```

讀者拿到的一律是 `cache-control: public, max-age=14400, must-revalidate`。而 `sw.js` 的每一個 `fetch` 都沒帶 `cache` 選項，那四小時內請求根本不出門，`networkFirst` 拿回來的是裝置上 HTTP 快取的舊副本。network-first 看起來問過網路，實際上問的是自己，而那份舊回應還會被寫回 `RUNTIME_PAGES`，讓舊內容更久留在裝置上。

分頁裡的 Safari 讀者感覺不到，從網址列進站或下拉重新整理的 cache mode 是 `reload`，本來就繞過 HTTP 快取。standalone 的 PWA 冷啟動與站內點連結都是 `default`，加上 iOS 的 home screen app 有獨立的 storage 分區，Safari 那邊抓到新內容也傳不過來。

還有第二層。`base.html` 註冊完 SW 之後從來沒呼叫過 `registration.update()`，而瀏覽器的 soft update 靠 navigation 觸發。PWA 常駐在背景，回到前景不產生新的 navigation，那個觸發點永遠等不到，換版提示不出現，讀者連更新按鈕都看不到。

## 這個 PR 改了什麼

- `sw.js` 五處 `fetch` 一律帶 `cache: "no-cache"`，抽成 `NO_HTTP_CACHE` 常數，把理由寫在旁邊。no-cache 是強制 revalidate，內容沒變時回 304，成本是一個往返。
- `base.html` 在 `visibilitychange` 轉 visible 時節流呼叫 `registration.update()`，半小時一次。
- `tools/test_sw_offline.mjs` 補一條測試，守著每一個 fetch 都帶 `no-cache`。少掉任何一個都會紅。

`networkFirst` 帶 init 去複製一個 mode 為 navigate 的 Request，規格會把 mode 降成 `same-origin`。這裡的請求在 fetch handler 入口已經濾成同源，站內連結也都是 mkdocs 產出的完整目錄形狀，走不到跨站轉址那條路。

## 驗證

```
node tools/test_sw_offline.mjs      # 75 通過，0 失敗
node tools/test_offline_library.mjs # 26 通過，0 失敗
node tools/test_lang_preference.mjs # 6 通過，0 失敗
```

新測試會抓到迴歸：手動拿掉 `networkFirst` 的 `no-cache` 之後是 74 通過、1 失敗。

## 還要做的一步（不在這個 PR 裡）

Cloudflare Cache Rules 最後要再加一條，把 `/docs/` 頁面的 `browser_ttl` 改掉。這個 PR 只讓 SW 自己不依賴 CDN 設定，已經裝了舊 SW 的裝置還是要等換版才會生效，而改 Cache Rule 對那些裝置立刻有效。

驗證過的規則優先順序：後面匹配的規則覆蓋前面的。前面那條「Static Files」給 `/docs/assets/*` 指定的 `browser_ttl: 43200` 實測已經被後面的 14400 蓋掉，所以新規則要放在清單最後面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)