### PR TITLE
fix(pwa): 沒有網路時不再每翻一頁都等滿逾時

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -925,6 +925,17 @@ function cacheKeyCandidates(pathname) {
 // 也命中，站上的 query 一律只由 client 端 JS 讀取，同一個路徑回傳的 HTML 是同一份。
 async function matchCachedPage(request) {
   const url = new URL(request.url);
+  // 先走精確比對。ignoreSearch 會讓 Cache Storage 放棄索引、線性掃過每一筆，而
+  // 按下「全部存到裝置」之後那是四百多筆，每翻一頁掃兩輪，在手機上是看得出來的
+  // 延遲。站上絕大多數導覽的網址沒有 query，這一條就結束了。
+  for (const pathname of cacheKeyCandidates(url.pathname)) {
+    const hit = await caches.match(url.origin + pathname);
+    if (hit) return hit;
+  }
+  // 精確那輪沒中才退回線性掃描。會走到這裡的是快取裡存著帶 query 的 key，例如讀者
+  // 從 /docs/x/?utm=... 進來，RUNTIME_PAGES 就存下了那個形狀。ignoreSearch 讓它跟
+  // 純路徑對得上，站上的 query 一律只由 client 端 JS 讀取，同一個路徑回傳的 HTML
+  // 是同一份。
   for (const pathname of cacheKeyCandidates(url.pathname)) {
     const hit = await caches.match(url.origin + pathname, { ignoreSearch: true });
     if (hit) return hit;
@@ -958,7 +969,27 @@ async function trimCache(cacheName, maxEntries) {
 // 完全斷線時 fetch 立刻就失敗，這個值用不到。它是為了「連得上但很慢」與「連線被
 // 干擾」那種狀態：讀者手上明明有離線副本，卻要陪著瀏覽器一路等到它自己放棄，
 // 而那種網路正是這個網站的讀者比別人更常遇到的。
-const NAVIGATE_TIMEOUT_MS = 3000;
+//
+// 2026-08-29 從三秒降下來。三秒是「網路慢的時候還願意等一下」的估計，實際遇到的
+// 是飛航模式底下 Wi-Fi 還開著，每翻一頁停三秒，而裝置上四百多頁一頁不缺。手上有
+// 副本可讀的時候，晚一輪拿到新內容比每一頁都卡住好。
+const NAVIGATE_TIMEOUT_MS = 1200;
+
+// 網路最近一次讓導覽等到逾時或直接失敗的時間。
+//
+// navigator.onLine 只有回 false 的時候可信，而讀者實際卡住的狀態正好是它回 true
+// 的那些：飛航模式底下 Wi-Fi 還開著、機上 Wi-Fi 沒買方案、公共熱點把流量攔在
+// 登入頁。那時候每翻一頁都要陪著等滿逾時，裝置上明明有一份讀得到的。
+//
+// 記下來之後的一分鐘內，有快取就直接給。網路那條照樣發出去在背景更新，它成功了
+// 就把這個狀態清掉，所以讀者接回網路之後不必自己按什麼，下一次導覽就恢復正常。
+const NETWORK_DOWN_TTL_MS = 60000;
+let networkDownSince = 0;
+
+function networkLooksDown() {
+  if (navigator.onLine === false) return true;
+  return networkDownSince > 0 && Date.now() - networkDownSince < NETWORK_DOWN_TTL_MS;
+}
 
 async function networkFirst(request, event) {
   // 先把網路那條發出去，不管後面走哪一條，它拿到的東西都要寫進快取。
@@ -968,6 +999,8 @@ async function networkFirst(request, event) {
   // same-origin。這裡的請求在 fetch handler 入口已經濾成同源，站內連結也都是
   // mkdocs 產出的完整目錄形狀，走不到跨站轉址那條路。
   const network = fetch(request, { cache: "no-cache" }).then(async (response) => {
+    // 這條路通了。不看 response.ok，回 404 也代表網路本身是好的。
+    networkDownSince = 0;
     if (response.ok && (await autoPrecacheEnabled())) {
       const cache = await caches.open(RUNTIME_PAGES);
       await cache.put(request, response.clone());
@@ -985,10 +1018,18 @@ async function networkFirst(request, event) {
     try {
       return await network;
     } catch (err) {
+      networkDownSince = Date.now();
       const offline = await caches.match(offlinePathFor(new URL(request.url)));
       if (offline) return offline;
       throw err;
     }
+  }
+
+  // 網路已經知道是斷的就不必再等一輪。直接給裝置上那一份，網路那條照樣在背景跑，
+  // 它成功的話會清掉離線狀態，下一次導覽就恢復成正常的賽跑。
+  if (networkLooksDown()) {
+    keepAlive(event, network.catch(() => {}));
+    return cached;
   }
 
   // 有副本就跟網路賽跑。網路先到就用網路的，讀者拿到的是最新內容。
@@ -1000,6 +1041,10 @@ async function networkFirst(request, event) {
 
   // 網路太慢或失敗，先給讀者看得到的那一份。網路那邊還在跑，回來時照樣寫進快取，
   // 下一次導覽拿到的就是新的。SW 要活到那時候，所以掛在 waitUntil 上。
+  //
+  // 同時記下這一次沒等到。接下來一分鐘內的導覽直接走上面那條，讀者不必每翻一頁
+  // 都重新等一遍逾時。
+  networkDownSince = Date.now();
   keepAlive(event, network.catch(() => {}));
   return cached;
 }

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -75,6 +75,9 @@ class FakeCache {
 class FakeCacheStorage {
   constructor() {
     this.named = new Map();
+    // 帶 ignoreSearch 的比對做過幾次。那條會讓 Cache Storage 放棄索引、線性掃過
+    // 每一筆，四百多筆的裝置上是看得出來的延遲，所以要驗它沒有被無條件用上。
+    this.ignoreSearchCalls = 0;
   }
   async open(name) {
     if (!this.named.has(name)) this.named.set(name, new FakeCache());
@@ -90,6 +93,7 @@ class FakeCacheStorage {
     return this.named.delete(name);
   }
   async match(request, opts) {
+    if (opts && opts.ignoreSearch) this.ignoreSearchCalls += 1;
     for (const cache of this.named.values()) {
       const hit = await cache.match(request, opts);
       if (hit) return hit;
@@ -153,6 +157,9 @@ const harness = `
   ${grab(/^async function migrateLegacyRuntime\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function keepAlive\(event, promise\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const NAVIGATE_TIMEOUT_MS = .*$/m)}
+  ${grab(/^const NETWORK_DOWN_TTL_MS = .*$/m)}
+  ${grab(/^let networkDownSince = .*$/m)}
+  ${grab(/^function networkLooksDown\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function networkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function staleWhileRevalidate\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function purgeStaleCaches\(\) \{[\s\S]*?\n\}/m)}
@@ -165,6 +172,7 @@ const harness = `
     libraryEntries, precachedEntries,
     messagePrefix, addToLibrary, removeFromLibrary, clearAllOffline,
     handleLibraryMessage, networkFirst, staleWhileRevalidate, NAVIGATE_TIMEOUT_MS,
+    networkLooksDown,
     OWN_CACHE_PREFIX, ownCacheNames, cacheUsage, purgeStaleCaches,
   };
 `;
@@ -235,7 +243,11 @@ const load = (opts = {}) => {
       matchAll: async () => (opts.clients || []).map((url) => ({ url })),
     },
   };
-  const navigatorStub = { storage: { estimate: async () => ({ usage: 1024, quota: 4096 }) } };
+  // onLine 不給就是 undefined，跟瀏覽器沒有回報一樣，networkLooksDown 只認 false
+  const navigatorStub = {
+    storage: { estimate: async () => ({ usage: 1024, quota: 4096 }) },
+    onLine: opts.onLine,
+  };
   // NAVIGATE_TIMEOUT_MS 那個 setTimeout 由外面給。fastTimeout 讓它立刻觸發，
   // 配上 networkDelay 就能在幾十毫秒內驗完「網路太慢」那條路。
   const setTimeoutStub = opts.fastTimeout ? (fn) => setTimeout(fn, 0) : setTimeout;
@@ -902,6 +914,67 @@ test('認不得的指令會回錯誤，不會靜靜沒反應', async (load) => {
   const replies = [];
   await sw.handleLibraryMessage({ type: 'NOPE' }, { postMessage: (d) => replies.push(d) });
   assert.equal(replies[0].type, 'error');
+});
+
+test('navigator.onLine 說沒有網路時直接給快取，不等那一輪逾時', async (load) => {
+  // 讀者切到飛航模式之後每翻一頁都停一下，而裝置上四百多頁一頁不缺。onLine 回
+  // false 是可信的（回 true 才不可信），拿來省掉那一輪等待剛好。
+  //
+  // networkDelay 比逾時短，少了這一條就會拿到網路那份，測得出差別。
+  const { sw, caches, fetched } = load({ onLine: false, networkDelay: 200 });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  assert.equal(await sw.networkFirst(req('/docs/tools/what-is-tor/'), null), 'CACHED');
+  // 網路那條照樣發出去。它成功的話下一次導覽就是新的，讀者不必自己按什麼。
+  assert.ok(fetched.includes(ORIGIN + '/docs/tools/what-is-tor/'), '背景那條沒有發出去');
+});
+
+test('等不到網路就記下來，下一頁不必重等一遍', async (load) => {
+  // 連得上但出不去的網路（飛航模式底下 Wi-Fi 還開著、機上 Wi-Fi 沒買方案、公共
+  // 熱點把流量攔在登入頁）下，navigator.onLine 回的是 true，每翻一頁都要陪著等
+  // 滿逾時。四百多頁存在裝置上卻頁頁卡住，那是這個功能最沒有道理的失敗方式。
+  const { sw, caches } = load({ networkDelay: 60, fastTimeout: true });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  assert.equal(sw.networkLooksDown(), false);
+  assert.equal(await sw.networkFirst(req('/docs/tools/what-is-tor/'), null), 'CACHED');
+  assert.equal(sw.networkLooksDown(), true, '沒記下來的話，下一頁又要從頭等一次');
+});
+
+test('網路回來就把離線狀態清掉，讀者不必自己按什麼', async (load) => {
+  const { sw, caches } = load({ networkDelay: 30, fastTimeout: true });
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+  await sw.networkFirst(req('/docs/tools/what-is-tor/'), null);
+  assert.equal(sw.networkLooksDown(), true);
+
+  // 背景那條慢了一步，回來的時候網路其實是通的
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  assert.equal(sw.networkLooksDown(), false, '網路回來了還當成離線，讀者會一直看到舊的');
+});
+
+test('沒有 query 的導覽不走 ignoreSearch 的線性掃描', async (load) => {
+  // ignoreSearch 會讓 Cache Storage 放棄索引、掃過每一筆。存了四百多頁的裝置上
+  // 每翻一頁掃兩輪，累積起來就是讀者說的那種停頓。站上絕大多數網址沒有 query。
+  const { sw, caches } = load();
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put('/docs/tools/what-is-tor/', 'CACHED');
+
+  assert.equal(await sw.matchCachedPage(req('/docs/tools/what-is-tor/')), 'CACHED');
+  assert.equal(caches.ignoreSearchCalls, 0, '沒有 query 也走了線性掃描');
+});
+
+test('精確那輪沒中就退回 ignoreSearch，帶 query 存下的照樣找得到', async (load) => {
+  // 讀者從 /docs/x/?utm=... 之類的網址進來時，RUNTIME_PAGES 存下的就是那個形狀。
+  // 下一次他從乾淨的網址進來，精確比對對不上，這時候線性掃描是唯一找得到的路。
+  const { sw, caches } = load();
+  const pages = await caches.open(sw.RUNTIME_PAGES);
+  await pages.put(ORIGIN + '/docs/tools/what-is-tor/?utm_source=x', 'CACHED');
+
+  assert.equal(await sw.matchCachedPage(req('/docs/tools/what-is-tor/')), 'CACHED');
+  assert.ok(caches.ignoreSearchCalls > 0, '精確沒中卻沒有退回線性掃描');
 });
 
 test('網路太慢時先給裝置上那一份，不陪著等到瀏覽器放棄', async (load) => {


### PR DESCRIPTION
## 回報

切到飛航模式之後,每翻一頁停四五秒,而裝置上四百多頁一頁不缺。在飛機上飛一段時間後反而變順,落地接上網路後停頓又回來。

## 診斷

不是搜尋索引。那份索引只在按下搜尋時才載入,頁面導覽不碰它,而且「接上網路後停頓又回來」正好排除了它:索引已經在本機、大小沒變。

三種網路狀態走的是 `networkFirst` 裡不同的路:

| 狀態 | fetch 的行為 | 讀者感受 |
|---|---|---|
| 完全斷線 | 立刻 reject,race 立刻結束 | 順（這是飛機上那段） |
| 連得上但出不去 | 一直掛著,等滿 3 秒逾時 | 每頁停 3 秒以上 |
| 有網路但慢 | 完整往返 | 視網路而定 |

讀者實際遇到的是第二種:飛航模式底下 Wi-Fi 還開著、機上 Wi-Fi 沒買方案、公共熱點把流量攔在登入頁。那時 `navigator.onLine` 回的是 `true`,程式沒有別的線索,只能每頁重等一次。

`matchCachedPage` 的 `ignoreSearch: true` 是另一個來源。那個選項會讓 Cache Storage 放棄索引、線性掃過每一筆,而按下「全部存到裝置」(#380) 之後那是四百多筆,每翻一頁掃兩輪。

## 改了什麼

- `networkLooksDown()`:`navigator.onLine === false` 就直接給快取。規範上回 `false` 可信、回 `true` 不可信,所以只認 `false` 這一邊。
- 等不到網路就記下時間,接下來一分鐘內有快取就直接給,網路那條照樣在背景跑。它成功就把狀態清掉,讀者接回網路之後不必自己按什麼。
- `NAVIGATE_TIMEOUT_MS` 從 3000 降到 1200。手上有副本可讀的時候,晚一輪拿到新內容比每頁都卡住好。
- `matchCachedPage` 先走精確比對(走得到索引),沒中才退回 `ignoreSearch`。正確性沒變:快取裡存著帶 query 的 key 時照樣找得到,只是那條變成退路。

## 跟 #376 的關係

上一輪讓 `sw.js` 的 fetch 帶 `no-cache`,有網路時每次導覽都要一個完整往返,把這個問題放大了。那個改動要留著,PWA 拿不拿得到新內容靠它。真正該調的是「有副本可讀時願意等多久」,這個 PR 調的是那個。

## 驗證

```
node tools/test_sw_offline.mjs       # 81 通過,0 失敗（原 76）
node tools/test_offline_library.mjs  # 32 通過,0 失敗
node tools/test_lang_preference.mjs  # 6 通過,0 失敗
node tools/check_invisible_chars.mjs # 900 個檔案,乾淨
```

四項改動逐一驗過拿掉會紅:拿掉 onLine 判斷 1 條紅、拿掉逾時記錄 2 條紅、拿掉網路回來的清除 1 條紅、精確比對改回無條件 `ignoreSearch` 1 條紅。

## 還可以更激進

導覽改成 stale-while-revalidate（有快取就立刻回,網路只在背景更新）能把停頓降到零,代價是讀者總是看到上一版。目前保留 network-first 的意圖,沒有走那一步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)