### PR TITLE
fix(offline): 確定清除改成紅底白字，不再被通用 hover 換掉文字色

### DIFF
--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -30,8 +30,10 @@
       border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; padding: .3rem .7rem;
     }
-    /* 填了底色的「套用變更」不套這條，不然滑鼠放上去文字就看不見了 */
-    #offline-library button:hover:not(:disabled):not(.ol-primary) {
+    /* 填了底色的按鈕不套這條，不然滑鼠放上去文字就跟底色融在一起。這條多一個
+       button 型別選擇器，特異性比 .ol-primary 與 .ol-danger 自己的 hover 都高，
+       漏排除哪一個，哪一個的文字色就會被換成 accent。 */
+    #offline-library button:hover:not(:disabled):not(.ol-primary):not(.ol-danger) {
       border-color: var(--md-accent-fg-color); color: var(--md-accent-fg-color);
     }
     #offline-library .ol-primary:hover:not(:disabled) {
@@ -96,12 +98,14 @@
     #offline-library .ol-title--absent { color: inherit; opacity: .55; }
     #offline-library .ol-filter { display: block; cursor: pointer; margin: 1.4rem 0 .2rem; }
     #offline-library .ol-legend { margin-bottom: .4rem; }
+    /* 二段式確認的第二顆。平常就填滿紅底，不等 hover 才變色：那是不可逆的操作，
+       而觸控裝置沒有 hover 可用，靠 hover 表達危險等於在手機上表達不出來。
+       #c62828 配白字的對比是 5.6:1，過 WCAG AA。 */
     #offline-library .ol-danger {
-      border-color: var(--md-typeset-del-color, #f44336);
-      color: #c62828;
+      border-color: #c62828; background: #c62828; color: #fff;
     }
     #offline-library .ol-danger:hover:not(:disabled) {
-      background: #c62828; border-color: #c62828; color: #fff;
+      background: #b71c1c; border-color: #b71c1c; color: #fff;
     }
     /* 進度條。原本把進度寫在按鈕文字上，一邊跑一邊改字會讓按鈕寬度跟著跳。 */
     #offline-library .ol-progress { margin: .2rem 0 1rem; }

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -632,14 +632,25 @@ test('大小含資產，章節的部分去重', async () => {
 });
 
 test('填了底色的按鈕不會被 hover 規則蓋掉文字色', () => {
-  // 通用 hover 把文字色換成 accent，而它的特異性比 .ol-primary 高。實際效果是
-  // 「套用變更」按下去之後滑鼠停在上面，字就跟藍底融在一起看不見了。
-  // 觸控裝置點完會停在 hover 狀態，所以手機上是按一下就消失。
+  // 通用 hover 把文字色換成 accent，而它多一個 button 型別選擇器，特異性比
+  // .ol-primary 與 .ol-danger 自己的 hover 都高。漏排除哪一個，哪一個的文字色就會
+  // 被換成 accent。「套用變更」踩過一次，「確定清除」2026-08-29 又踩了一次，回報
+  // 是紅底配藍字。觸控裝置點完會停在 hover 狀態，所以手機上按一下就變成那樣。
   assert.ok(
-    src.includes('button:hover:not(:disabled):not(.ol-primary)'),
-    'hover 規則要排除填了底色的按鈕'
+    src.includes('button:hover:not(:disabled):not(.ol-primary):not(.ol-danger)'),
+    'hover 規則要排除每一顆填了底色的按鈕'
   );
-  assert.ok(src.includes('.ol-primary:hover'), '填色按鈕要有自己的 hover 回饋');
+  assert.ok(src.includes('.ol-primary:hover'), '.ol-primary 要有自己的 hover 回饋');
+  assert.ok(src.includes('.ol-danger:hover'), '.ol-danger 要有自己的 hover 回饋');
+});
+
+test('確定清除平常就是紅底白字，不等 hover 才看得出危險', () => {
+  // 清除是不可逆的，而觸控裝置沒有 hover 可用，靠 hover 表達危險等於在手機上
+  // 表達不出來。#c62828 配白字的對比是 5.6:1，過 WCAG AA。
+  const rule = src.match(/#offline-library \.ol-danger \{[^}]*\}/);
+  assert.ok(rule, '找不到 .ol-danger 的樣式');
+  assert.ok(/background:\s*#c62828/.test(rule[0]), rule[0]);
+  assert.ok(/color:\s*#fff/.test(rule[0]), rule[0]);
 });
 
 test('進度與完成訊息都在底部那條裡，不是散在頁面頂端', async () => {


### PR DESCRIPTION
## 回報

離線閱讀頁的「確定清除」按鈕背景是紅的,字卻是藍的,讀起來吃力。

## 實測

用 CDP 在線上頁面量 computed style,強制 `:hover`:

```
平常   color: rgb(198, 40, 40)   background: rgba(0, 0, 0, 0)
hover  color: rgb(0, 109, 153)   background: rgb(198, 40, 40)   ← 紅底藍字
```

`rgb(0, 109, 153)` 是 `--md-accent-fg-color`。

原因是 CSS specificity。通用 hover 規則寫成:

```css
#offline-library button:hover:not(:disabled):not(.ol-primary)
```

它多一個 `button` 型別選擇器,特異性 (1,3,1) 比 `.ol-danger:hover:not(:disabled)` 的 (1,3,0) 高,於是 `color: #fff` 被換成 accent 藍,只有 `background` 活下來。

`.ol-primary` 當初踩過同一個坑,那條規則的 `:not(.ol-primary)` 就是為此加的,`.ol-danger` 漏了。觸控裝置點完會停在 hover 狀態,所以在 PWA 上按一下就變成那樣並停住。

## 改了什麼

- 通用 hover 一併排除 `.ol-danger`
- `.ol-danger` 平常就填滿紅底白字,不等 hover 才變色。清除是不可逆的操作,而觸控裝置沒有 hover 可用,靠 hover 表達危險等於在手機上表達不出來
- `#c62828` 配白字的對比是 5.6:1,過 WCAG AA。hover 深一階到 `#b71c1c`

修正後用同一套 CDP 量過:

```
平常   color: rgb(255, 255, 255)  background: rgb(198, 40, 40)
hover  color: rgb(255, 255, 255)  background: rgb(183, 28, 28)
ol-primary 沒被波及               color: rgb(255,255,255) background: rgb(0,109,153)
```

## 驗證

```
node tools/test_offline_library.mjs  # 34 通過,0 失敗（原 33）
node tools/test_sw_offline.mjs       # 81 通過,0 失敗
node tools/check_invisible_chars.mjs # 900 個檔案,乾淨
python3 tools/docs_style_lint.py …   # 0 error、0 warn
```

兩項改動各自拿掉都是 1 條紅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)