### PR TITLE
feat(offline): 按下按鈕立刻看得到在跑，網路差時不必猜有沒有按到

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -81,6 +81,10 @@ jobs:
       - name: 語言偏好導向規則
         run: node tools/test_lang_preference.mjs
 
+      # 按下更新到頁面換好中間有好幾秒空白，按鈕不動的話讀者會一直重複按
+      - name: 換版提示按下更新之後的狀態
+        run: node tools/test_update_banner.mjs
+
       # 語言切換器不列出目前語系，但那一筆要留在 DOM 裡給偏好轉址與語言選擇卡片用
       - name: 語言切換器藏起目前語系
         run: python3 tools/test_lang_switcher.py

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -169,6 +169,33 @@
           background: var(--md-accent-fg-color);
           color: var(--md-accent-bg-color);
         }
+        .anoni-banner-action:disabled {
+          opacity: .75;
+          cursor: default;
+        }
+        /*
+          按下之後那顆按鈕自己轉。送出 SKIP_WAITING 到 controllerchange 之間，
+          service worker 要跑完 activate、清掉舊快取，接著整頁重新載入，網路差的
+          時候那是好幾秒的空白。原本按鈕上什麼都沒變，讀者只會以為沒按到，再按
+          一次，而每按一次就多送一則訊息。
+        */
+        .anoni-banner-spinner {
+          display: inline-block;
+          width: .75em;
+          height: .75em;
+          margin-right: .4em;
+          border: .1em solid currentColor;
+          border-top-color: transparent;
+          border-radius: 50%;
+          animation: anoni-spin .7s linear infinite;
+          flex: none;
+        }
+        @keyframes anoni-spin {
+          to { transform: rotate(360deg); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .anoni-banner-spinner { animation: none; opacity: .6; }
+        }
       </style>
     {% endblock %}
     {% block libs %}
@@ -428,15 +455,15 @@
           var STRINGS = {
             "zh-TW": {
               text: "離線存的內容有新版本。更新會重新載入這一頁。",
-              update: "更新", later: "稍後"
+              update: "更新", later: "稍後", updating: "更新中"
             },
             "zh": {
               text: "离线存的内容有新版本。更新会重新加载这一页。",
-              update: "更新", later: "稍后"
+              update: "更新", later: "稍后", updating: "更新中"
             },
             "en": {
               text: "A newer version is available for offline reading. Updating reloads this page.",
-              update: "Update", later: "Later"
+              update: "Update", later: "Later", updating: "Updating"
             }
           };
           var t = STRINGS[document.documentElement.lang] || STRINGS["zh-TW"];
@@ -476,18 +503,39 @@
 
             var actions = document.createElement("div");
             actions.className = "anoni-toast__actions";
-            actions.appendChild(actionButton(t.update, true, function () {
+
+            // 按下之後把按鈕換成轉圈的「更新中」並停用。從送出 SKIP_WAITING 到
+            // 頁面真的重新載入，中間是 activate 加一次完整的導覽，網路差的時候
+            // 好幾秒都沒有動靜。沒有這一段的話讀者會以為沒按到而重複按。
+            //
+            // 「稍後」一起停掉。那顆會關掉卡片，可是更新已經送出去了，頁面照樣
+            // 會在幾秒後自己重新載入，關掉只會讓那次重載變得莫名其妙。
+            var updateButton;
+            var laterButton;
+            updateButton = actionButton(t.update, true, function () {
               reloadOnTakeover = true;
+              updateButton.disabled = true;
+              laterButton.disabled = true;
+              updateButton.textContent = "";
+              var spinner = document.createElement("span");
+              spinner.className = "anoni-banner-spinner";
+              spinner.setAttribute("aria-hidden", "true");
+              updateButton.appendChild(spinner);
+              updateButton.appendChild(document.createTextNode(t.updating));
+              // 讀螢幕的人靠這個知道狀態變了，轉圈的圖案對他們沒有意義
+              updateButton.setAttribute("aria-busy", "true");
               waiting.postMessage({ type: "SKIP_WAITING" });
-            }));
-            actions.appendChild(actionButton(t.later, false, function () {
+            });
+            laterButton = actionButton(t.later, false, function () {
               try {
                 sessionStorage.setItem(DISMISS_KEY, "1");
               } catch (err) {
                 // 存不進去就只是這次關掉，換頁會再出現
               }
               dismiss();
-            }));
+            });
+            actions.appendChild(updateButton);
+            actions.appendChild(laterButton);
 
             banner.appendChild(line);
             banner.appendChild(actions);

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -120,6 +120,16 @@
     #offline-library .ol-progress__track--idle .ol-progress__fill {
       width: 30%; animation: ol-sweep 1.1s ease-in-out infinite;
     }
+    /* 正在跑的那顆按鈕自己轉。進度條 sticky 在畫面下緣，而讀者的視線停在剛按下
+       的按鈕上，網路差的時候那裡好幾秒都沒有動靜，人就會再按一次。 */
+    #offline-library .ol-spinner {
+      display: inline-block;
+      width: .75em; height: .75em; margin-right: .4em;
+      border: .1em solid currentColor; border-top-color: transparent;
+      border-radius: 50%; animation: ol-spin .7s linear infinite;
+      vertical-align: -.05em; flex: none;
+    }
+    @keyframes ol-spin { to { transform: rotate(360deg); } }
     #offline-library .ol-progress__text {
       margin: .3rem 0 0; font-size: .7rem; opacity: .8;
     }
@@ -140,6 +150,7 @@
       #offline-library .ol-progress__track--idle .ol-progress__fill {
         width: 100%; animation: none;
       }
+      #offline-library .ol-spinner { animation: none; opacity: .6; }
     }
     #offline-library .ol-primary {
       border-color: var(--md-primary-fg-color);
@@ -470,6 +481,23 @@
     return node;
   }
 
+  // 跟 button 一樣，但工作正在跑的時候換成轉圈加狀態文字。
+  //
+  // 底部那條進度條本來就會出現，可是讀者的視線停在剛按下的那顆按鈕上，而網路差
+  // 的時候第一筆回報要等好幾秒。按鈕自己沒有變化，人就會以為沒按到而重複按。
+  function taskButton(key, label, className, onClick) {
+    const running = state.task && state.task.key === key;
+    const node = button(running ? "" : label, className, onClick);
+    if (!running) return node;
+    const spin = el("span", "ol-spinner");
+    spin.setAttribute("aria-hidden", "true");
+    node.appendChild(spin);
+    node.appendChild(document.createTextNode(state.task.label));
+    // 轉圈的圖案對讀螢幕的人沒有意義，狀態要用屬性講
+    node.setAttribute("aria-busy", "true");
+    return node;
+  }
+
   function renderStatus() {
     const status = el("p", "ol-status");
     if (state.swMissing) {
@@ -660,7 +688,7 @@
 
   function renderApply() {
     const bar = el("div", "ol-apply__row");
-    const applyButton = button(t.apply, "ol-primary", () => {
+    const applyButton = taskButton("apply", t.apply, "ol-primary", () => {
         const toAdd = Array.from(state.add);
         const toRemove = Array.from(state.remove);
         // 移掉一頁不代表它的圖可以丟。留著的頁面還用得到的就不動，
@@ -674,7 +702,7 @@
         // 只送有沒有做這個動作，不送勾了幾頁也不送勾了哪些
         if (toAdd.length) trackOffline("add");
         if (toRemove.length) trackOffline("remove");
-        runTask(t.applying, toAdd.length + addAssets.length, (report) =>
+        runTask("apply", t.applying, toAdd.length + addAssets.length, (report) =>
           Promise.resolve()
             .then(() =>
               toRemove.length
@@ -792,11 +820,12 @@
     const missing = allPages().filter((url) => !state.saved.has(url));
     if (!state.swMissing && missing.length) {
       const missingAssets = Array.from(assetsOf(missing));
-      const saveAll = button(
+      const saveAll = taskButton(
+        "saveAll",
         fill("saveAll", { n: missing.length, size: size(weightOf(missing)) }),
         "ol-primary",
         () =>
-          runTask(t.applying, missing.length + missingAssets.length, (report) => {
+          runTask("saveAll", t.applying, missing.length + missingAssets.length, (report) => {
             trackOffline("add");
             return ask(
               {
@@ -819,10 +848,10 @@
 
     // 更新的對象是讀者自己勾存的那批。網站自動存的那批跟著網站版本走，讀者
     // 按不出新的內容來，所以沒有自選內容時停用並說明，而不是按了沒有反應。
-    const refresh = button(t.refresh, null, () => {
+    const refresh = taskButton("refresh", t.refresh, null, () => {
       const paths = Array.from(state.saved);
       const assets = Array.from(assetsOf(paths));
-      return runTask(t.refreshing, paths.length + assets.length, (report) =>
+      return runTask("refresh", t.refreshing, paths.length + assets.length, (report) =>
         ask(
           {
             type: "OFFLINE_ADD",
@@ -848,8 +877,8 @@
     } else {
       // 兩段式確認。原本是同一顆按鈕換文字，讀者不見得注意到字變了，
       // 這裡改成兩顆並排，要按的那顆帶危險色。
-      const confirm = button(t.clearConfirm, "ol-danger", () =>
-        runTask(t.clearing, 0, () =>
+      const confirm = taskButton("clear", t.clearConfirm, "ol-danger", () =>
+        runTask("clear", t.clearing, 0, () =>
           ask({ type: "OFFLINE_CLEAR" }).then(() => {
             trackOffline("clear");
             return { message: t.cleared };
@@ -899,10 +928,13 @@
     const track = el("div", "ol-progress__track");
     const fillBar = el("div", "ol-progress__fill");
     const task = state.task;
-    if (task.total > 0) {
+    // done 還是 0 的時候比例畫出來是一條靜止的空槽，看起來跟沒反應一樣。網路差
+    // 的時候第一頁要等好幾秒，而那正是讀者最想知道「到底有沒有按到」的時候，
+    // 沒有動靜的話他只會再按一次。先用來回掃動表示在跑，第一筆回報到了才切成
+    // 實際比例。清除這種沒有頁數可數的工作也走這一條。
+    if (task.total > 0 && task.done > 0) {
       fillBar.style.width = Math.round((task.done / task.total) * 100) + "%";
     } else {
-      // 清除這種沒有頁數可數的工作，用來回掃動表示還在跑
       track.classList.add("ol-progress__track--idle");
     }
     track.appendChild(fillBar);
@@ -988,9 +1020,9 @@
   //
   // 進度顯示在獨立的進度條上，不去改按鈕文字。原本邊跑邊改按鈕文字，按鈕寬度會
   // 跟著跳，而清除那種沒有頁數可數的工作根本沒東西可顯示，按下去看起來就像沒反應。
-  function runTask(label, total, run) {
+  function runTask(key, label, total, run) {
     state.busy = true;
-    state.task = { label: label, done: 0, total: total };
+    state.task = { key: key, label: label, done: 0, total: total };
     render();
 
     const report = (data) => {
@@ -1001,6 +1033,9 @@
       if (bar && data.total) {
         bar.style.width = Math.round((data.done / data.total) * 100) + "%";
       }
+      // 第一筆回報到了，從來回掃動切成實際比例
+      const track = root.querySelector(".ol-progress__track");
+      if (track && data.done > 0) track.classList.remove("ol-progress__track--idle");
       const line = root.querySelector(".ol-progress__text");
       if (line) {
         line.textContent =

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -72,6 +72,10 @@ class FakeElement {
         for (const n of names) if (!have.includes(n)) have.push(n);
         this.className = have.join(' ');
       },
+      remove: (...names) => {
+        const have = this.className ? this.className.split(/\s+/) : [];
+        this.className = have.filter((n) => !names.includes(n)).join(' ');
+      },
       contains: (name) => (this.className || '').split(/\s+/).includes(name),
     };
   }
@@ -201,6 +205,8 @@ const makeServiceWorker = (opts) => {
             estimate: opts.estimate || null,
           });
         } else if (message.type === 'OFFLINE_ADD') {
+          // 模擬網路很差：service worker 收到了，但一筆都還沒回報
+          if (opts.holdAdd) return;
           let done = 0;
           for (const p of message.paths) {
             done += 1;
@@ -651,6 +657,45 @@ test('確定清除平常就是紅底白字，不等 hover 才看得出危險', (
   assert.ok(rule, '找不到 .ol-danger 的樣式');
   assert.ok(/background:\s*#c62828/.test(rule[0]), rule[0]);
   assert.ok(/color:\s*#fff/.test(rule[0]), rule[0]);
+});
+
+test('按下之後那顆按鈕自己轉起來，不必等第一筆回報', async () => {
+  // 進度條 sticky 在畫面下緣，而讀者的視線停在剛按下的那顆按鈕上。網路差的時候
+  // 第一筆回報要等好幾秒，按鈕沒有變化的話人會以為沒按到，一直重複按。
+  const { root } = await load({ holdAdd: true });
+  clickButton(root, '全部存到裝置');
+  await tick(10);
+
+  const busy = root.querySelectorAll('button').find((b) => b.textContent.includes('處理中'));
+  assert.ok(busy, '按下之後沒有任何一顆按鈕顯示狀態');
+  assert.ok(busy.querySelector('.ol-spinner'), '按鈕上沒有轉圈');
+  assert.equal(busy.getAttribute('aria-busy'), 'true', '讀螢幕的人拿不到狀態');
+});
+
+test('第一筆回報之前進度條在掃動，不是一條靜止的空槽', async () => {
+  // 比例是 0 的時候畫出來就是一條空槽，看起來跟沒反應一樣，而那正是讀者最想知道
+  // 「到底有沒有按到」的時候。
+  const { root } = await load({ holdAdd: true });
+  clickButton(root, '全部存到裝置');
+  await tick(10);
+
+  const track = root.querySelector('.ol-progress__track');
+  assert.ok(track, '沒有畫出進度條');
+  assert.ok(
+    track.classList.contains('ol-progress__track--idle'),
+    '第一筆回報還沒到，進度條卻是靜止的'
+  );
+});
+
+test('回報進來之後進度條切成實際比例', async () => {
+  const { root } = await load();
+  clickButton(root, '全部存到裝置');
+  await tick(30);
+
+  // 工作跑完了，進度條收掉，按鈕也回到原本的樣子
+  assert.equal(root.querySelector('.ol-progress__track'), null);
+  const still = root.querySelectorAll('button').find((b) => b.textContent.includes('處理中'));
+  assert.equal(still, undefined, '工作結束了按鈕還卡在處理中');
 });
 
 test('進度與完成訊息都在底部那條裡，不是散在頁面頂端', async () => {

--- a/tools/test_update_banner.mjs
+++ b/tools/test_update_banner.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * 換版提示卡片的單元測試。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * 按下「更新」到頁面真的換好，中間是 service worker 的 activate 加一次完整的
+ * 導覽：清掉舊快取、重新取得整頁。網路好的時候那是一瞬間，網路差的時候是好幾秒
+ * 的空白，而卡片上原本什麼都不會變。讀者的合理反應是再按一次，每按一次就多送
+ * 一則 SKIP_WAITING，而他要的那件事其實早就在跑了。
+ *
+ * 這種問題只在慢網路上看得出來，本機開發永遠碰不到，所以值得有測試守著。
+ *
+ * === 怎麼驗 ===
+ *
+ * 跟 test_lang_preference.mjs 同一套做法，把 showUpdateBanner 與它用得到的那幾樣
+ * 從 overrides/base.html 原地抽出來執行，不重寫一份。DOM 用最小替身，只實作這段
+ * 真正用到的那幾個方法。
+ *
+ * 用法：
+ *   node tools/test_update_banner.mjs
+ * 不需要建置產物，也沒有外部相依。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const BASE = path.join(HERE, '..', 'docs', 'overrides', 'base.html');
+const src = fs.readFileSync(BASE, 'utf8');
+
+const grab = (re) => {
+  const m = src.match(re);
+  if (!m) throw new Error(`base.html 裡找不到 ${re}`);
+  return m[0];
+};
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.attributes = {};
+    this.className = '';
+    this.disabled = false;
+    this._text = '';
+    this._handlers = {};
+  }
+  set textContent(v) {
+    this._text = v == null ? '' : String(v);
+    this.children = [];
+  }
+  get textContent() {
+    if (this.children.length) return this._text + this.children.map((c) => c.textContent).join('');
+    return this._text;
+  }
+  appendChild(node) {
+    this.children.push(node);
+    return node;
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+  }
+  addEventListener(type, fn) {
+    this._handlers[type] = fn;
+  }
+  click() {
+    if (this._handlers.click) this._handlers.click();
+  }
+  get descendants() {
+    return this.children.flatMap((c) => [c, ...c.descendants]);
+  }
+  find(pred) {
+    return this.descendants.find(pred);
+  }
+}
+
+const load = () => {
+  const created = [];
+  const document = {
+    createElement: (tag) => {
+      const el = new FakeElement(tag);
+      created.push(el);
+      return el;
+    },
+    // 純文字節點只需要撐住 textContent 與 appendChild 的介面
+    createTextNode: (text) => {
+      const node = new FakeElement('#text');
+      node.textContent = text;
+      return node;
+    },
+    // 卡片還沒掛上去，所以永遠回 null，那正是要走的那條路
+    getElementById: () => null,
+  };
+  const sessionStorage = { getItem: () => null, setItem: () => {} };
+  let toasted = null;
+  const window = { __anoniToast: (node) => { toasted = node; return () => {}; } };
+
+  const harness = `
+    ${grab(/var STRINGS = \{[\s\S]*?\n          \};/)}
+    var t = STRINGS["zh-TW"];
+    var DISMISS_KEY = "anoni-docs-update-dismissed";
+    var reloadOnTakeover = false;
+    ${grab(/function actionButton\(label, primary, onClick\) \{[\s\S]*?\n          \}/)}
+    ${grab(/function showUpdateBanner\(waiting\) \{[\s\S]*?\n          \}/)}
+    return { showUpdateBanner: showUpdateBanner, reloaded: function () { return reloadOnTakeover; } };
+  `;
+  const api = new Function('document', 'sessionStorage', 'window', harness)(
+    document, sessionStorage, window
+  );
+
+  const sent = [];
+  const waiting = { postMessage: (m) => sent.push(m) };
+  api.showUpdateBanner(waiting);
+  const banner = toasted;
+  const buttonBy = (text) =>
+    banner.find((n) => n.tagName === 'button' && n.textContent.includes(text));
+  return { api, banner, sent, buttonBy };
+};
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test('卡片畫出更新與稍後兩顆', () => {
+  const { buttonBy } = load();
+  assert.ok(buttonBy('更新'), '找不到更新按鈕');
+  assert.ok(buttonBy('稍後'), '找不到稍後按鈕');
+});
+
+test('按下更新會送出 SKIP_WAITING', () => {
+  const { buttonBy, sent, api } = load();
+  buttonBy('更新').click();
+  assert.deepEqual(sent, [{ type: 'SKIP_WAITING' }]);
+  assert.equal(api.reloaded(), true, '沒有標記接管後要重新載入');
+});
+
+test('按下更新之後那顆按鈕停用並顯示更新中', () => {
+  // activate 加一次完整導覽，網路差的時候是好幾秒的空白。按鈕沒有變化的話讀者
+  // 會以為沒按到而重複按，每按一次就多送一則 SKIP_WAITING。
+  const { buttonBy } = load();
+  const update = buttonBy('更新');
+  update.click();
+
+  assert.equal(update.disabled, true, '按下之後還能再按');
+  assert.ok(update.textContent.includes('更新中'), update.textContent);
+  assert.ok(
+    update.children.some((c) => c.className === 'anoni-banner-spinner'),
+    '按鈕上沒有轉圈'
+  );
+  assert.equal(update.getAttribute('aria-busy'), 'true', '讀螢幕的人拿不到狀態');
+});
+
+test('按下更新之後稍後也停用', () => {
+  // 那顆會關掉卡片，可是更新已經送出去了，頁面照樣會在幾秒後自己重新載入，
+  // 關掉只會讓那次重載變得莫名其妙。
+  const { buttonBy } = load();
+  const later = buttonBy('稍後');
+  buttonBy('更新').click();
+  assert.equal(later.disabled, true, '更新跑著的時候還能按稍後');
+});
+
+test('沒按更新之前兩顆都是可以按的', () => {
+  const { buttonBy } = load();
+  assert.equal(buttonBy('更新').disabled, false);
+  assert.equal(buttonBy('稍後').disabled, false);
+});
+
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    passed++;
+    console.log('  ✓ ' + name);
+  } catch (err) {
+    failed++;
+    console.error('  ✗ ' + name);
+    console.error('    ' + String(err.message).split('\n').join('\n    '));
+  }
+}
+
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## 回報

在網路很差的地方按下按鈕沒有任何動靜,不知道請求送出去了沒,於是一直重複按。換版提示的「更新」也一樣。

## 兩處各有各的問題

**離線管理頁**:進度條其實有畫出來,但 `done` 還是 0 的時候比例是 0%,畫出來是一條靜止的空槽,跟沒反應看起來一樣。網路差的時候第一筆回報要等好幾秒,那正是讀者最想知道「到底有沒有按到」的時候。

```js
if (task.total > 0) {
  fillBar.style.width = Math.round((task.done / task.total) * 100) + "%";  // done=0 → 0%
} else {
  track.classList.add("ol-progress__track--idle");   // 只有清除走得到掃動動畫
}
```

**換版提示**:完全沒有回饋。從送出 `SKIP_WAITING` 到頁面重新載入,中間是 `activate` 加一次完整導覽,卡片上什麼都不會變,每多按一次就多送一則訊息。

## 改了什麼

- 進度條在收到第一筆回報之前用來回掃動,第一筆到了才切成實際比例
- 正在跑的那顆按鈕自己轉,文字換成狀態（處理中、更新中、清除中）並帶 `aria-busy`。進度條 sticky 在畫面下緣,而讀者的視線停在剛按下的那顆按鈕上
- 換版提示按下更新後,那顆換成轉圈的「更新中」並停用。「稍後」一起停掉:那顆會關掉卡片,可是更新已經送出去了,頁面照樣會自己重新載入,關掉只會讓那次重載變得莫名其妙
- 兩處的轉圈都在 `prefers-reduced-motion` 底下停掉

## 新增的測試檔

`tools/test_update_banner.mjs`,把 `showUpdateBanner` 從 `base.html` 原地抽出來在假 DOM 上跑,跟 `test_lang_preference.mjs` 同一套做法。已掛進 `tools-tests.yml`。

這種問題只在慢網路上看得出來,本機開發永遠碰不到,所以值得有測試守著。

## 驗證

```
node tools/test_offline_library.mjs  # 37 通過,0 失敗（原 34）
node tools/test_update_banner.mjs    # 5 通過,0 失敗（新增）
node tools/test_sw_offline.mjs       # 81 通過,0 失敗
node tools/test_lang_preference.mjs  # 6 通過,0 失敗
node tools/check_invisible_chars.mjs # 901 個檔案,乾淨
python3 tools/docs_style_lint.py …   # 0 error、0 warn
```

進度條改回無條件比例是 1 條紅,`taskButton` 退回普通 button 是 1 條紅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)