### PR TITLE
feat(tools): 會讓讀者等待的互動一律加上轉圈，轉圈本身收斂成一份

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -85,6 +85,10 @@ jobs:
       - name: 換版提示按下更新之後的狀態
         run: node tools/test_update_banner.mjs
 
+      # 每一個會讓讀者等待的互動都要在等的時候讓畫面說一聲，慢裝置上才不會像當掉
+      - name: 忙碌回饋的覆蓋檢查
+        run: node tools/test_busy_feedback.mjs
+
       # 語言切換器不列出目前語系，但那一筆要留在 DOM 裡給偏好轉址與語言選擇卡片用
       - name: 語言切換器藏起目前語系
         run: python3 tools/test_lang_switcher.py

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -174,12 +174,19 @@
           cursor: default;
         }
         /*
-          按下之後那顆按鈕自己轉。送出 SKIP_WAITING 到 controllerchange 之間，
-          service worker 要跑完 activate、清掉舊快取，接著整頁重新載入，網路差的
-          時候那是好幾秒的空白。原本按鈕上什麼都沒變，讀者只會以為沒按到，再按
-          一次，而每按一次就多送一則訊息。
+          全站共用的忙碌轉圈。定義在這裡而不是各工具自己寫一份：站上的小工具有
+          八支，每一支都在自己的 JS 裡注入樣式，各寫一份 keyframes 只會讓「轉多快、
+          多大顆、reduced-motion 要不要停」在八個地方各自漂移。
+
+          用途是同一件事：按下之後有段時間沒有結果可以顯示。換版提示按下更新到
+          頁面真的換好，中間是 activate 加一次完整導覽；移除中繼資料要讀完整個
+          檔案再重編一次；解 QR 要先把圖解開。網路或裝置慢的時候那都是好幾秒的
+          空白，而畫面上什麼都不動，讀者只會以為沒按到，再按一次。
+
+          尺寸用 em，跟著按鈕或那行字的字級走。currentColor 讓它自動配合底色，
+          填色按鈕上是白的，一般文字旁邊是文字色。
         */
-        .anoni-banner-spinner {
+        .anoni-spinner {
           display: inline-block;
           width: .75em;
           height: .75em;
@@ -188,13 +195,15 @@
           border-top-color: transparent;
           border-radius: 50%;
           animation: anoni-spin .7s linear infinite;
+          vertical-align: -.05em;
           flex: none;
         }
         @keyframes anoni-spin {
           to { transform: rotate(360deg); }
         }
         @media (prefers-reduced-motion: reduce) {
-          .anoni-banner-spinner { animation: none; opacity: .6; }
+          /* 不轉了還是要看得出跟平常不一樣，留一個淡掉的圈 */
+          .anoni-spinner { animation: none; opacity: .6; }
         }
       </style>
     {% endblock %}
@@ -518,7 +527,7 @@
               laterButton.disabled = true;
               updateButton.textContent = "";
               var spinner = document.createElement("span");
-              spinner.className = "anoni-banner-spinner";
+              spinner.className = "anoni-spinner";
               spinner.setAttribute("aria-hidden", "true");
               updateButton.appendChild(spinner);
               updateButton.appendChild(document.createTextNode(t.updating));

--- a/docs/zh-TW/js/leaks.js
+++ b/docs/zh-TW/js/leaks.js
@@ -498,6 +498,7 @@
       timeout: "你允許了，但等了十五秒還沒定出位置",
       askTitle: "下面這一項要你按了才會問",
       askButton: "顯示我的位置",
+      asking: "等待授權",
       askNote: "按下去瀏覽器會跳出授權視窗。允許之後畫面上會顯示你的經緯度與誤差範圍，只顯示在畫面上，不會送出也不會存起來。重新整理就沒了。",
       note: "以上全部在你的瀏覽器裡取得，沒有送出任何一項，也沒有寫進任何儲存。斷網時照樣讀得出來，沒有網路，這些值當然無處可送。刻意不提供匯出，匯出的檔案本身就是一份完整的指紋。",
       prefs: { dark: "深色模式", motion: "減少動態", contrast: "高對比", forced: "強制色彩" },
@@ -571,6 +572,7 @@
       timeout: "你允许了，但等了十五秒还没定出位置",
       askTitle: "下面这一项要你按了才会问",
       askButton: "显示我的位置",
+      asking: "等待授权",
       askNote: "按下去浏览器会跳出授权窗口。允许之后画面上会显示你的经纬度与误差范围，只显示在画面上，不会送出也不会存起来。刷新就没了。",
       note: "以上全部在你的浏览器里取得，没有送出任何一项，也没有写进任何存储。断网时照样读得出来，没有网络，这些值当然无处可送。刻意不提供导出，导出的文件本身就是一份完整的指纹。",
       prefs: { dark: "深色模式", motion: "减少动态", contrast: "高对比", forced: "强制色彩" },
@@ -644,6 +646,7 @@
       timeout: "you allowed it, but no fix arrived within fifteen seconds",
       askTitle: "This one only runs when you press the button",
       askButton: "Show my location",
+      asking: "Waiting for permission",
       askNote: "Pressing this brings up the browser's permission prompt. If you allow it, this page receives your latitude, longitude and accuracy, shows them on screen, and neither sends nor stores them. Reload and they are gone.",
       note: "Everything above was read inside your browser. None of it was sent anywhere and none of it was written to storage. This page still works with the network off, which is itself the proof that nothing is being sent. There is deliberately no export button: such a file would be a complete fingerprint sitting on your device.",
       prefs: { dark: "dark mode", motion: "reduced motion", contrast: "high contrast", forced: "forced colours" },
@@ -805,7 +808,15 @@
       const button = el("button", null, t.askButton);
       button.type = "button";
       button.addEventListener("click", () => {
+        // 只把按鈕變灰，讀者不知道是按到了還是壞了。授權視窗跳出來之前有一段空白，
+        // 而他允許之後還要等瀏覽器把座標算出來，那在室內可能是好幾秒。
         button.disabled = true;
+        button.textContent = "";
+        const spin = el("span", "anoni-spinner");
+        spin.setAttribute("aria-hidden", "true");
+        button.appendChild(spin);
+        button.appendChild(document.createTextNode(t.asking));
+        button.setAttribute("aria-busy", "true");
         Promise.resolve()
           .then(() => probe.read(t))
           .then((value) => ask.replaceWith(renderItem(probe, value)))

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -120,16 +120,6 @@
     #offline-library .ol-progress__track--idle .ol-progress__fill {
       width: 30%; animation: ol-sweep 1.1s ease-in-out infinite;
     }
-    /* 正在跑的那顆按鈕自己轉。進度條 sticky 在畫面下緣，而讀者的視線停在剛按下
-       的按鈕上，網路差的時候那裡好幾秒都沒有動靜，人就會再按一次。 */
-    #offline-library .ol-spinner {
-      display: inline-block;
-      width: .75em; height: .75em; margin-right: .4em;
-      border: .1em solid currentColor; border-top-color: transparent;
-      border-radius: 50%; animation: ol-spin .7s linear infinite;
-      vertical-align: -.05em; flex: none;
-    }
-    @keyframes ol-spin { to { transform: rotate(360deg); } }
     #offline-library .ol-progress__text {
       margin: .3rem 0 0; font-size: .7rem; opacity: .8;
     }
@@ -150,7 +140,6 @@
       #offline-library .ol-progress__track--idle .ol-progress__fill {
         width: 100%; animation: none;
       }
-      #offline-library .ol-spinner { animation: none; opacity: .6; }
     }
     #offline-library .ol-primary {
       border-color: var(--md-primary-fg-color);
@@ -489,7 +478,8 @@
     const running = state.task && state.task.key === key;
     const node = button(running ? "" : label, className, onClick);
     if (!running) return node;
-    const spin = el("span", "ol-spinner");
+    // 轉圈用全站共用的那顆，樣式定義在 overrides/base.html
+    const spin = el("span", "anoni-spinner");
     spin.setAttribute("aria-hidden", "true");
     node.appendChild(spin);
     node.appendChild(document.createTextNode(state.task.label));

--- a/docs/zh-TW/js/passphrase.js
+++ b/docs/zh-TW/js/passphrase.js
@@ -570,7 +570,17 @@
     if (state.mode === "dice" && !state.rolled.length) {
       out.textContent = state.words === false ? t.failed : t.diceEmpty;
     } else if (state.mode === "phrase" && !state.words) {
-      out.textContent = state.words === false ? t.failed : t.loading;
+      if (state.words === false) {
+        out.textContent = t.failed;
+      } else {
+        // 詞表有七千多個詞，慢的連線上要等一會，而那行字不會動，讀者分不出是
+        // 還在抓還是壞了。抓完會自己 render 一次，這裡不必收尾。
+        const spin = el("span", "anoni-spinner");
+        spin.setAttribute("aria-hidden", "true");
+        out.appendChild(spin);
+        out.appendChild(document.createTextNode(t.loading));
+        out.setAttribute("aria-busy", "true");
+      }
     } else if (!state.value && state.mode === "password") {
       out.textContent = t.charsetEmpty;
     } else {

--- a/docs/zh-TW/js/qrread.js
+++ b/docs/zh-TW/js/qrread.js
@@ -822,7 +822,18 @@
     picker.accept = "image/*";
     picker.addEventListener("change", () => handle(picker.files && picker.files[0]));
 
-    const drop = el("div", "qd-drop", state.status === "reading" ? t.reading : t.drop);
+    // 解讀中要看得出在跑。整張圖解開再掃過一次，大張的照片在手機上是好幾秒，
+    // 而原本只有一行不會動的字，讀者分不出是在做事還是卡住了。
+    const drop = el("div", "qd-drop");
+    if (state.status === "reading") {
+      const spin = el("span", "anoni-spinner");
+      spin.setAttribute("aria-hidden", "true");
+      drop.appendChild(spin);
+      drop.appendChild(document.createTextNode(t.reading));
+      drop.setAttribute("aria-busy", "true");
+    } else {
+      drop.textContent = t.drop;
+    }
     drop.addEventListener("click", () => picker.click());
     drop.addEventListener("dragover", (event) => {
       event.preventDefault();

--- a/docs/zh-TW/js/stripmeta.js
+++ b/docs/zh-TW/js/stripmeta.js
@@ -972,6 +972,11 @@
   // 第一次遇到 PDF 要先把函式庫抓回來，那段時間畫面要說一聲
   let loadingLib = false;
 
+  // 正在處理第幾個檔案。移除中繼資料要把整個檔案讀進來、重編一次、再解一次驗證，
+  // 大一點的圖或影片在手機上是好幾秒，而畫面原本從按下到全部做完都不會動，讀者
+  // 只能猜是不是當掉了。t.working 這個字串本來就在，之前沒有人用上。
+  let working = null;
+
   function release() {
     for (const item of files) {
       if (item.url) URL.revokeObjectURL(item.url);
@@ -1083,6 +1088,23 @@
     root.appendChild(formats);
 
     if (loadingLib) root.appendChild(el("p", "sm-loading", t.loadingLib));
+    if (working) {
+      const line = el("p", "sm-loading");
+      // 轉圈用全站共用的那顆，樣式定義在 overrides/base.html
+      const spin = el("span", "anoni-spinner");
+      spin.setAttribute("aria-hidden", "true");
+      line.appendChild(spin);
+      line.appendChild(document.createTextNode(
+        working.total > 1
+          ? t.working + "　" + working.done + " / " + working.total + "　" + working.name
+          : t.working + "　" + working.name
+      ));
+      // 轉圈對讀螢幕的人沒有意義。aria-busy 說「這一塊還在做事」，aria-live 讓
+      // 換到下一個檔案的時候把檔名唸出來，兩件事各自要一個屬性。
+      line.setAttribute("aria-busy", "true");
+      line.setAttribute("aria-live", "polite");
+      root.appendChild(line);
+    }
     for (const item of files) root.appendChild(renderFile(item));
 
     if (files.length) {
@@ -1204,6 +1226,7 @@
         break;
       }
     }
+    let index = 0;
     for (const file of list) {
       const okType = !file.type || file.type.indexOf("image/") === 0 ||
         file.type.indexOf("video/") === 0 || file.type === "application/pdf";
@@ -1211,8 +1234,16 @@
         files.push({ ok: false, name: file.name, reason: "notImage" });
         continue;
       }
+      index += 1;
+      // 先讓畫面說一聲再開始做。handleOne 從頭到尾不回到事件迴圈，不先畫出來的話
+      // 讀者看到的是一個凍住的頁面，而多檔案時他連做到第幾個都不知道。
+      working = { done: index, total: list.length, name: file.name };
+      render();
+      // 交還主執行緒，讓那一行先畫出來
+      await new Promise((next) => setTimeout(next, 0));
       files.push(await handleOne(file));
     }
+    working = null;
     loadingLib = false;
     render();
   }

--- a/tools/test_busy_feedback.mjs
+++ b/tools/test_busy_feedback.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * 忙碌回饋的覆蓋檢查。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * 站上每一個「按下去之後有段時間沒有結果可以顯示」的地方，都要在那段時間裡讓
+ * 畫面說一聲。少了那一聲，讀者看到的是一個不動的頁面，合理的反應是再按一次，
+ * 而他要的那件事其實早就在跑了。移除中繼資料會被重跑一遍整個檔案，換版提示會
+ * 多送幾則 SKIP_WAITING。
+ *
+ * 這種問題只在慢裝置與慢網路上看得出來，本機開發永遠碰不到，改動的人不會知道
+ * 自己弄丟了什麼。2026-08-29 的回報就是這樣來的：離線管理頁的進度條在收到第一
+ * 筆回報之前是一條靜止的空槽，而 stripmeta 定義了 working 這個字串卻從來沒有
+ * 用上，兩者都通過了當時的全部測試。
+ *
+ * === 怎麼驗 ===
+ *
+ * 逐檔檢查兩件事：轉圈用的是全站共用的 .anoni-spinner（樣式定義在
+ * overrides/base.html，不要各自再寫一份 keyframes），以及狀態有用 aria-busy
+ * 講出來，轉圈的圖案對讀螢幕的人沒有意義。
+ *
+ * 清單是人工維護的。新增一個會等待的互動時，把它加進來。
+ *
+ * 用法：
+ *   node tools/test_busy_feedback.mjs
+ * 不需要建置產物，也沒有外部相依。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DOCS = path.join(HERE, '..', 'docs');
+
+// 每一筆都是一個會讓讀者等待的互動。why 寫的是「等的是什麼」，方便後來的人
+// 判斷自己的改動有沒有動到這件事。
+const WAITS = [
+  {
+    file: 'overrides/base.html',
+    why: '換版提示按下更新之後，activate 加一次完整導覽',
+  },
+  {
+    file: 'zh-TW/js/offline-library.js',
+    why: '整批下載，一次四百多個請求',
+  },
+  {
+    file: 'zh-TW/js/stripmeta.js',
+    why: '把整個檔案讀進來、重編一次、再解一次驗證',
+  },
+  {
+    file: 'zh-TW/js/qrread.js',
+    why: '整張圖解開再掃過一次',
+  },
+  {
+    file: 'zh-TW/js/leaks.js',
+    why: '授權視窗跳出來，加上瀏覽器把座標算出來',
+  },
+  {
+    file: 'zh-TW/js/passphrase.js',
+    why: '七千多個詞的詞表要抓回來',
+  },
+];
+
+const read = (rel) => fs.readFileSync(path.join(DOCS, rel), 'utf8');
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+for (const entry of WAITS) {
+  test(`${entry.file} 等待的時候有轉圈（${entry.why}）`, () => {
+    const src = read(entry.file);
+    assert.ok(
+      src.includes('anoni-spinner'),
+      '沒有用到全站共用的轉圈。樣式在 overrides/base.html，不要各自再寫一份'
+    );
+    assert.ok(
+      src.includes('aria-busy'),
+      '轉圈的圖案對讀螢幕的人沒有意義，狀態要用 aria-busy 講出來'
+    );
+  });
+}
+
+test('轉圈只定義一次，在 overrides/base.html', () => {
+  // 八支小工具各自在 JS 裡注入樣式，各寫一份 keyframes 只會讓「轉多快、多大顆、
+  // reduced-motion 要不要停」在八個地方各自漂移。
+  const base = read('overrides/base.html');
+  assert.ok(base.includes('.anoni-spinner {'), 'base.html 裡找不到 .anoni-spinner 的定義');
+  assert.ok(base.includes('@keyframes anoni-spin'), '找不到轉圈的 keyframes');
+
+  const dupes = [];
+  for (const entry of WAITS) {
+    if (entry.file === 'overrides/base.html') continue;
+    if (/@keyframes\s+[\w-]*spin/i.test(read(entry.file))) dupes.push(entry.file);
+  }
+  assert.deepEqual(dupes, [], '這些檔案自己又寫了一份轉圈的 keyframes');
+});
+
+test('轉圈在 prefers-reduced-motion 底下停下來', () => {
+  // 會被動態干擾的人不只是偏好問題，前庭系統的症狀是真的不舒服
+  // base.html 裡不只一個 reduced-motion 區塊（toast 的進場動畫也有一個），
+  // 所以要掃過每一個，不能只看第一個。
+  const base = read('overrides/base.html');
+  const blocks = [...base.matchAll(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n        \}/g)];
+  assert.ok(blocks.length, '找不到 prefers-reduced-motion 的區塊');
+  assert.ok(
+    blocks.some((b) => /\.anoni-spinner\s*\{[^}]*animation:\s*none/.test(b[0])),
+    'reduced-motion 底下轉圈沒有停'
+  );
+});
+
+test('stripmeta 的 working 字串真的有用上', () => {
+  // 三個語系都定義了這個字串，卻一直沒有人使用它，而那正是處理檔案時該顯示的
+  // 那一行。定義了沒用的字串在 code review 裡看不出來，只有讀者會發現。
+  const src = read('zh-TW/js/stripmeta.js');
+  assert.ok(/working:\s*"/.test(src), '找不到 working 這個字串');
+  assert.ok(src.includes('t.working'), 'working 定義了卻沒有任何地方用它');
+});
+
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    passed++;
+    console.log('  ✓ ' + name);
+  } catch (err) {
+    failed++;
+    console.error('  ✗ ' + name);
+    console.error('    ' + String(err.message).split('\n').join('\n    '));
+  }
+}
+
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -668,7 +668,7 @@ test('按下之後那顆按鈕自己轉起來，不必等第一筆回報', async
 
   const busy = root.querySelectorAll('button').find((b) => b.textContent.includes('處理中'));
   assert.ok(busy, '按下之後沒有任何一顆按鈕顯示狀態');
-  assert.ok(busy.querySelector('.ol-spinner'), '按鈕上沒有轉圈');
+  assert.ok(busy.querySelector('.anoni-spinner'), '按鈕上沒有轉圈');
   assert.equal(busy.getAttribute('aria-busy'), 'true', '讀螢幕的人拿不到狀態');
 });
 

--- a/tools/test_update_banner.mjs
+++ b/tools/test_update_banner.mjs
@@ -149,7 +149,7 @@ test('按下更新之後那顆按鈕停用並顯示更新中', () => {
   assert.equal(update.disabled, true, '按下之後還能再按');
   assert.ok(update.textContent.includes('更新中'), update.textContent);
   assert.ok(
-    update.children.some((c) => c.className === 'anoni-banner-spinner'),
+    update.children.some((c) => c.className === 'anoni-spinner'),
     '按鈕上沒有轉圈'
   );
   assert.equal(update.getAttribute('aria-busy'), 'true', '讀螢幕的人拿不到狀態');


### PR DESCRIPTION
## 掃描結果

全站八支小工具,`@keyframes` 數量全是 0,沒有任何一支有動畫。等待期間的回饋不是沒有就是一行不會動的字。

| 工具 | 等的是什麼 | 原本的回饋 |
|---|---|---|
| `stripmeta.js` | 讀完整個檔案、重編一次、再解一次驗證 | 只有「第一次抓 PDF 函式庫」有一行字 |
| `leaks.js` | 授權視窗加座標計算 | 按鈕只 `disabled = true` |
| `qrread.js` | 整張圖解開再掃過一次 | 一行不會動的「解讀中」 |
| `passphrase.js` | 七千多個詞的詞表 | 一行不會動的「詞表載入中」 |

## `stripmeta.js` 有兩個獨立的問題

`working: "處理中"` 三個語系都定義了,**全檔沒有任何一處使用它**。

而處理迴圈是這樣:

```js
for (const file of list) {
  files.push(await handleOne(file));   // 中間沒有 render()
}
render();                              // 全部做完才畫一次
```

拖進一張大圖或幾個檔案,畫面從按下到全部做完都不會動。

## 改了什麼

- 轉圈抽成全站共用的 `.anoni-spinner`,定義在 `overrides/base.html`。原本各工具各自在 JS 裡注入樣式,八份 keyframes 只會讓「轉多快、多大顆、reduced-motion 要不要停」各自漂移。`offline-library.js` 那份也改用它,少一份重複
- `stripmeta`:用上那個字串,逐檔顯示「處理中　n / N　檔名」,每檔開始前先 render 並讓出主執行緒
- `leaks`:按下的按鈕顯示轉圈與「等待授權」
- `qrread`、`passphrase`:既有的狀態文字加上轉圈

三語系的這些 js 都是指向 `zh-TW` 的 symlink,改一份三處到位。

## 新增的測試

`tools/test_busy_feedback.mjs`,逐檔檢查每一個會等待的互動都有共用的轉圈與 `aria-busy`,並確認沒有人又自己寫一份 keyframes、reduced-motion 底下有停。清單是人工維護的,新增會等待的互動時要加進去。已掛進 `tools-tests.yml`。

那支測試當場就抓到我自己漏掉的一個:`stripmeta` 只設了 `aria-live`,沒設 `aria-busy`。

## 同步那四支沒有動

`threatmodel.js`、`invisible.js`、`cleanurl.js`、`qrcode.js` 是同步計算,不會有「請求送出去了沒」的疑問。真要處理是另一類問題（把運算切塊或丟 worker）,值得先量過再決定,這個 PR 沒有碰。

## 驗證

```
node tools/test_busy_feedback.mjs    # 9 通過,0 失敗（新增）
node tools/test_stripmeta.mjs        # 52 通過,0 失敗
node tools/test_qrread.mjs           # 55 通過,0 失敗
node tools/test_leaks.mjs            # 32 通過,0 失敗
node tools/test_passphrase.mjs       # 25 通過,0 失敗
node tools/test_offline_library.mjs  # 37 通過,0 失敗
node tools/test_update_banner.mjs    # 5 通過,0 失敗
node tools/check_invisible_chars.mjs # 902 個檔案,乾淨
python3 tools/docs_style_lint.py …   # 0 error、0 warn
```

四支工具各自拿掉轉圈都是 1 條紅,拿掉 reduced-motion 也是 1 條紅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)