### PR TITLE
fix(start): 修掉說明句宣稱但目標頁沒有的內容，並讓這類問題驗得出來

### DIFF
--- a/docs/en/community/upload-sensitive.md
+++ b/docs/en/community/upload-sensitive.md
@@ -1,6 +1,6 @@
 ---
 title: Sending Us Sensitive Material
-description: How to send personal data, leaked material, or sensitive collaboration files to the anoni.net community using our self-hosted Send instance, with OnionShare as an alternative for higher-risk cases.
+description: How to send personal data, leaked material, or sensitive collaboration files to the anoni.net community using our self-hosted Send instance, with one-time download, expiry, and an agreed password.
 icon: material/file-lock
 ---
 # :material-file-lock: Sending Us Sensitive Material

--- a/docs/en/start/civil-society.md
+++ b/docs/en/start/civil-society.md
@@ -22,7 +22,7 @@ Fill in the [threat model checklist](../utils/threat-model.md) first. It produce
 
 They may be an employee, a directly affected person, or a witness who does not want to be identified. Ordinary forms and mailboxes leave correlatable records, and the sender has no way to assess the risk. They need a channel they can evaluate for themselves.
 
-See [sending us sensitive material](../community/upload-sensitive.md), which covers the PGP and OnionShare approaches and the trade-off between them.
+See [sending us sensitive material](../community/upload-sensitive.md), the channel the community uses itself: the file goes to a self-hosted Send instance, the link is set to expire after one download and carries an agreed password.
 
 ### Donors do not want a record, and the organization still has to issue receipts
 
@@ -47,7 +47,7 @@ See [anonymous donation channels for advocacy organizations](../scenarios/nonpro
 
 ### Intake and donations
 
-- [Sending us sensitive material](../community/upload-sensitive.md): how the receiving end should be set up
+- [Sending us sensitive material](../community/upload-sensitive.md): the channel the community uses itself, files go through a self-hosted Send instance and links expire on their own
 - [File metadata stripper](../utils/strip-metadata.md): clean files in the browser before publishing, nothing is uploaded
 - [Anonymous donation channels](../scenarios/nonprofit-anonymous-donation.md): the full workflow and its legal constraints
 

--- a/docs/en/start/developer.md
+++ b/docs/en/start/developer.md
@@ -24,7 +24,7 @@ The most direct contribution. Start with a relay; switch to a bridge if bandwidt
 
 - [How to set up a Tor relay](../community/setup-tor-relay.md): full configuration
 - [How to set up a Tor WebTunnel bridge](../community/setup-tor-webtunnel.md): far lower bandwidth requirements, and worth more in a censored environment
-- [Tor Snowflake](../tools/tor-snowflake.md): the lowest barrier of all, a browser extension and it is running
+- [Tor Snowflake](../tools/tor-snowflake.md): the lowest barrier of all, keep the page open and you are already helping; install the extension to leave it running
 - [Setting up a .onion service](../community/setup-onion-service.md): give a service you already run an onion entrance
 - [Help pin the site's IPFS mirror](../community/pin-ipfs-mirror.md): currently a single point, and each additional pin is redundancy
 - [Tor relay watcher](../regional/tor-relay-watcher.md): see how many relays exist in the region and which ASNs they sit in

--- a/docs/en/start/media.md
+++ b/docs/en/start/media.md
@@ -41,7 +41,7 @@ See [keeping multiple sources apart](../scenarios/journalist.md#Keeping-multiple
 ### Setting up intake
 
 - [OnionShare](../tools/onionshare.md): a source can send files without registering an account
-- [Sending us sensitive material](../community/upload-sensitive.md): how the receiving end should be set up, including PGP
+- [Sending us sensitive material](../community/upload-sensitive.md): the channel the community uses itself, files go through a self-hosted Send instance and links expire on their own
 - [Secure messaging compared](../tools/messaging-comparison.md): what follow-up contact runs on
 
 ### Retention and cleanup

--- a/docs/zh-CN/community/tools.md
+++ b/docs/zh-CN/community/tools.md
@@ -1,14 +1,18 @@
 ---
 title: 沟通与协作工具
-description: Matrix、Cryptpad、Jitsi 使用说明与帐号申请
+description: anoni.net 自架的 Matrix、Cryptpad、Etherpad、SearXNG、Send、Formbricks，以及搭配的外部 Jitsi，给社群讨论、共笔、搜索、传文件、表单等协作场景使用。
 icon: material/message-text
 ---
 
 # :material-message-text: 沟通与协作工具
 
-社区使用 **Matrix** 做日常讨论、**Cryptpad** 做加密协作文档、**Jitsi** 做在线视频会议。以下是入口与使用方式以及帐号申请方式。
+社群自架 Matrix、Cryptpad、Etherpad、SearXNG、Send、Formbricks 6 个服务，搭配外部 Jitsi 做在线会议。自架的目的是减少对第三方的依赖、保留数据主权，也为社群讨论与敏感协作提供可信任的基础设施。
 
-## Matrix（即时讨论）
+关于我们为什么自架 Matrix（与背后的隐私取舍），可参考 [从 Discord 年龄验证谈起：我们为什么自架 Matrix](../blog/posts/2026-discord-matrix-statement.md)。
+
+## 即时沟通与长期协作
+
+### Matrix（即时讨论）
 
 - **用途**：日常讨论、表达主题意愿、各主题 room 讨论与活动协调
 - **主服务器（homeserver）**：`im.anoni.net`
@@ -22,7 +26,7 @@ icon: material/message-text
 - **建议加入**：社区设有 **[Public Space](https://matrix.to/#/#community:im.anoni.net)**，可一次加入社区相关 rooms。
 - **如何加入**：注册后在 Element 中打开上述 Space 链接加入，或根据需要加入单独的 rooms。
 
-## Cryptpad（加密协作文档）
+### Cryptpad（加密协作文档）
 
 - **用途**：共笔、活动共编、敏感内容加密协作
 - **入口**：社区 Cryptpad [首页](https://cryptpad.anoni.net/)
@@ -30,7 +34,42 @@ icon: material/message-text
 - **界面语言**：自 CryptPad 2026.5.0 起，「中文（简体）」与「中文（正体）」皆为内建语系，可在右上角设置页切换，或于网址加 `?lang=zh_Hans` / `?lang=zh_Hant`。社区为 zh_Hant 投入两年半上游翻译的历程见 [CryptPad 2026.5.0 上线：正体中文（zh_Hant）正式收进内建语系](../blog/posts/2026-cryptpad-zh-hant.md)。
 - **使用方式**：取得帐号后可新建 pad、分享链接、设置权限（仅查看、可编辑），活动用的共笔链接通常会在 Matrix 公布。
 
-## Jitsi（在线视频会议）
+### Etherpad（即时共笔）
+
+- **用途**：活动现场共同记录、低门槛临时笔记。内容无加密，有链接即可访问，不适合放敏感信息。
+- **入口**：[https://pad.anoni.net/](https://pad.anoni.net/){target="_blank"}
+- **帐号申请**：无须帐号，建立 pad 后分享链接即可协作。
+- **使用方式**：适合公开、可丢弃的内容。需要长期保存或加密协作时改用 Cryptpad。
+- **临时聊天场景**：当下遇到一个人但双方都不想交换 app 帐号时，可开新 pad 把 URL 给对方，使用 pad 内建的 chat sidebar 当作一次性对话空间。聊完关闭标签页、清空 pad 内容即可。注意内容无加密，server 端理论上仍可看到。
+
+## 个人隐私工具
+
+### SearXNG（隐私搜索）
+
+- **用途**：聚合多个搜索引擎，不留记录、无广告、无第三方 cookie。
+- **入口**：[https://search.anoni.net/](https://search.anoni.net/){target="_blank"}
+- **帐号申请**：无须帐号。
+- **使用方式**：可在浏览器设成默认搜索引擎。URL 直接加 `?q=keyword` 也能搜索。
+
+### Send（端到端加密文件分享）
+
+- **用途**：暂时性的加密文件传递，链接可设密码、下载次数与过期时间。
+- **入口**：[https://send.anoni.net/](https://send.anoni.net/){target="_blank"}
+- **帐号申请**：无须帐号（依设置，登录帐号通常可获得更大配额与更长保留时间）。
+- **使用方式**：上传文件、选择有效期、设置下载次数，视需要再加密码，最后分享链接。逾期或达下载次数上限后即删除。
+
+## 社群运作工具
+
+### Formbricks（隐私表单）
+
+- **用途**：订阅表单、活动报名、社群反馈收集。自架可避免被第三方表单服务追踪，目前 newsletter 订阅即通过此服务。
+- **入口**：[https://form.anoni.net/](https://form.anoni.net/){target="_blank"}
+- **帐号申请**：填表者直接打开链接填写，无须帐号。维运者要建立新表单请来信 <whisper@anoni.net> 申请后台帐号。
+- **使用方式**：建立后分享链接即可收集回应，后台可看回应汇总与导出。
+
+## 在线会议（外部）
+
+### Jitsi（在线视频）
 
 - **用途**：线上会议（主题讨论、定期同步）
 - **服务**：[https://jitsi.goodmeet.asia/](https://jitsi.goodmeet.asia/){target="_blank"}（免费使用，第三方提供、非社区自架，条款与可用性依对方为准）。

--- a/docs/zh-CN/community/upload-sensitive.md
+++ b/docs/zh-CN/community/upload-sensitive.md
@@ -1,6 +1,6 @@
 ---
 title: 上传机敏信息流程
-description: 机敏数据上传给 anoni.net 社群的安全流程，含 PGP 公钥与 OnionShare 替代方案。给需要安全传递个资、爆料素材或敏感文件的华语社群成员与外部协作者。
+description: 机敏数据上传给 anoni.net 社群的安全流程，走社群自架的 Send，链接设成一次下载就失效并加上密码。给需要安全传递个资、爆料素材或敏感文件的华语社群成员与外部协作者。
 icon: material/file-lock
 ---
 # :material-file-lock: 上传机敏信息流程

--- a/docs/zh-CN/start/civil-society.md
+++ b/docs/zh-CN/start/civil-society.md
@@ -22,7 +22,7 @@ icon: material/account-group
 
 对方可能是体制内的员工、当事人，或不想曝光的目击者。一般的表单与邮箱会留下可比对的记录，对方需要一条能自己判断风险的通道。
 
-看 [上传机敏信息流程](../community/upload-sensitive.md)，里面有 PGP 与 OnionShare 两种做法的取舍。
+看 [上传机敏信息流程](../community/upload-sensitive.md)，社群自己在用的那条通道就是这样做的：文件传上自架的 Send，链接设成一次下载就失效并加上密码，再把链接给收件人。
 
 ### 捐款人不想留下记录，组织仍需开立收据
 
@@ -47,7 +47,7 @@ icon: material/account-group
 
 ### 对外的线索与捐款
 
-- [上传机敏信息流程](../community/upload-sensitive.md)：收件端该怎么准备
+- [上传机敏信息流程](../community/upload-sensitive.md)：社群自己在用的那条通道，文件走自架的 Send，链接会自动失效
 - [文件 metadata 清除器](../utils/strip-metadata.md)：发布素材前在浏览器里清干净，文件不会送出去
 - [倡议组织的匿名捐款渠道](../scenarios/nonprofit-anonymous-donation.md)：完整流程与法规限制
 

--- a/docs/zh-CN/start/developer.md
+++ b/docs/zh-CN/start/developer.md
@@ -24,7 +24,7 @@ icon: material/console
 
 - [如何搭建 Tor Relay](../community/setup-tor-relay.md)：中继节点的完整设置
 - [如何搭建 Tor WebTunnel 桥接](../community/setup-tor-webtunnel.md)：桥接对带宽的要求低很多，在审查环境下的价值也更高
-- [Tor Snowflake](../tools/tor-snowflake.md)：门槛最低的一种，装一个浏览器扩展就开始运作
+- [Tor Snowflake](../tools/tor-snowflake.md)：门槛最低的一种，开着那一页就在帮忙，要常驻再装扩展
 - [如何搭建 .onion 服务](../community/setup-onion-service.md)：把手上的服务多开一个 onion 入口
 - [帮忙 pin 文件站的 IPFS 镜像](../community/pin-ipfs-mirror.md)：目前是单点，多一个 pin 就多一份备援
 - [Tor Relays 观测点](../taiwan/tor-relay-watcher.md)：先看台湾现在有多少节点、分布在哪些 ASN

--- a/docs/zh-CN/start/media.md
+++ b/docs/zh-CN/start/media.md
@@ -41,7 +41,7 @@ icon: material/newspaper-variant-outline
 ### 建立收件渠道
 
 - [OnionShare](../tools/onionshare.md)：来源不需要注册账号就能传文件给你
-- [上传机敏信息流程](../community/upload-sensitive.md)：收件端该怎么准备，含 PGP 公钥的做法
+- [上传机敏信息流程](../community/upload-sensitive.md)：社群自己在用的那条通道，文件走自架的 Send，链接会自动失效
 - [匿名通讯工具比较](../tools/messaging-comparison.md)：后续联络走哪一套
 
 ### 素材的保存与清理

--- a/docs/zh-TW/community/upload-sensitive.md
+++ b/docs/zh-TW/community/upload-sensitive.md
@@ -1,6 +1,6 @@
 ---
 title: 上傳機敏資訊流程
-description: 機敏資料上傳給 anoni.net 社群的安全流程，含 PGP 公鑰與 OnionShare 替代方案。給需要安全傳遞個資、爆料素材、或敏感檔案的台灣社群成員與外部協作者。
+description: 機敏資料上傳給 anoni.net 社群的安全流程，走社群自架的 Send，連結設成一次下載就失效並加上密碼。給需要安全傳遞個資、爆料素材、或敏感檔案的台灣社群成員與外部協作者。
 icon: material/file-lock
 ---
 # :material-file-lock: 上傳機敏資訊流程

--- a/docs/zh-TW/start/civil-society.md
+++ b/docs/zh-TW/start/civil-society.md
@@ -22,7 +22,7 @@ icon: material/account-group
 
 對方可能是體制內的員工、當事人，或不想曝光的目擊者。一般的表單與信箱會留下可比對的紀錄，對方需要一條能自己判斷風險的通道。
 
-看 [上傳機敏資訊流程](../community/upload-sensitive.md)，裡面有 PGP 與 OnionShare 兩種做法的取捨。
+看 [上傳機敏資訊流程](../community/upload-sensitive.md)，社群自己在用的那條通道就是這樣做的：檔案傳上自架的 Send，連結設成一次下載就失效並加上密碼，再把連結給收件人。
 
 ### 捐款人不想留下紀錄，組織仍需開立收據
 
@@ -47,7 +47,7 @@ icon: material/account-group
 
 ### 對外的線索與捐款
 
-- [上傳機敏資訊流程](../community/upload-sensitive.md)：收件端該怎麼準備
+- [上傳機敏資訊流程](../community/upload-sensitive.md)：社群自己在用的那條通道，檔案走自架的 Send，連結會自動失效
 - [檔案 metadata 清除器](../utils/strip-metadata.md)：發布素材前在瀏覽器裡清乾淨，檔案不會送出去
 - [倡議組織的匿名捐款管道](../scenarios/nonprofit-anonymous-donation.md)：完整流程與法規限制
 

--- a/docs/zh-TW/start/developer.md
+++ b/docs/zh-TW/start/developer.md
@@ -24,7 +24,7 @@ icon: material/console
 
 - [如何搭建 Tor Relay](../community/setup-tor-relay.md)：中繼節點的完整設定
 - [如何搭建 Tor WebTunnel 橋接](../community/setup-tor-webtunnel.md)：橋接對頻寬的要求低很多，在審查環境下的價值也更高
-- [Tor Snowflake](../tools/tor-snowflake.md)：門檻最低的一種，裝一個瀏覽器擴充套件就開始運作
+- [Tor Snowflake](../tools/tor-snowflake.md)：門檻最低的一種，開著那一頁就在幫忙，要常駐再裝擴充套件
 - [如何搭建 .onion 服務](../community/setup-onion-service.md)：把手上的服務多開一個 onion 入口
 - [幫忙 pin 文件站的 IPFS 鏡像](../community/pin-ipfs-mirror.md)：目前是單點，多一個 pin 就多一份備援
 - [Tor Relays 觀測點](../taiwan/tor-relay-watcher.md)：先看台灣現在有多少節點、分布在哪些 ASN

--- a/docs/zh-TW/start/media.md
+++ b/docs/zh-TW/start/media.md
@@ -41,7 +41,7 @@ icon: material/newspaper-variant-outline
 ### 建立收件管道
 
 - [OnionShare](../tools/onionshare.md)：來源不需要註冊帳號就能傳檔案給你
-- [上傳機敏資訊流程](../community/upload-sensitive.md)：收件端該怎麼準備，含 PGP 公鑰的做法
+- [上傳機敏資訊流程](../community/upload-sensitive.md)：社群自己在用的那條通道，檔案走自架的 Send，連結會自動失效
 - [匿名通訊工具比較](../tools/messaging-comparison.md)：後續聯絡走哪一套
 
 ### 素材的保存與清理

--- a/tools/check_start_parity.py
+++ b/tools/check_start_parity.py
@@ -67,6 +67,9 @@ RE_EMOJI_SHORTHAND = re.compile(r":[a-z0-9_+-]+:", re.IGNORECASE)
 RE_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.M)
 # ](../a/b.md#anchor) 與 ](./a.md)，只取站內的相對連結
 RE_LINK = re.compile(r"\]\((\.{1,2}/[^)\s]+)\)")
+# 連結加上後面那句說明。start/ 的寫法是 [文字](路徑)：說明，說明講的是目標頁有什麼。
+RE_CLAIM = re.compile(r"\[([^\]]+)\]\((\.\./[^)#]+\.md)\)([^\n]*)")
+RE_FRONTMATTER = re.compile(r"^---\n.*?\n---\n", re.S)
 
 
 def slugify(text: str) -> str:
@@ -211,7 +214,44 @@ def main() -> int:
                     "index.md 說那是所有身分同樣要做到的，每條路徑都要走得到"
                 )
 
-    # 五、h2 骨架，只提醒
+    # 五、說明句裡的專有名詞要在目標頁的正文出現
+    #
+    # 2026-08-30：civil-society.md 說 upload-sensitive「裡面有 PGP 與 OnionShare 兩種
+    # 做法的取捨」，而那一頁的正文從頭到尾只有社群自架 Send 的上傳流程。PGP 與
+    # OnionShare 只出現在它自己的 frontmatter description 裡，那個 description 同樣
+    # 是錯的。用 grep 掃整個檔案會命中 frontmatter 然後放行，人工 review 那次就是
+    # 這樣漏掉的，所以這裡切掉 frontmatter 只看正文。
+    #
+    # 只對中文語系跑。中文的說明句裡出現的 ASCII 詞幾乎都是專有名詞（PGP、OONI、
+    # Send、Tor），英文版的句首大寫是普通詞，抽出來只會製造雜訊，實測 en 會報
+    # Answers 與 Mainland 這種。
+    #
+    # 抓得到的是「說明句提到某個東西，目標頁一個字都沒有」。目標頁提了但講得很淺，
+    # 或者說明句用中文概括（「三題」「四封信」），這一項驗不出來，那些仍然要人看。
+    TERM = re.compile(r"\b[A-Z][A-Za-z0-9]{2,}\b")
+    # 句首大寫的普通英文詞，出現在中文說明句裡的機會很低，先擋掉最常見的幾個
+    TERM_STOP = {"The", "This", "That", "And", "For", "With", "How", "What"}
+    for lang in ("zh-TW", "zh-CN"):
+        for name, path in sorted(pages.get(lang, {}).items()):
+            for label, target, rest in RE_CLAIM.findall(path.read_text(encoding="utf-8")):
+                claim = rest.strip().lstrip("：:").strip()
+                if not claim:
+                    continue
+                dest = (path.parent / target).resolve()
+                if not dest.is_file():
+                    errors.append(f"{lang} 的 {SECTION}/{name} 連到不存在的檔案：{target}")
+                    continue
+                body = RE_FRONTMATTER.sub("", dest.read_text(encoding="utf-8"), count=1)
+                for term in sorted(set(TERM.findall(claim)) - TERM_STOP):
+                    if term in body:
+                        continue
+                    rel = dest.relative_to(DOCS / lang)
+                    errors.append(
+                        f"{lang} 的 {SECTION}/{name} 說 {rel} 有「{term}」，"
+                        f"那一篇的正文沒有提到它（frontmatter 不算）"
+                    )
+
+    # 六、h2 骨架，只提醒
     for name in sorted(base_names & set.intersection(*(set(pages[l]) for l in LANGS))):
         counts = {l: sum(1 for lv, _ in headings(pages[l][name]) if lv == 2) for l in LANGS}
         if len(set(counts.values())) > 1:

--- a/tools/test_check_start_parity.py
+++ b/tools/test_check_start_parity.py
@@ -64,6 +64,9 @@ class Harness(unittest.TestCase):
             (mod.DOCS / lang / "start").mkdir(parents=True, exist_ok=True)
             (mod.DOCS / lang / "scenarios").mkdir(parents=True, exist_ok=True)
             (mod.DOCS / lang / "scenarios" / "target.md").write_text(TARGET, encoding="utf-8")
+            # 每個入口頁都要連到這一篇，PAGE 裡就寫著，所以它得真的存在
+            (mod.DOCS / lang / "scenarios" / "everyday-baseline.md").write_text(
+                TARGET.replace("目標", "不分身分都要做到的"), encoding="utf-8")
             listed = []
             for name in pages:
                 (mod.DOCS / lang / "start" / name).write_text(
@@ -131,6 +134,56 @@ class TestAnchors(Harness):
                 encoding="utf-8",
             )
         self.assertEqual(self.run_check(), 1)
+
+    def test_說明句提到目標頁沒有的東西時紅燈(self):
+        # 2026-08-30：civil-society.md 說 upload-sensitive「裡面有 PGP 與 OnionShare
+        # 兩種做法的取捨」，而那一頁的正文從頭到尾只有社群自架 Send 的上傳流程。
+        self.build()
+        for lang in mod.LANGS:
+            path = mod.DOCS / lang / "start" / "index.md"
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "看 [別頁](../scenarios/target.md#存在的小標)。",
+                    "看 [別頁](../scenarios/target.md)：裡面有 PGP 的做法。",
+                ),
+                encoding="utf-8",
+            )
+        self.assertEqual(self.run_check(), 1)
+
+    def test_目標頁的_frontmatter_不算數(self):
+        # PGP 只寫在目標頁的 description 裡，正文一個字都沒有。grep 掃整個檔案會
+        # 命中然後放行，人工 review 那次就是這樣漏掉的。
+        self.build()
+        for lang in mod.LANGS:
+            target = mod.DOCS / lang / "scenarios" / "target.md"
+            target.write_text(
+                TARGET.replace("title: 目標", "title: 目標\ndescription: 含 PGP 公鑰"),
+                encoding="utf-8",
+            )
+            path = mod.DOCS / lang / "start" / "index.md"
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "看 [別頁](../scenarios/target.md#存在的小標)。",
+                    "看 [別頁](../scenarios/target.md)：裡面有 PGP 的做法。",
+                ),
+                encoding="utf-8",
+            )
+        self.assertEqual(self.run_check(), 1)
+
+    def test_說明句提到的東西在正文裡就放行(self):
+        self.build()
+        for lang in mod.LANGS:
+            target = mod.DOCS / lang / "scenarios" / "target.md"
+            target.write_text(TARGET.replace("內文。", "內文提到 PGP。"), encoding="utf-8")
+            path = mod.DOCS / lang / "start" / "index.md"
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "看 [別頁](../scenarios/target.md#存在的小標)。",
+                    "看 [別頁](../scenarios/target.md)：裡面有 PGP 的做法。",
+                ),
+                encoding="utf-8",
+            )
+        self.assertEqual(self.run_check(), 0)
 
     def test_連到不存在的檔案時紅燈(self):
         self.build(link="../scenarios/nope.md#存在的小標")


### PR DESCRIPTION
## 你指出的那一句

`civil-society.md` 說 `upload-sensitive`「裡面有 PGP 與 OnionShare 兩種做法的取捨」。查下去發現根源在目標頁自己:

```
upload-sensitive.md 正文（三語系都一樣）
  ## 上傳流程        ← 社群自架 Send 的五個步驟
  ## 流程示意圖      ← 三張截圖

PGP        正文出現 0 次
OnionShare 正文出現 0 次
```

那兩個詞只出現在它的 frontmatter `description` 裡,而那個 description 同樣是錯的。

**上一輪為什麼沒抓到**:我用 `grep -c 'PGP'` 掃整個檔案,命中的正是 frontmatter 那一次,就放行了。這次改成切掉 frontmatter 只讀正文,把 start/ 六頁的每一句說明重新對過一遍。

## 重查之後又找到一處

`developer.md` 說 Snowflake「裝一個瀏覽器擴充套件就開始運作」。那一頁的結構是:

```
## 啟動瀏覽器版橋接點     ← iframe，開著頁面就在跑，不用裝任何東西
## 進階：用瀏覽器擴充套件  ← 擴充套件在這裡
```

門檻最低的其實是開著那一頁,說成裝擴充套件反而把門檻講高了。

## 內容修正（三語系）

- `upload-sensitive.md` 的 description 改成如實描述 Send 的流程
- `civil-society.md` 兩處與 `media.md` 一處,改成「社群自己在用的那條通道,檔案走自架的 Send,連結會自動失效」。原本寫「收件端該怎麼準備」也不對,那一頁講的是寄件端
- `developer.md` 的 Snowflake 改成「開著那一頁就在幫忙,要常駐再裝擴充套件」

## 加了第五項機械檢查

`check_start_parity.py`:說明句裡的專有名詞要在目標頁的**正文**出現,frontmatter 不算。

只對中文語系跑。中文說明句裡的 ASCII 詞幾乎都是專有名詞（PGP、OONI、Send、Tor）,英文版的句首大寫是普通詞,實測 en 會報 `Answers` 與 `Mainland` 這種雜訊。

驗得出來的是「說明句提到某個東西,目標頁一個字都沒有」。目標頁提了但講得很淺,或者說明句用中文概括（「三題」「四封信」）,這一項驗不出來,那些仍然要人看。

## 那一項當場抓到另一個缺口

`zh-CN` 的 `community/tools.md` 是舊版:

| | h2 | h3 | 行數 | 服務 |
|---|---|---|---|---|
| zh-TW | 4 | 7 | 80 | 七個 |
| zh-CN（原） | 3 | 0 | 42 | Matrix、Cryptpad、Jitsi |
| en | 4 | 7 | 82 | 七個 |

而 zh-CN 的 `start/` 說「Matrix、CryptPad 与 Send 都开放社群使用」,讀者點過去看不到 Send。補齊 Etherpad、SearXNG、Send、Formbricks 四段與分類結構,三語系現在都是 h2 四個、h3 七個。

`title` 與 `icon` 沒動:那個名稱有十處連結文字引用,其中三處在已發布的 blog 文章裡,改動代價不成比例。

## 驗證

```
python3 tools/check_start_parity.py       # 通過
python3 tools/test_check_start_parity.py  # 15 通過（原 12）
python3 tools/docs_style_lint.py …        # 0 error、2 warn（都是 origin/main 就有的）
node tools/check_invisible_chars.mjs      # 902 個檔案,乾淨
```

停掉第五項檢查是 2 條紅。三條新測試分別驗:說明句提到目標頁沒有的東西會紅、目標頁的 frontmatter 不算數、東西真的在正文裡就放行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)