### PR TITLE
feat(sw): 預快取收進小工具索引與斷網應變卡

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -101,8 +101,10 @@ const SCOPE_PATH = new URL(self.registration.scope).pathname;
 const LANG_PREFIXES = ["", "zh-cn/", "en/"];
 
 // 每個語系各一份的資產：theme app shell（hash 檔名與 overrides/base.html 同步），
-// 加上離線內容管理頁要用的兩份。管理頁本身在 CORE_PAGES 裡，但它離線打開時還需要
-// 自己的程式與那份頁面索引，少了索引就只剩「清除全部」可以按。
+// 加上兩個頁面各自要用的程式。頁面本身在 CORE_PAGES 裡，但 HTML 進了快取不代表
+// 它會動，工具的程式是另一個請求，少了它離線打開只剩一個空容器。
+//
+// 離線內容管理頁還需要那份頁面索引，少了索引就只剩「清除全部」可以按。
 const SHELL_ASSETS = [
   "assets/stylesheets/main.ec1eaa64.min.css",
   "assets/stylesheets/palette.ab4e12ef.min.css",
@@ -114,6 +116,8 @@ const SHELL_ASSETS = [
   // 離線內容管理頁（hooks/offline_index.py 產生索引，js 是三語系共用的 symlink）
   "offline-index.json",
   "js/offline-library.js",
+  // 斷網應變卡（js 是三語系共用的 symlink，樣式與文案都內嵌在裡面）
+  "js/shutdown-card.js",
 ];
 
 // zh 版（zh-TW 根、/zh-cn/）章節結構一致，預快取完整指南集 + 緊急頁。
@@ -185,6 +189,19 @@ const CORE_PAGES_ZH = [
   "taiwan/vasp-2026/",
   "taiwan/ooni-asn-coverage/",
   "taiwan/tor-relay-watcher/",
+  // utils（小工具，只收索引與斷網應變卡）
+  //
+  // 這一區其他八個工具留給執行期快取，落差不大：它們是「手上有個東西想查一下」
+  // 的工具，收到可疑連結、要清一張照片的座標，那個當下通常還連得上。
+  //
+  // 應變卡不同。它唯一的使用時機就是網路已經斷了，預快取沒有收它的話，讀者要在
+  // 斷網前剛好打開過那一頁才用得到，那等於把準備工作的成敗押在巧合上。索引頁
+  // 一起收，離線時才有入口走得到它，不必先記住完整網址。
+  //
+  // 身分敏感度照上面那條判準檢查過：讀者是「任何需要在中斷時聯絡上別人的人」，
+  // 不指向特定受威脅身分，跟旅行類同一種。工具的程式在 SHELL_ASSETS 裡。
+  "utils/",
+  "utils/shutdown-card/",
   // community（社群，選錄離線可讀的工具頁）
   "community/onionoo-mcp/",
   // 互動與呈現的索引頁。作品本體不在這裡，見下面的 GAME_APPS。
@@ -256,6 +273,9 @@ const CORE_PAGES_EN = [
   "regional/taiwan-vasp-2026/",
   "regional/ooni-asn-coverage/",
   "regional/tor-relay-watcher/",
+  // utils（小工具，只收索引與斷網應變卡，理由見 CORE_PAGES_ZH 的同一段註解）
+  "utils/",
+  "utils/shutdown-card/",
   // community（社群，選錄離線可讀的工具頁）
   "community/onionoo-mcp/",
   // 互動與呈現的索引頁。作品本體不在這裡，見下面的 GAME_APPS。


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

`sw.js` 的預快取清單加三筆：`utils/`、`utils/shutdown-card/`，以及 `SHELL_ASSETS` 裡的 `js/shutdown-card.js`。

**依賴 #390，要在那個 PR 之後才合併。** 萬一順序反了也不會壞，install 用 `allSettled` 容忍個別 404，只是那一頁不會被存下來。

相關 PR：#390

## 為什麼

整份 `sw.js` 搜不到 `utils` 這個字串。小工具區目前靠的是「瀏覽過的頁面會被存下來」這條執行期快取，讀者要在斷網前剛好打開過那一頁，離線才用得到。

對其他八個工具這個落差不大，它們是「手上有個東西想查一下」的工具，收到可疑連結、要清一張照片的座標，那個當下通常還連得上。

斷網應變卡不同，它唯一的使用時機就是網路已經斷了。預快取沒有收的話，等於把準備工作的成敗押在「使用者剛好在斷網前打開過」這個巧合上。索引頁一起收，離線時才有入口走得到它，不必先記住完整網址。

## 身分敏感度

照 `CORE_PAGES_ZH` 上方那條判準逐一問過：

> 這頁是不是用第二人稱或隱含第二人稱，指導「唯一一種身分的人」在採取某個具體行動前後該做什麼準備？

這兩頁的讀者是「任何需要在中斷時聯絡上別人的人」，跟旅行類同一種，不指向特定受威脅身分，通得過。工具頁本身也是說明書性質，讀者拿去做什麼是開放的。

## 為什麼 JS 要另外列進 SHELL_ASSETS

頁面的 HTML 進了快取不代表它會動，工具的程式是另一個請求。少了它，離線打開只剩一個空容器，而讀者看到的是「這一頁存下來了但是壞的」。離線內容管理頁早就是這樣處理的（`js/offline-library.js` 就在那份清單裡），這裡沿用同一個做法，順手把那段註解改成講得清楚一點。

## 代價

| 語系 | 之前 | 之後 |
|---|---|---|
| zh-TW | 11.98 MB（79 個 URL） | 12.44 MB（82 個 URL） |
| zh-cn | 11.47 MB（79 個 URL） | 11.90 MB（82 個 URL） |
| en | 13.08 MB（87 個 URL） | 13.51 MB（90 個 URL） |

## 驗證

- `tools/test_sw_offline.mjs` 81 項全過
- `tools/check_precache.mjs` 通過（在有 #390 頁面的樹上建置三語系後跑的，清單裡每個 URL 都對得到檔案）

## 自我檢查 / Self-check

- [x] 只動 `docs/zh-TW/sw.js`，沒有內容或 URL 變更
- [x] 對讀者的影響：PWA 預下載量每語系增加約 0.46 MB
