### PR TITLE
feat(changelog): 新增 OnionShare 更新日誌，並補上 Tor Browser 16.0a10

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: Software Changelog
-description: Concise English summaries of Tor, Tails, OONI, and Arti releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
+description: Concise English summaries of Tor, Tails, OONI, Arti, and OnionShare releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
 icon: material/history
 ---
 
@@ -16,3 +16,4 @@ Most of our release translations begin life in zh-TW and reach English on a roll
 - :material-usb-flash-drive-outline: [Tails changelog](./tails.md) — Tails operating system
 - :material-code-tags: [Arti changelog](./arti.md) — Tor Project's Rust implementation
 - :material-access-point-network: [OONI changelog](./ooni.md) — OONI Probe, Explorer, Run
+- :material-share-variant: [OnionShare changelog](./onionshare.md) — OnionShare file sharing and onion sites

--- a/docs/en/changelog/onionshare.md
+++ b/docs/en/changelog/onionshare.md
@@ -1,0 +1,50 @@
+---
+title: OnionShare Changelog
+description: English summaries of OnionShare releases translated from upstream changelogs and security advisories, with notes on security fixes and new features.
+icon: material/share-variant
+---
+
+# :material-share-variant: OnionShare Changelog
+
+Release summaries for [OnionShare](../tools/onionshare.md), condensed from upstream changelogs and security advisories. Newest at the top.
+
+OnionShare ships far less often than Tor Browser or Tails: fifteen months passed between 2.6.3 and 2.6.4. A long gap between releases is normal here, so the thing to watch is whether a given release fixes something that affects how you use it.
+
+## OnionShare 2.6.5
+
+> 2026-07-28 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
+
+- Dependency updates covering the bundled tor, Python packages, and web-side dependencies.
+- No new features or behaviour changes. The two security fixes from 2.6.4 remain the reason to upgrade, and anyone still on 2.6.3 can go straight to 2.6.5.
+
+## OnionShare 2.6.4
+
+> 2026-06-09 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
+
+- Fixes two security issues affecting 2.6.3 and earlier. Both the desktop app and `onionshare-cli` are affected, since they share the same web module.
+- CVE-2026-54706 ([GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}): Share mode and Website mode followed symlinks inside the selected directory and served the link target instead of restricting access to files physically inside that directory. If the shared directory contains attacker-supplied or otherwise untrusted symlinks, whoever has the onion address can read other local files readable by the OnionShare process. Rated medium severity — exploiting it requires getting a symlink into the directory you share.
+- CVE-2026-54707 ([GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}): With "Disable uploading files" enabled in Receive mode, the restriction was not enforced at the write sink. A crafted multipart request still wrote the uploaded bytes to disk; the route handler merely skipped the upload accounting. A service configured as a text-message-only endpoint could therefore be made to write unexpected files. The same release also stops an empty POST payload from creating an empty folder.
+- Dependency updates, including the bundled tor and the flatpak runtime.
+- Tor connection now shows indeterminate progress and warns the user while it waits, instead of looking unresponsive.
+
+## OnionShare 2.6.3
+
+> 2025-02-25 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
+
+- The CLI gained `--log-filenames`, showing which URLs are visited in Share and Website mode.
+- A saved persistent onion tab can now start automatically once OnionShare launches and Tor connects.
+- Fixed bridge requests and meek as a pluggable transport, plus a fatal error when censorship circumvention returned no bridges.
+- Fixed a thread race segfault on CLI shutdown, and the auto-stop timer failing in Share mode after someone had visited the share.
+- Added Irish, Slovak, and Tamil interface translations, with improvements across existing languages.
+- Documentation now covers every config file parameter, and includes a systemd unit example for persistent onions.
+- Packaging: the snap builds for Ubuntu 24.04 and later, ARM64 flatpak packaging was fixed, and armhf support was dropped for now because PySide6 packages are unavailable for that architecture.
+
+## OnionShare 2.6.2
+
+> 2024-03-21 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
+
+- An all-security release, concentrated on input handling in Receive mode and Chat mode.
+- Newlines are stripped from History item paths.
+- Text messages in Receive mode are capped at 524288 characters.
+- Usernames are restricted to specific ASCII characters with control characters removed, and username validation exceptions are handled so users can no longer join silently.
+- Users are forcefully disconnected from chat on a `disconnect` event.

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,19 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 16.0a10 (alpha)
+
+> 2026-08-27 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
+
+- The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
+- New opt-in "Use generic window titles" setting, under Privacy and security → Advanced settings → Protections from third-party applications. With it enabled, every window title simply reads Tor Browser Alpha. Window titles normally track the page's `<title>` element, and other applications or the OS can read those changes without special permissions, which makes them a side channel for recording browsing history. The feature has been upstreamed, so vanilla Firefox users can set `privacy.exposeContentTitleInWindow` and `privacy.exposeContentTitleInWindow.pbm` to false in `about:config`. The Tor Project had hoped to enable it by default in 16.0, but held off over possible breakage with accessibility software and non-standard desktop environments.
+- The desktop built-in manual has been replaced with the Tor Project's updated support content, baked into the browser. Open it directly at `about:manual`, or through the "Learn more" links in the UI.
+- The settings page now uses Mozilla's redesigned `about:preferences` by default, with Tor Browser's own settings (connection, letterboxing, security level) migrated to the new design language.
+- Rebased the Firefox base onto 153.1.0esr (tor-browser#45205) and backported security fixes from Firefox 154 (tor-browser#45219).
+- Disabled locale-based font rules as defence in depth against fingerprinting (tor-browser#44257).
+- Updated NoScript to 13.6.31.90301984 and OpenSSL to 3.5.8.
+- `about:torconnect` now reports an error when the tor daemon crashes (tor-browser#43570), and bridge settings update when a connection fails (tor-browser#43939).
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md
+          - changelog/onionshare.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 關於我們是社群的一部分，收進去讓第一層再短一項。放在 community/index.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -127,6 +127,7 @@ nav:
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md
+          - changelog/onionshare.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 关于我们是社群的一部分，收进去让第一层再短一项。放在 community/index.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -125,6 +125,7 @@ nav:
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md
+          - changelog/onionshare.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
       # About is part of the community section. Placed after community/index.md rather

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 软件更新日志
-description: Tor、Tails、OONI、Arti 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
+description: Tor、Tails、OONI、Arti、OnionShare 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
 icon: material/history
 ---
 
@@ -14,6 +14,7 @@ icon: material/history
 - :material-usb-flash-drive-outline: [Tails 更新日志](./tails.md)：Tails 操作系统
 - :material-code-tags: [Arti 更新日志](./arti.md)：Tor Project 的 Rust 实现
 - :material-access-point-network: [OONI 更新日志](./ooni.md)：OONI Probe、Explorer、Run
+- :material-share-variant: [OnionShare 更新日志](./onionshare.md)：OnionShare 文件分享与匿名网站
 
 ## 想找完整翻译文章
 

--- a/docs/zh-CN/changelog/onionshare.md
+++ b/docs/zh-CN/changelog/onionshare.md
@@ -1,0 +1,50 @@
+---
+title: OnionShare 更新日志
+description: OnionShare 各版本更新的中文重点整理，从上游 changelog 与安全公告翻译而成，方便华语读者掌握安全修补与新功能。
+icon: material/share-variant
+---
+
+# :material-share-variant: OnionShare 更新日志
+
+[OnionShare](../tools/onionshare.md) 的版本发布整理，从上游 changelog 与安全公告条列摘译。新版本永远在最上面。
+
+OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 之间隔了十五个月。长时间没有新版属于正常状态，重点放在每次发布的安全修补有没有打到自己的用法。
+
+## OnionShare 2.6.5
+
+> 2026-07-28 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
+
+- 依赖包更新，涵盖内置的 tor、Python 包与网页端依赖。
+- 没有新功能与行为变更。2.6.4 的两个安全修补仍是这一轮的重点，还停在 2.6.3 的人可以直接升到 2.6.5。
+
+## OnionShare 2.6.4
+
+> 2026-06-09 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
+
+- 修补两个安全问题，影响 2.6.3 与更早的版本，桌面版与 `onionshare-cli` 都受影响，两者共用同一份 web 模块。
+- CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式与网站模式会跟着文件夹里的符号链接（symlink）走，把链接指向的文件一并提供出去。分享的文件夹里若有他人放进来或来源不明的符号链接，获得 onion 地址的对方就能读到 OnionShare 进程权限范围内的其他本地文件。严重度评为中等，利用前提是对方要先有办法把符号链接放进你分享的文件夹。
+- CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾选「停用文件上传」之后，限制没有落实到实际写文件那一段。发出特制的 multipart 请求仍会把文件写进磁盘，路由处理只是不把它计入上传记录。设置成纯文本消息端点的服务因此可能被写入非预期的文件。同一版顺手修掉空的 POST 请求会创建空文件夹的问题。
+- 依赖包更新，包含内置的 tor 与 flatpak runtime。
+- 连接 Tor 的等待期间改为显示不确定进度并提示用户，避免以为程序没有反应。
+
+## OnionShare 2.6.3
+
+> 2025-02-25 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
+
+- CLI 新增 `--log-filenames`，分享模式与网站模式可以看到哪些网址被访问过。
+- 保存下来的持久 onion 标签页，可在 OnionShare 启动并连上 Tor 之后自动开始服务。
+- 修好无法获取网桥、无法使用 meek 传输的问题，以及网桥查询没有返回结果时的致命错误。
+- 修好 CLI 关闭时线程竞争造成的 segfault，以及分享模式在有人访问过之后自动停止计时器失效的问题。
+- 界面新增爱尔兰语、斯洛伐克语与泰米尔语，其他语言的翻译也有增补。
+- 文档补齐配置文件各字段的说明，并加入用 systemd unit 维持持久 onion 的示例。
+- 打包：snap 支持 Ubuntu 24.04 以上，修正 ARM64 的 flatpak 打包，armhf 因为取不到 PySide6 包暂停支持。
+
+## OnionShare 2.6.2
+
+> 2024-03-21 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
+
+- 全部是安全修补，集中在接收模式与聊天模式的输入处理。
+- 历史记录项目的路径移除换行字符。
+- 接收模式的文本消息长度上限设为 524288 字符。
+- 用户名只允许特定 ASCII 字符并移除控制字符，另补上名称验证的异常处理，避免无声加入聊天室。
+- 收到 `disconnect` 事件时强制断开该用户的连接。

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,19 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 16.0a10（Alpha 测试通道）
+
+> 2026-08-27 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
+
+- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
+- 新增「使用通用窗口标题」选项，在设置的隐私与安全、高级设置、防范第三方应用程序那一组，开启后所有窗口标题一律显示 Tor Browser Alpha。窗口标题默认跟着网页的 title 变动，操作系统与其他程序不需特殊权限就读得到，可以当成侧录浏览记录的旁路通道。此功能已上游进 Firefox，一般 Firefox 用户可在 `about:config` 把 `privacy.exposeContentTitleInWindow` 与 `privacy.exposeContentTitleInWindow.pbm` 设为 false。官方原本希望 16.0 稳定版就默认开启，顾虑无障碍软件与非标准桌面环境的兼容性，改为先开放测试。
+- 桌面版内置手册改版，把更新过的官方说明内容打包进浏览器取代旧版手册，地址栏输入 `about:manual` 可直接打开，界面上的「Learn more」也都指向新版。
+- 设置页改用 Mozilla 的新版 `about:preferences` 设计并默认启用，连接、letterboxing、安全等级等自定义项目都已搬到新版面。
+- Firefox 基底 rebase 至 153.1.0esr（tor-browser#45205），并从 Firefox 154 backport 安全修补（tor-browser#45219）。
+- 停用以语系为基础的字体规则，作为浏览器指纹的纵深防御（tor-browser#44257）。
+- NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
+- tor daemon 崩溃时，`about:torconnect` 会显示错误信息（tor-browser#43570）。网桥连接失败时也会更新网桥设置的显示（tor-browser#43939）。
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 軟體更新日誌
-description: Tor、Tails、OONI、Arti 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
+description: Tor、Tails、OONI、Arti、OnionShare 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
 icon: material/history
 ---
 
@@ -14,6 +14,7 @@ icon: material/history
 - :material-usb-flash-drive-outline: [Tails 更新日誌](./tails.md)：Tails 作業系統
 - :material-code-tags: [Arti 更新日誌](./arti.md)：Tor Project 的 Rust 實作
 - :material-access-point-network: [OONI 更新日誌](./ooni.md)：OONI Probe、Explorer、Run
+- :material-share-variant: [OnionShare 更新日誌](./onionshare.md)：OnionShare 檔案分享與匿名網站
 
 ## 想找完整翻譯文章
 

--- a/docs/zh-TW/changelog/onionshare.md
+++ b/docs/zh-TW/changelog/onionshare.md
@@ -1,0 +1,50 @@
+---
+title: OnionShare 更新日誌
+description: OnionShare 各版本更新的中文重點整理，從上游 changelog 與安全公告翻譯而成，方便台灣與華語讀者掌握安全修補與新功能。
+icon: material/share-variant
+---
+
+# :material-share-variant: OnionShare 更新日誌
+
+[OnionShare](../tools/onionshare.md) 的版本發布整理，從上游 changelog 與安全公告條列摘譯。新版本永遠在最上面。
+
+OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 之間隔了十五個月。長時間沒有新版屬於正常狀態，重點放在每次釋出的安全修補有沒有打到自己的用法。
+
+## OnionShare 2.6.5
+
+> 2026-07-28 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
+
+- 相依套件更新，涵蓋內建的 tor、Python 套件與網頁端相依。
+- 沒有新功能與行為變更。2.6.4 的兩個安全修補仍是這一輪的重點，還停在 2.6.3 的人可以直接升到 2.6.5。
+
+## OnionShare 2.6.4
+
+> 2026-06-09 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
+
+- 修補兩個安全問題，影響 2.6.3 與更早的版本，桌面版與 `onionshare-cli` 都受影響，兩者共用同一份 web 模組。
+- CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式與網站模式會跟著資料夾裡的符號連結（symlink）走，把連結指向的檔案一併提供出去。分享的資料夾裡若有他人放進來或來源不明的符號連結，取得 onion 網址的對方就能讀到 OnionShare 行程權限範圍內的其他本機檔案。嚴重度評為中等，利用前提是對方要先有辦法把符號連結放進你分享的資料夾。
+- CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾選「停用檔案上傳」之後，限制沒有落實到實際寫檔那一段。送出特製的 multipart 請求仍會把檔案寫進磁碟，路由處理只是不把它計入上傳紀錄。設定成純文字訊息端點的服務因此可能被寫入非預期的檔案。同一版順手修掉空的 POST 請求會建立空資料夾的問題。
+- 相依套件更新，包含內建的 tor 與 flatpak runtime。
+- 連線 Tor 的等待期間改為顯示不確定進度並提示使用者，避免以為程式沒有反應。
+
+## OnionShare 2.6.3
+
+> 2025-02-25 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
+
+- CLI 新增 `--log-filenames`，分享模式與網站模式可以看到哪些網址被造訪過。
+- 儲存下來的持續性 onion 分頁，可在 OnionShare 啟動並連上 Tor 之後自動開始服務。
+- 修好無法取得橋接、無法使用 meek 傳輸的問題，以及橋接查詢沒有回傳結果時的致命錯誤。
+- 修好 CLI 關閉時執行緒競爭造成的 segfault，以及分享模式在有人造訪過之後自動停止計時器失效的問題。
+- 介面新增愛爾蘭文、斯洛伐克文與坦米爾文，其他語言的翻譯也有增補。
+- 文件補齊設定檔各欄位的說明，並加入用 systemd unit 維持持續性 onion 的範例。
+- 打包：snap 支援 Ubuntu 24.04 以上，修正 ARM64 的 flatpak 打包，armhf 因為取不到 PySide6 套件暫停支援。
+
+## OnionShare 2.6.2
+
+> 2024-03-21 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
+
+- 全部是安全修補，集中在接收模式與聊天模式的輸入處理。
+- 歷史紀錄項目的路徑移除換行字元。
+- 接收模式的文字訊息長度上限設為 524288 字元。
+- 使用者名稱只允許特定 ASCII 字元並移除控制字元，另補上名稱驗證的例外處理，避免無聲加入聊天室。
+- 收到 `disconnect` 事件時強制中斷該使用者的連線。

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,19 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 16.0a10（Alpha 測試通道）
+
+> 2026-08-27 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
+
+- Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
+- 新增「使用通用視窗標題」選項，在設定的隱私與安全性、進階設定、防範第三方應用程式那一組，開啟後所有視窗標題一律顯示 Tor Browser Alpha。視窗標題預設跟著網頁的 title 變動，作業系統與其他程式不需特殊權限就讀得到，可以當成側錄瀏覽紀錄的旁通道。此功能已上游進 Firefox，一般 Firefox 使用者可在 `about:config` 把 `privacy.exposeContentTitleInWindow` 與 `privacy.exposeContentTitleInWindow.pbm` 設為 false。官方原本希望 16.0 穩定版就預設開啟，顧慮無障礙軟體與非標準桌面環境的相容性，改為先開放測試。
+- 桌面版內建手冊改版，把更新過的官方說明內容包進瀏覽器取代舊版手冊，網址列輸入 `about:manual` 可直接開啟，介面上的「Learn more」也都指向新版。
+- 設定頁改用 Mozilla 的新版 `about:preferences` 設計並預設啟用，連線、letterboxing、安全性等級等自訂項目都已搬到新版面。
+- Firefox 基底 rebase 至 153.1.0esr（tor-browser#45205），並從 Firefox 154 backport 安全修補（tor-browser#45219）。
+- 停用以語系為基礎的字型規則，作為瀏覽器指紋的深度防禦（tor-browser#44257）。
+- NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
+- tor daemon 崩潰時，`about:torconnect` 會顯示錯誤訊息（tor-browser#43570）。橋接連線失敗時也會更新橋接設定的顯示（tor-browser#43939）。
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}


### PR DESCRIPTION
## 這個 PR 做了什麼

### 新增 OnionShare 更新日誌

站上有 OnionShare 工具頁，更新日誌卻沒收它。三語系各新增一份 `changelog/onionshare.md`，收 2.6.5、2.6.4、2.6.3、2.6.2 四個版本，同步進三個 `mkdocs*.yml` 的 nav 與三語系的 changelog 索引頁。

2.6.4 是這頁最重要的一條，內容取自上游的兩則安全公告：

- CVE-2026-54706（GHSA-22p9-r2f5-22mf）：分享模式與網站模式會跟著資料夾裡的符號連結走，取得 onion 網址的對方讀得到 OnionShare 行程權限範圍內的其他本機檔案。
- CVE-2026-54707（GHSA-v833-3823-cmhp）：接收模式勾了「停用檔案上傳」，限制沒有落實到實際寫檔那一段，特製的 multipart 請求照樣把檔案寫進磁碟。

兩個都影響 2.6.3 與更早版本，桌面版與 `onionshare-cli` 共用同一份 web 模組所以都中。2.6.5 只有相依更新，條目直接寫出還停在 2.6.3 的人可以一次升到 2.6.5。

頁首說明這個專案 2.6.3 到 2.6.4 隔了十五個月，長時間沒有新版屬於正常狀態，避免讀者看到空窗以為專案不再維護。

### 補上 Tor Browser 16.0a10

三語系 `changelog/tor.md` 各加一則條目。重點是新增的 opt-in「使用通用視窗標題」：視窗標題平常跟著網頁 title 變動，其他程式與作業系統不需特殊權限就讀得到，可以當成側錄瀏覽紀錄的旁通道。此功能已上游進 Firefox，條目一併寫出一般 Firefox 使用者要改的兩個 `about:config` 值。其餘是內建手冊改版（`about:manual`）、設定頁改用新版 `about:preferences`、rebase 到 153.1.0esr 加 Firefox 154 的 backport。

### 其他三個軟體的版本檢查

查過上游，Tails 7.11、Arti 2.5.1、OONI Probe 6.2.0 都還是最新，這輪不動。

## 驗證

- `python3 tools/docs_style_lint.py` 掃這次變更的九個 Markdown，0 error 0 warn
- `sh run.sh`、`sh run_zh-cn.sh`、`sh run_en.sh` 三語系建置皆通過，nav 與 icon 都正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)