### PR TITLE
feat(changelog): 新增 GrapheneOS 月度更新摘要，按月聚合而非逐版

### DIFF
--- a/docs/en/changelog/grapheneos.md
+++ b/docs/en/changelog/grapheneos.md
@@ -1,0 +1,46 @@
+---
+title: GrapheneOS Monthly Summary
+description: Plain-language monthly summaries of GrapheneOS releases: how far the Android security patch level has advanced, which everyday features got fixed, and any changes to device support.
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: GrapheneOS Monthly Summary
+
+Release summaries for [GrapheneOS](../tools/grapheneos.md), aggregated by month. Over the past four months a new release landed every six days on average, and the version number is just the release date (`2026081300`, for example), so going release by release tells you very little. This page groups each month into one entry and answers three questions: how far the Android security patch level advanced, which everyday features got fixed, and whether device support changed. Newest month at the top.
+
+GrapheneOS updates automatically in the background, so ordinary users need to do nothing on account of this page. It is here for people who want to know what is happening underneath, or who need to explain to a team why they chose this OS.
+
+Source data comes from the [official releases page](https://grapheneos.org/releases){target="_blank"}. The official atom feed keeps only the last 20 entries (roughly four months), so anything older has to be looked up on the site.
+
+## August 2026
+
+> Releases `2026080500`, `2026081300` · [Official releases](https://grapheneos.org/releases){target="_blank"}
+
+- The security patch level advanced to the full 2026-08-05 Pixel level, alongside August's Pixel driver and firmware code.
+- The kernel backported the fix for CVE-2026-64560. Tails shipped an emergency fix for the same Linux kernel flaw in [7.10.1](./tails.md), where it let an attacker inside Tor Browser gain administrator privileges.
+- Contact Scopes had compatibility problems with WhatsApp and sandboxed Google Play services on Android 17. A workaround shipped on 5 August, replaced by a proper fix on 13 August that runs the filtered query using the calling app's identity.
+- Two vulnerabilities still unfixed upstream were closed on 13 August: both CredentialManager and the Play services FIDO activities were made opaque, so nothing underneath shows through. Fixing upstream issues before Google does is one of the practical differences from stock Android.
+- Vanadium (the hardened Chromium browser bundled with GrapheneOS) shipped four updates during August, tracking the Chromium 151 series.
+- Device coverage runs from Pixel 6 to Pixel 10a, unchanged this month.
+- No release shipped between 13 August and the end of the month, the longest gap in the past four months.
+
+## July 2026
+
+> Releases `2026070500`, `2026071100`, `2026071500`, `2026072900` · [Official releases](https://grapheneos.org/releases){target="_blank"}
+
+- The listed security patch level moved to 2026-07-05 on 11 July, a level for which neither the Android nor the Pixel bulletin lists additional patches. The same release picked up July's Pixel driver and firmware code.
+- A location privacy flaw inherited from upstream Android was fixed: apps without precise location permission could still read secondary fields such as altitude and accuracy from the coarse location. GrapheneOS now rebuilds coarse locations from an allowlist of fields.
+- Kernel hardware memory tagging caught a double-free in the USB gadget Ethernet driver. Protections GrapheneOS enables by default catching real upstream bugs is a pattern that recurs in later months here.
+- The PIN entry interface used outside the lock screen gained the enhanced privacy treatment, and the 128-digit PIN limit now works in the new interface.
+- Secure (exec) spawning was reimplemented, with the global toggle replaced by a per-app one and noticeably better app compatibility. A follow-up on 15 July handled anti-tampering libraries, so protection schemes like V-KEY are no longer blocked.
+- ContactsProvider and Telephony each got an upstream Android security fix, the latter caused by a missing system permission check for apps targeting API levels below 30.
+
+## June 2026
+
+> Releases `2026060100` through `2026062800` (eight in total) · [Official releases](https://grapheneos.org/releases){target="_blank"}
+
+- The month Android 17 shipped. The full 2026-06-01 level landed on 1 June, followed on 18 June by the full 2026-06-05 Pixel level released alongside Android 17. What Android 17 means for the position GrapheneOS is in is covered in [a separate post](../blog/posts/2026-grapheneos-android-17.md).
+- Hardware memory tagging caught three upstream driver bugs this month: a use-after-free in the Broadcom Wi-Fi driver, plus two out-of-bounds reads in the DisplayPort driver caused by displays that do not follow the DisplayPort specification.
+- Network Location now requires TLSv1.3 for the Apple and Apple China location services as well, matching what GrapheneOS already required of its own service.
+- Android 17 brought several behaviour changes: the Wi-Fi quick tile now actually disables Wi-Fi rather than merely disconnecting from the current network, and Nearby Devices was split to break out local network access, which stays enabled by default for apps not targeting Android 17.
+- Settings again lists the duress password under the screen lock menu, a feature that only gets used if people can find it.

--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: Software Changelog
-description: Concise English summaries of Tor, Tails, OONI, Arti, OnionShare, and iOS releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
+description: Concise English summaries of Tor, Tails, OONI, Arti, OnionShare, iOS, and GrapheneOS releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
 icon: material/history
 ---
 
@@ -25,3 +25,4 @@ Your device is part of the attack surface. This group skips the line-by-line tra
 
 - :material-usb-flash-drive-outline: [Tails changelog](./tails.md) — Tails operating system
 - :material-apple-ios: [iOS security updates](./ios.md) — iPhone and iPad, with urgency ratings and older-model support
+- :material-cellphone-lock: [GrapheneOS monthly summary](./grapheneos.md) — hardened Android on Pixel, aggregated by month

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 關於我們是社群的一部分，收進去讓第一層再短一項。放在 community/index.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -129,6 +129,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 关于我们是社群的一部分，收进去让第一层再短一项。放在 community/index.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -127,6 +127,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
       # About is part of the community section. Placed after community/index.md rather

--- a/docs/zh-CN/changelog/grapheneos.md
+++ b/docs/zh-CN/changelog/grapheneos.md
@@ -1,0 +1,46 @@
+---
+title: GrapheneOS 月度更新摘要
+description: GrapheneOS 每月更新的白话整理，说明 Android 安全修补等级进度、日常会碰到的功能修补，以及机型支持变动。
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: GrapheneOS 月度更新摘要
+
+[GrapheneOS](../tools/grapheneos.md) 的更新整理，按月聚合。近四个月平均六天就发一版，版本号是发布日期（例如 `2026081300`），逐版看没有意义，所以这一页把同一个月的版本合成一则，回答三件事：这个月的 Android 安全修补等级推进到哪、有没有修到日常会碰到的功能、机型支持有没有变动。新的月份永远在最上面。
+
+GrapheneOS 走自动更新，设备在后台就会装好，一般用户不需要为了这一页做任何事。内容是给想知道背后发生什么、或需要向团队说明为何选这套系统的人看的。
+
+原始数据来自[官方发布页](https://grapheneos.org/releases){target="_blank"}。官方的 atom feed 只保留最近 20 则（大约四个月），更早的记录要到官网翻。
+
+## 2026 年 8 月
+
+> 版本 `2026080500`、`2026081300` · [官方发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 安全修补等级推进到完整的 2026-08-05 Pixel 等级，同时更新 8 月的 Pixel 驱动与固件代码。
+- 内核 backport 了 CVE-2026-64560 的修补。同一个 Linux 内核漏洞 Tails 在 [7.10.1](./tails.md) 也紧急修过，在 Tails 上它可以让 Tor Browser 内的攻击者取得管理员权限。
+- 通讯录范围控制（Contact Scopes）在 Android 17 上跟 WhatsApp 与沙盒化 Google Play 服务的兼容问题，8 月 5 日先用临时解法挡住，8 月 13 日换成正式做法，改用调用端 app 的身份执行过滤查询。
+- 8 月 13 日修掉两个上游还没修的漏洞：凭证管理器（CredentialManager）与 Play 服务的 FIDO 界面都改为不透明，避免底下的界面被叠在上面的内容看穿。GrapheneOS 自己先挡掉上游未修的问题，是它跟原厂 Android 的差别之一。
+- Vanadium（GrapheneOS 内置的强化版 Chromium 浏览器）在 8 月连更四版，跟上 Chromium 151 系列。
+- 机型涵盖 Pixel 6 到 Pixel 10a，本月没有变动。
+- 8 月 13 日之后到月底没有再发新版，是近四个月最长的一次间隔。
+
+## 2026 年 7 月
+
+> 版本 `2026070500`、`2026071100`、`2026071500`、`2026072900` · [官方发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 安全修补等级在 7 月 11 日拉到 2026-07-05，Android 与 Pixel 两份公告在该等级都没有额外的修补项目。同一版更新 7 月的 Pixel 驱动与固件代码。
+- 位置隐私修掉一个上游 Android 的缺陷：没有取得精确位置权限的 app，仍然可以从粗略位置读到海拔、精度这类次要字段。GrapheneOS 改成只用允许列表上的字段重建粗略位置。
+- 内核的硬件内存标记（hardware memory tagging）抓到 USB 以太网 gadget 驱动的一个 double-free。GrapheneOS 默认开启的防护实际拦下上游的错误，同样的记录在后面几个月还会反复出现。
+- 锁屏以外的 PIN 输入界面补上隐私强化，并修好 128 位数 PIN 在新版界面被截断的问题。
+- secure（exec）spawning 换成新实现，开关从全局改为逐 app 设置，兼容性明显改善。7 月 15 日再补上跟反篡改库的兼容处理，V-KEY 这类保护方案不会再被挡住。
+- ContactsProvider 与电话（Telephony）各修一个上游 Android 的安全漏洞，后者的成因是缺少对 API 等级低于 30 的 app 的系统权限检查。
+
+## 2026 年 6 月
+
+> 版本 `2026060100` 到 `2026062800`（八版）· [官方发布页](https://grapheneos.org/releases){target="_blank"}
+
+- Android 17 上线的月份。6 月 1 日先到完整的 2026-06-01 等级，6 月 18 日跟上随 Android 17 发布的完整 2026-06-05 Pixel 等级。Android 17 对 GrapheneOS 的处境代表什么，站上有[专文](../blog/posts/2026-grapheneos-android-17.md)讨论。
+- 硬件内存标记这个月抓到三个上游驱动的错误：Broadcom Wi-Fi 驱动的 use-after-free，以及 DisplayPort 驱动的两次越界读取。后者的成因是部分屏幕设备没有照 DisplayPort 规格实现。
+- 网络定位（Network Location）对 Apple 与 Apple China 的定位服务也改为要求 TLSv1.3，跟 GrapheneOS 自家服务的要求一致。
+- Android 17 带来几个行为变动：Wi-Fi 快速设置改成真的关闭 Wi-Fi，不再只是断开当前的网络。邻近设备权限拆出局域网访问，没有针对 Android 17 改版的 app 默认仍可使用。
+- 设置界面把胁迫密码（duress password）重新列回屏幕锁定菜单，这个功能靠有人看得到才会被用到。

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 软件更新日志
-description: Tor、Tails、OONI、Arti、OnionShare 与 iOS 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
+description: Tor、Tails、OONI、Arti、OnionShare、iOS 与 GrapheneOS 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
 icon: material/history
 ---
 
@@ -23,6 +23,7 @@ icon: material/history
 
 - :material-usb-flash-drive-outline: [Tails 更新日志](./tails.md)：Tails 操作系统
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 与 iPad，含紧急程度与旧机支持状况
+- :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的强化 Android，按月聚合
 
 ## 想找完整翻译文章
 

--- a/docs/zh-TW/changelog/grapheneos.md
+++ b/docs/zh-TW/changelog/grapheneos.md
@@ -1,0 +1,46 @@
+---
+title: GrapheneOS 月度更新摘要
+description: GrapheneOS 每月更新的白話整理，說明 Android 安全修補等級進度、日常會碰到的功能修補，以及機型支援變動。
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: GrapheneOS 月度更新摘要
+
+[GrapheneOS](../tools/grapheneos.md) 的更新整理，按月聚合。近四個月平均六天就發一版，版本號是發布日期（例如 `2026081300`），逐版看沒有意義，所以這一頁把同一個月的版本合成一則，回答三件事：這個月的 Android 安全修補等級推進到哪、有沒有修到日常會碰到的功能、機型支援有沒有變動。新的月份永遠在最上面。
+
+GrapheneOS 走自動更新，裝置在背景就會裝好，一般使用者不需要為了這一頁做任何事。內容是給想知道背後發生什麼、或需要向團隊說明為何選這套系統的人看的。
+
+原始資料來自[官方發布頁](https://grapheneos.org/releases){target="_blank"}。官方的 atom feed 只保留最近 20 則（大約四個月），更早的紀錄要到官網翻。
+
+## 2026 年 8 月
+
+> 版本 `2026080500`、`2026081300` · [官方發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 安全修補等級推進到完整的 2026-08-05 Pixel 等級，同時更新 8 月的 Pixel 驅動與韌體程式碼。
+- 核心 backport 了 CVE-2026-64560 的修補。同一個 Linux 核心漏洞 Tails 在 [7.10.1](./tails.md) 也緊急修過，在 Tails 上它可以讓 Tor Browser 內的攻擊者取得管理員權限。
+- 通訊錄範圍控制（Contact Scopes）在 Android 17 上跟 WhatsApp 與沙箱化 Google Play 服務的相容問題，8 月 5 日先用暫時解法擋住，8 月 13 日換成正式做法，改用呼叫端 app 的身分執行過濾查詢。
+- 8 月 13 日修掉兩個上游還沒修的漏洞：憑證管理員（CredentialManager）與 Play 服務的 FIDO 畫面都改為不透明，避免底下的畫面被疊在上面的內容看穿。GrapheneOS 自己先擋掉上游未修的問題，是它跟原廠 Android 的差別之一。
+- Vanadium（GrapheneOS 內建的強化版 Chromium 瀏覽器）在 8 月連更四版，跟上 Chromium 151 系列。
+- 機型涵蓋 Pixel 6 到 Pixel 10a，本月沒有變動。
+- 8 月 13 日之後到月底沒有再發新版，是近四個月最長的一次間隔。
+
+## 2026 年 7 月
+
+> 版本 `2026070500`、`2026071100`、`2026071500`、`2026072900` · [官方發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 安全修補等級在 7 月 11 日拉到 2026-07-05，Android 與 Pixel 兩份公告在該等級都沒有額外的修補項目。同一版更新 7 月的 Pixel 驅動與韌體程式碼。
+- 位置隱私修掉一個上游 Android 的缺陷：沒有取得精確位置權限的 app，仍然可以從粗略位置讀到海拔、精確度這類次要欄位。GrapheneOS 改成只用允許清單上的欄位重建粗略位置。
+- 核心的硬體記憶體標記（hardware memory tagging）抓到 USB 乙太網路 gadget 驅動的一個 double-free。GrapheneOS 預設開啟的防護實際攔下上游的錯誤，同樣的紀錄在後面幾個月還會反覆出現。
+- 鎖定畫面以外的 PIN 輸入介面補上隱私強化，並修好 128 位數 PIN 在新版介面被截斷的問題。
+- secure（exec）spawning 換成新實作，開關從全域改為逐 app 設定，相容性明顯改善。7 月 15 日再補上跟反竄改函式庫的相容處理，V-KEY 這類保護方案不會再被擋住。
+- ContactsProvider 與電話（Telephony）各修一個上游 Android 的安全漏洞，後者的成因是缺少對 API 等級低於 30 的 app 的系統權限檢查。
+
+## 2026 年 6 月
+
+> 版本 `2026060100` 到 `2026062800`（八版）· [官方發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- Android 17 上線的月份。6 月 1 日先到完整的 2026-06-01 等級，6 月 18 日跟上隨 Android 17 發布的完整 2026-06-05 Pixel 等級。Android 17 對 GrapheneOS 的處境代表什麼，站上有[專文](../blog/posts/2026-grapheneos-android-17.md)討論。
+- 硬體記憶體標記這個月抓到三個上游驅動的錯誤：Broadcom Wi-Fi 驅動的 use-after-free，以及 DisplayPort 驅動的兩次越界讀取。後者的成因是部分螢幕裝置沒有照 DisplayPort 規格實作。
+- 網路定位（Network Location）對 Apple 與 Apple China 的定位服務也改為要求 TLSv1.3，跟 GrapheneOS 自家服務的要求一致。
+- Android 17 帶來幾個行為變動：Wi-Fi 快速設定改成真的關閉 Wi-Fi，不再只是斷開目前的網路。鄰近裝置權限拆出區域網路存取，沒有針對 Android 17 改版的 app 預設仍可使用。
+- 設定畫面把脅迫密碼（duress password）重新列回螢幕鎖定選單，這個功能靠有人看得到才會被用到。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 軟體更新日誌
-description: Tor、Tails、OONI、Arti、OnionShare 與 iOS 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
+description: Tor、Tails、OONI、Arti、OnionShare、iOS 與 GrapheneOS 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
 icon: material/history
 ---
 
@@ -23,6 +23,7 @@ icon: material/history
 
 - :material-usb-flash-drive-outline: [Tails 更新日誌](./tails.md)：Tails 作業系統
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 與 iPad，含急迫程度與舊機支援狀況
+- :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的強化 Android，按月聚合
 
 ## 想找完整翻譯文章
 


### PR DESCRIPTION
## 為什麼按月而不是按版

抓官方 releases atom 統計，近四個月 20 版，平均 6 天一版。而且版本號就是發布日期（`2026081300`），沒有語意版本，逐版列出來讀者也對不上自己的機器。所以這一頁把同一個月的版本合成一則，回答三件事：

- 這個月的 Android 安全修補等級推進到哪
- 有沒有修到日常會碰到的功能
- 機型支援有沒有變動

## 收錄範圍

2026 年 6、7、8 三個月。

三則都寫進了硬體記憶體標記（hardware memory tagging）攔下上游驅動錯誤的紀錄：7 月是 USB 乙太網路 gadget 驅動的 double-free，6 月是 Broadcom Wi-Fi 的 use-after-free 加 DisplayPort 驅動的兩次越界讀取。這是這套系統跟原廠 Android 的實際差別，光講「更安全」看不出來。

8 月那則的核心 backport 是 CVE-2026-64560，跟 Tails 7.10.1 修的是同一個 Linux 核心漏洞，條目直接連到 `changelog/tails.md`，兩頁互相參照讀者才看得到全貌。6 月是 Android 17 上線月，連到站上既有的 [Android 17 上線後的 GrapheneOS](../blog/posts/2026-grapheneos-android-17.md) 那篇。

## 頁首交代的兩件事

- GrapheneOS 走自動更新，一般使用者不需要為這一頁做任何事，免得讀者以為要手動處理
- 官方 atom 只保留最近 20 則（約四個月），所以歷史只能追到這裡，更早的要去官網翻

## 驗證

- `python3 tools/docs_style_lint.py` 掃六個變更檔案，0 error 0 warn
- `sh run.sh`、`sh run_zh-cn.sh`、`sh run_en.sh` 三語系建置皆通過
- 另外驗過產物裡三個內文連結都指得到（`tools/grapheneos/`、`changelog/tails/`、`blog/2026/07/2026-grapheneos-android-17/`），mkdocs 的 anchors 檢查只給 INFO，斷了不會擋建置

🤖 Generated with [Claude Code](https://claude.com/claude-code)