### PR TITLE
fix(docs): en 五頁的 front matter 沒生效，description 的冒號要跳脫

### DIFF
--- a/docs/en/changelog/grapheneos.md
+++ b/docs/en/changelog/grapheneos.md
@@ -1,6 +1,6 @@
 ---
 title: GrapheneOS Monthly Summary
-description: Plain-language monthly summaries of GrapheneOS releases: how far the Android security patch level has advanced, which everyday features got fixed, and any changes to device support.
+description: "Plain-language monthly summaries of GrapheneOS releases: how far the Android security patch level has advanced, which everyday features got fixed, and any changes to device support."
 icon: material/cellphone-lock
 ---
 

--- a/docs/en/changelog/ios.md
+++ b/docs/en/changelog/ios.md
@@ -1,6 +1,6 @@
 ---
 title: iOS Security Updates
-description: Plain-language summaries of iPhone and iPad security updates: what each one fixes, whether you need to install it now, and which older models still get patches.
+description: "Plain-language summaries of iPhone and iPad security updates: what each one fixes, whether you need to install it now, and which older models still get patches."
 icon: material/apple-ios
 ---
 

--- a/docs/en/games/onion-rendezvous.md
+++ b/docs/en/games/onion-rendezvous.md
@@ -1,6 +1,6 @@
 ---
 title: Tor Traffic Flow
-description: A watch-first visualisation. Glowing particles and afterimages trace Tor's two traffic paths: a .onion connection where both sides build a 3-hop circuit and meet at a rendezvous point, and a clear web connection that goes 3 hops to an exit and back.
+description: "A watch-first visualisation. Glowing particles and afterimages trace Tor's two traffic paths: a .onion connection where both sides build a 3-hop circuit and meet at a rendezvous point, and a clear web connection that goes 3 hops to an exit and back."
 icon: material/lan
 social:
   cards: false

--- a/docs/en/start/developer.md
+++ b/docs/en/start/developer.md
@@ -1,6 +1,6 @@
 ---
 title: Open-source developers
-description: A participation path for open-source contributors. Four independent lines depending on what you have: running nodes, measurement analysis, campus deployments, and documentation.
+description: "A participation path for open-source contributors. Four independent lines depending on what you have: running nodes, measurement analysis, campus deployments, and documentation."
 icon: material/console
 ---
 

--- a/docs/en/utils/invisible.md
+++ b/docs/en/utils/invisible.md
@@ -1,6 +1,6 @@
 ---
 title: Invisible character detector
-description: Find characters that are present but not visible: zero-width characters, bidirectional controls, tag characters, and homoglyphs mixed into Latin text. Everything happens in your browser and it works with the network off.
+description: "Find characters that are present but not visible: zero-width characters, bidirectional controls, tag characters, and homoglyphs mixed into Latin text. Everything happens in your browser and it works with the network off."
 icon: material/format-letter-matches
 ---
 


### PR DESCRIPTION
## 問題

`description` 值裡出現未加引號的「冒號加空格」，YAML 把它當成巢狀 mapping，整組 front matter 解析失敗被丟掉。後果：

- `title` 落回從檔名推導。線上 `docs/en/changelog/ios/` 的標題是 `Ios`，`docs/en/changelog/grapheneos/` 是 `Grapheneos`
- `meta description` 落回站台預設，五頁共用同一段文字
- `icon` 不會出現

mkdocs 對此完全不報錯，建置照樣 success，所以問題可以在線上放很久沒人發現。這次是驗證 GrapheneOS 上線時比對 en 的 `<title>` 才看出來，接著全站掃了一遍 front matter，找出五個。

## 受影響的檔案

| 檔案 | 來源 |
|---|---|
| `en/changelog/ios.md` | #393 新加的 |
| `en/changelog/grapheneos.md` | #394 新加的 |
| `en/games/onion-rendezvous.md` | 既有 |
| `en/utils/invisible.md` | 既有 |
| `en/start/developer.md` | 既有 |

值統一用雙引號包起來，內容一個字沒改。

## 驗證

重新建置 en（`sh run_en.sh`），五頁的 `title`、`meta description` 與 h1 的 icon 全部正常：

- `iOS Security Updates`、`GrapheneOS Monthly Summary`
- `Tor Traffic Flow`、`Invisible character detector`、`Open-source developers`

另外用 `yaml.safe_load` 掃過三語系全部 Markdown 的 front matter，修完剩 0 個解析失敗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)