### PR TITLE
feat(changelog): 標籤擴到 Tails、Tor、OnionShare，三頁各用適合自己的那組

### DIFF
--- a/docs/en/changelog/onionshare.md
+++ b/docs/en/changelog/onionshare.md
@@ -10,18 +10,25 @@ Release summaries for [OnionShare](../tools/onionshare.md), condensed from upstr
 
 OnionShare ships far less often than Tor Browser or Tails: fifteen months passed between 2.6.3 and 2.6.4. A long gap between releases is normal here, so the thing to watch is whether a given release fixes something that affects how you use it.
 
+## How we rate urgency
+
+- <span class="urg-tag urg-tag--soon">Soon</span>The release contains security fixes. An OnionShare service is reachable from outside while it runs, so its fixes usually govern who can read what you share.
+- <span class="urg-tag urg-tag--routine">Routine</span>Features, dependencies, and packaging.
+
+Releases are infrequent and none so far has warranted same-day installation, so this page has no "Now" entries yet.
+
 ## OnionShare 2.6.5
 
 > 2026-07-28 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- Dependency updates covering the bundled tor, Python packages, and web-side dependencies.
+- <span class="urg-tag urg-tag--routine">Routine</span>Dependency updates covering the bundled tor, Python packages, and web-side dependencies.
 - No new features or behaviour changes. The two security fixes from 2.6.4 remain the reason to upgrade, and anyone still on 2.6.3 can go straight to 2.6.5.
 
 ## OnionShare 2.6.4
 
 > 2026-06-09 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
 
-- Fixes two security issues affecting 2.6.3 and earlier. Both the desktop app and `onionshare-cli` are affected, since they share the same web module.
+- <span class="urg-tag urg-tag--soon">Soon</span>Fixes two security issues affecting 2.6.3 and earlier. Both the desktop app and `onionshare-cli` are affected, since they share the same web module.
 - CVE-2026-54706 ([GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}): Share mode and Website mode followed symlinks inside the selected directory and served the link target instead of restricting access to files physically inside that directory. If the shared directory contains attacker-supplied or otherwise untrusted symlinks, whoever has the onion address can read other local files readable by the OnionShare process. Rated medium severity — exploiting it requires getting a symlink into the directory you share.
 - CVE-2026-54707 ([GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}): With "Disable uploading files" enabled in Receive mode, the restriction was not enforced at the write sink. A crafted multipart request still wrote the uploaded bytes to disk; the route handler merely skipped the upload accounting. A service configured as a text-message-only endpoint could therefore be made to write unexpected files. The same release also stops an empty POST payload from creating an empty folder.
 - Dependency updates, including the bundled tor and the flatpak runtime.
@@ -31,7 +38,7 @@ OnionShare ships far less often than Tor Browser or Tails: fifteen months passed
 
 > 2025-02-25 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- The CLI gained `--log-filenames`, showing which URLs are visited in Share and Website mode.
+- <span class="urg-tag urg-tag--routine">Routine</span>The CLI gained `--log-filenames`, showing which URLs are visited in Share and Website mode.
 - A saved persistent onion tab can now start automatically once OnionShare launches and Tor connects.
 - Fixed bridge requests and meek as a pluggable transport, plus a fatal error when censorship circumvention returned no bridges.
 - Fixed a thread race segfault on CLI shutdown, and the auto-stop timer failing in Share mode after someone had visited the share.
@@ -43,7 +50,7 @@ OnionShare ships far less often than Tor Browser or Tails: fifteen months passed
 
 > 2024-03-21 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- An all-security release, concentrated on input handling in Receive mode and Chat mode.
+- <span class="urg-tag urg-tag--soon">Soon</span>An all-security release, concentrated on input handling in Receive mode and Chat mode.
 - Newlines are stripped from History item paths.
 - Text messages in Receive mode are capped at 524288 characters.
 - Usernames are restricted to specific ASCII characters with control characters removed, and username validation exceptions are handled so users can no longer join silently.

--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,11 +8,21 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## How we rate urgency
+
+- <span class="urg-tag urg-tag--now">Now</span>An emergency security release from the Tails project, marked by a third version number (7.10.1, for example). Upstream decided it could not wait for the next scheduled release, which means the flaw is serious.
+- <span class="urg-tag urg-tag--soon">Soon</span>A scheduled release whose fixes cover kernel privilege escalation, sandbox escape, or an important Tor Browser security update.
+- <span class="urg-tag urg-tag--routine">Routine</span>Everything else, mostly features and hardware support.
+
+A compromise on Tails means something different from a compromise on an ordinary OS. Gaining administrator privileges means losing anonymity protection, and the attacker sees everything you do inside Tails, so "Now" on this page deserves to be taken more seriously than elsewhere.
+
+The Tails project only distinguishes emergency from scheduled releases. The middle tier is a judgement community volunteers add after reading each advisory.
+
 ## Tails 7.11
 
 > 2026-08-19 · [Upstream announcement](https://tails.net/news/version_7.11/){target="_blank"}
 
-- A scheduled release that also carries a Linux kernel security update.
+- <span class="urg-tag urg-tag--soon">Soon</span>A scheduled release that also carries a Linux kernel security update.
 - Tor Browser updated to 15.0.20 (based on Firefox ESR 140.14).
 - The kernel is updated to 6.12.101, covering the 24 flaws in Debian security advisory DSA-6415-1, whose impact ranges over privilege escalation, denial of service, and information leaks.
 - Fixes Persistent Storage failing to unlock on some computers. Activation used to wait for `udevadm settle`, so an unrelated hardware problem could make that step time out or fail; the wait has been removed.
@@ -25,7 +35,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-08-05 · [Upstream announcement](https://tails.net/news/version_7.10.1/){target="_blank"}
 
-- Emergency security release fixing critical flaws in the Linux kernel and the expat XML library.
+- <span class="urg-tag urg-tag--now">Now</span>Emergency security release fixing critical flaws in the Linux kernel and the expat XML library.
 - The kernel is updated to 6.12.100, fixing CVE-2026-64560, which could let Tor Browser inside Tails gain administrator privileges. A malicious website that exploits it could fully compromise Tails and deanonymize the user. The attack is unlikely and would take a strong adversary such as a government or a hacking firm; no active exploitation has been observed.
 - The expat XML library is updated to 2.8.2, fixing DSA-6404-1, a set of flaws that could let applications using expat gain administrator privileges. Opening a malicious file in LibreOffice, Audacity, or Git could lead to the same full compromise and deanonymization. No active exploitation has been observed.
 - USB images and automatic upgrades are 70 MB smaller after removing unused firmware.
@@ -36,7 +46,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-23 · [Upstream announcement](https://tails.net/news/version_7.10/){target="_blank"}
 
-- A scheduled release introducing a new shutdown procedure and a new video player.
+- <span class="urg-tag urg-tag--soon">Soon</span>A scheduled release introducing a new shutdown procedure and a new video player.
 - Adopts GNOME's standard shutdown procedure. The Power Off dialog now warns about unsaved documents and open applications, and shutdown completes automatically after 60 seconds. It is a bit slower in exchange for better data protection. An emergency shutdown option remains for a faster power-off.
 - The video player is now Celluloid, more modern and reliable, and it has no network access. To watch videos online, use Tor Browser or install VLC as additional software. Celluloid does not work on computers manufactured in 2011 or earlier.
 - Tor Browser updated to 15.0.19.
@@ -47,7 +57,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-01 · [Upstream announcement](https://tails.net/news/version_7.9.1/){target="_blank"}
 
-- Emergency security release fixing two local privilege-escalation flaws in the Linux kernel.
+- <span class="urg-tag urg-tag--now">Now</span>Emergency security release fixing two local privilege-escalation flaws in the Linux kernel.
 - Patches CVE-2026-43503 (DirtyClone) and CVE-2026-46331 (PACKET_EDIT_MEME), with the kernel updated to 6.12.94. Such flaws let an application inside Tails gain administrator privileges; combined with other unknown vulnerabilities they could fully compromise Tails and deanonymize the user. No active exploitation has been observed.
 - Tor Browser updated to 15.0.17, and the Tor client to 0.4.9.11.
 - This is a security-only release; aside from Tor Browser, the kernel, and the Tor client, it keeps 7.9's software set. Automatic upgrades are available from Tails 7.0 or later.
@@ -56,7 +66,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-18 · [Upstream announcement](https://tails.net/news/version_7.9/){target="_blank"}
 
-- Regular scheduled release, not an emergency security update.
+- <span class="urg-tag urg-tag--routine">Routine</span>Regular scheduled release, not an emergency security update.
 - Tor Browser updated to 15.0.16.
 - Updated some firmware packages, improving support for newer hardware such as graphics and Wi-Fi.
 - Fixed a bug where the "outdated Secure Boot certificate" prompt could appear in the rare case when the certificates were already up to date.
@@ -66,7 +76,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-04 · [Upstream announcement](https://tails.net/news/version_7.8.1/){target="_blank"}
 
-- Emergency security release fixing a serious Linux kernel vulnerability and several Tor client security vulnerabilities.
+- <span class="urg-tag urg-tag--now">Now</span>Emergency security release fixing a serious Linux kernel vulnerability and several Tor client security vulnerabilities.
 - Patches the Linux kernel flaw CVE-2026-43503 (kernel updated to 6.12.90-2), a local privilege escalation that lets an application inside Tails gain administrator privileges; combined with other unknown vulnerabilities it could fully compromise Tails and deanonymize the user. No active exploitation has been observed.
 - Tor client updated to 0.4.9.9, fixing several security vulnerabilities.
 - This is a security-only emergency release; Tor Browser, Thunderbird, and the Debian base version are unchanged from 7.8. Automatic upgrades are available from Tails 7.0 or later.
@@ -75,7 +85,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-05-21 · [Upstream announcement](https://tails.net/news/version_7.8/){target="_blank"}
 
-- Tor Browser updated to 15.0.14 (based on Firefox ESR 140.11).
+- <span class="urg-tag urg-tag--soon">Soon</span>Tor Browser updated to 15.0.14 (based on Firefox ESR 140.11).
 - Mitigates the Linux kernel local privilege escalation "Fragnesia" (alongside the earlier "Drity Frag" mitigation). Such flaws let an application inside Tails gain administrator privileges, which combined with other unknown vulnerabilities could fully compromise Tails and deanonymize the user.
 - Mitigates a Flatpak sandbox escape via Yelp; yelp updated to 42.2-4tails1.
 - Patches CVE-2026-46529 (evince), CVE-2026-41989 (libgcrypt20), and CVE-2026-41054 (haveged).
@@ -88,7 +98,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-03-26 · [Upstream announcement](https://tails.net/news/version_7.6/){target="_blank"} · [Full translation](../blog/posts/2026-tails-7-6.md)
 
-- Automatic Tor bridges (region-aware via Moat API), GNOME Secrets replaces KeePassXC as the built-in password manager, routine component bumps (Tor Browser 15.0.8, Thunderbird 140.8.0, Electrum 4.7.0).
+- <span class="urg-tag urg-tag--routine">Routine</span>Automatic Tor bridges (region-aware via Moat API), GNOME Secrets replaces KeePassXC as the built-in password manager, routine component bumps (Tor Browser 15.0.8, Thunderbird 140.8.0, Electrum 4.7.0).
 
 !!! info "Earlier versions"
 

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,11 +8,18 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Two release channels
+
+- <span class="chan-tag chan-tag--stable">Stable</span>What regular users should run, versioned like 15.0.20.
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Testing only. It may contain bugs affecting usability, security, and privacy, and is versioned with an a (16.0a10, for example). Do not use it if you need strong anonymity.
+
+Since 16.0a9 the alpha channel tracks Firefox betas and rebases incrementally, so versions move faster than they used to. Stable releases almost always carry Firefox or tor daemon security fixes, so install them as they appear.
+
 ## Tor Browser 16.0a10 (alpha)
 
 > 2026-08-27 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
 
-- The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
+- <span class="chan-tag chan-tag--alpha">Alpha</span>The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
 - New opt-in "Use generic window titles" setting, under Privacy and security → Advanced settings → Protections from third-party applications. With it enabled, every window title simply reads Tor Browser Alpha. Window titles normally track the page's `<title>` element, and other applications or the OS can read those changes without special permissions, which makes them a side channel for recording browsing history. The feature has been upstreamed, so vanilla Firefox users can set `privacy.exposeContentTitleInWindow` and `privacy.exposeContentTitleInWindow.pbm` to false in `about:config`. The Tor Project had hoped to enable it by default in 16.0, but held off over possible breakage with accessibility software and non-standard desktop environments.
 - The desktop built-in manual has been replaced with the Tor Project's updated support content, baked into the browser. Open it directly at `about:manual`, or through the "Learn more" links in the UI.
 - The settings page now uses Mozilla's redesigned `about:preferences` by default, with Tor Browser's own settings (connection, letterboxing, security level) migrated to the new design language.
@@ -25,7 +32,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-08-18 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
 
-- A small release focused on Firefox security fixes.
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes.
 - Rebased the Firefox base onto 140.14.0esr (tor-browser#45204); desktop and Android GeckoView also moved to 140.14.0esr.
 - Backported security fixes from Firefox 154 (tor-browser#45219).
 - Updated libevent to 2.1.13 in the build toolchain (tor-browser-build#41839).
@@ -36,7 +43,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-07-23 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
 
-- The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
+- <span class="chan-tag chan-tag--alpha">Alpha</span>The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
 - Major rebase of the Firefox base onto 153.0esr (up from 140.0esr); Android GeckoView also moved to 153.0esr (tor-browser#45101).
 - The Tor Project announced the alpha channel will now track Firefox beta releases and rebase incrementally, instead of jumping a full year of Firefox versions at once, aiming to ship Tor Browser 16.0 stable a month early in September.
 - NoScript updated to 13.6.30.90201984, Go to 1.26.5, and libevent to 2.1.13 in the build toolchain.
@@ -47,7 +54,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-07-21 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
 
-- A small release focused on Firefox security fixes, carrying important security updates from Firefox.
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes, carrying important security updates from Firefox.
 - Rebased the Firefox base onto 140.13.0esr (tor-browser#45117); desktop and Android GeckoView also moved to 140.13.0esr.
 - Backported security fixes from Firefox 153 (tor-browser#45124).
 - NoScript updated to 13.6.31.1984.
@@ -57,7 +64,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-07-14 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
 
-- A small release focused on Firefox security fixes.
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes.
 - The Firefox base stays at 140.12.0esr; rather than rebasing, later fixes were cherry-picked from the firefox/esr140 branch (tor-browser#45111).
 - NoScript updated to 13.6.30.1984, and Go to 1.25.12 in the build toolchain (Windows, Linux, Android).
 - Build process updated boklm's GPG subkey (tor-browser-build#41821).
@@ -66,7 +73,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-07-02 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}
 
-- The alpha channel is for testing only and may contain usability, security, and privacy bugs; regular users should stay on the stable channel (15.x).
+- <span class="chan-tag chan-tag--alpha">Alpha</span>The alpha channel is for testing only and may contain usability, security, and privacy bugs; regular users should stay on the stable channel (15.x).
 - Important Firefox security update, rebased onto Firefox 152.0a1 (the previous alpha 16.0a7 was on 151.0a1); Android GeckoView also moved to 152.0a1.
 - tor client updated to 0.4.9.11, NoScript to 13.6.25.90301984, OpenSSL to 3.5.7, and Go to 1.26.4 in the build toolchain.
 - Fixed a cross-site oracle vulnerability by rejecting worklets in Safer Mode; XSLT disabled for the 16.0 series.
@@ -76,7 +83,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-06-28 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
 
-- A small release focused on a tor security update, with no change to the Firefox base.
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on a tor security update, with no change to the Firefox base.
 - tor client updated to 0.4.9.11.
 - NoScript updated to 13.6.25.1984.
 - Build process updated boklm's GPG subkey and renewed morgan's signing key (tor-browser-build#41821, #41827).
@@ -85,7 +92,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-06-17 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
 
-- Important security update to Firefox.
+- <span class="chan-tag chan-tag--stable">Stable</span>Important security update to Firefox.
 - Rebased onto Firefox 140.12.0esr (tor-browser#45046), with security fixes backported from Firefox 152 (tor-browser#45054); Android GeckoView also moved to 140.12.0esr.
 - NoScript updated to 13.6.24.1984, fixing a DocStartInjection regression introduced in 13.6.19.902 (tor-browser#45044); OpenSSL updated to 3.5.7.
 - Removed the tor daemon requirement for signing (tor-browser-build#41802), and updated Go to 1.25.11 in the build toolchain.
@@ -94,7 +101,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-06-03 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
 
-- Important security update to the tor daemon, plus fixes for some censorship circumvention problems.
+- <span class="chan-tag chan-tag--stable">Stable</span>Important security update to the tor daemon, plus fixes for some censorship circumvention problems.
 - tor client updated to 0.4.9.9, NoScript updated to 13.6.20.1984.
 - Moat module now supports multiple configured (front, reflector) domain fronting pairs (tor-browser#42436).
 - Fixed a captcha failure on desktop (tor-browser#44997) and notified Linux i686 users that updates have ended (tor-browser#44886).
@@ -103,7 +110,7 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 
 > 2026-06-03 · [dist directory](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
 
-- The alpha channel is for testing only; regular users should stay on the stable channel (15.x). Binaries are published on dist, but the upstream blog has not posted an announcement yet. Now based on Firefox 151.0a1 (the previous alpha 16.0a6 was on 150.0a1).
+- <span class="chan-tag chan-tag--alpha">Alpha</span>The alpha channel is for testing only; regular users should stay on the stable channel (15.x). Binaries are published on dist, but the upstream blog has not posted an announcement yet. Now based on Firefox 151.0a1 (the previous alpha 16.0a6 was on 150.0a1).
 
 !!! info "Earlier Tor Browser versions"
 

--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -71,7 +71,8 @@
    colour blindness or monochrome printing.
    Light contrast 5.72 / 5.81 / 8.35, dark 6.41 / 9.33 / 7.24, all pass AA 4.5
    ========================================================================== */
-.urg-tag {
+.urg-tag,
+.chan-tag {
   display: inline-block;
   font-size: 0.66rem;
   font-weight: 700;
@@ -90,6 +91,12 @@
 [data-md-color-scheme="slate"] .urg-tag--now     { background: rgba(211,47,47,.18);  color: #ef9a9a; border-color: rgba(211,47,47,.45); }
 [data-md-color-scheme="slate"] .urg-tag--soon    { background: rgba(230,145,0,.18);  color: #ffcc80; border-color: rgba(230,145,0,.45); }
 [data-md-color-scheme="slate"] .urg-tag--routine { background: rgba(120,144,156,.20); color: #b0bec5; border-color: rgba(120,144,156,.45); }
+
+.chan-tag--stable { background: #e8f5e9; color: #1b5e20; border-color: #a5d6a7; }
+.chan-tag--alpha  { background: #f3e5f5; color: #6a1b9a; border-color: #ce93d8; }
+
+[data-md-color-scheme="slate"] .chan-tag--stable { background: rgba(76,175,80,.18);  color: #81c784; border-color: rgba(76,175,80,.42); }
+[data-md-color-scheme="slate"] .chan-tag--alpha  { background: rgba(123,31,162,.24); color: #ce93d8; border-color: rgba(123,31,162,.50); }
 
 /* Schedule table: tint the session icon + title with the category colour (matches .sess-tag,
    only appears on the activity page; :has(+ strong) targets the session icon before the title,

--- a/docs/zh-CN/changelog/onionshare.md
+++ b/docs/zh-CN/changelog/onionshare.md
@@ -10,18 +10,25 @@ icon: material/share-variant
 
 OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 之间隔了十五个月。长时间没有新版属于正常状态，重点放在每次发布的安全修补有没有打到自己的用法。
 
+## 紧急程度怎么判断
+
+- <span class="urg-tag urg-tag--soon">尽快</span>该版含安全修补。OnionShare 的服务在运行期间是对外可触及的，修补通常关系到谁读得到你分享的内容。
+- <span class="urg-tag urg-tag--routine">一般</span>功能、依赖包与打包更新。
+
+发版节奏慢，目前没有出现过需要当天更新的等级，所以这一页还没有「立刻」。
+
 ## OnionShare 2.6.5
 
 > 2026-07-28 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- 依赖包更新，涵盖内置的 tor、Python 包与网页端依赖。
+- <span class="urg-tag urg-tag--routine">一般</span>依赖包更新，涵盖内置的 tor、Python 包与网页端依赖。
 - 没有新功能与行为变更。2.6.4 的两个安全修补仍是这一轮的重点，还停在 2.6.3 的人可以直接升到 2.6.5。
 
 ## OnionShare 2.6.4
 
 > 2026-06-09 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
 
-- 修补两个安全问题，影响 2.6.3 与更早的版本，桌面版与 `onionshare-cli` 都受影响，两者共用同一份 web 模块。
+- <span class="urg-tag urg-tag--soon">尽快</span>修补两个安全问题，影响 2.6.3 与更早的版本，桌面版与 `onionshare-cli` 都受影响，两者共用同一份 web 模块。
 - CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式与网站模式会跟着文件夹里的符号链接（symlink）走，把链接指向的文件一并提供出去。分享的文件夹里若有他人放进来或来源不明的符号链接，获得 onion 地址的对方就能读到 OnionShare 进程权限范围内的其他本地文件。严重度评为中等，利用前提是对方要先有办法把符号链接放进你分享的文件夹。
 - CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾选「停用文件上传」之后，限制没有落实到实际写文件那一段。发出特制的 multipart 请求仍会把文件写进磁盘，路由处理只是不把它计入上传记录。设置成纯文本消息端点的服务因此可能被写入非预期的文件。同一版顺手修掉空的 POST 请求会创建空文件夹的问题。
 - 依赖包更新，包含内置的 tor 与 flatpak runtime。
@@ -31,7 +38,7 @@ OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2025-02-25 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- CLI 新增 `--log-filenames`，分享模式与网站模式可以看到哪些网址被访问过。
+- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式与网站模式可以看到哪些网址被访问过。
 - 保存下来的持久 onion 标签页，可在 OnionShare 启动并连上 Tor 之后自动开始服务。
 - 修好无法获取网桥、无法使用 meek 传输的问题，以及网桥查询没有返回结果时的致命错误。
 - 修好 CLI 关闭时线程竞争造成的 segfault，以及分享模式在有人访问过之后自动停止计时器失效的问题。
@@ -43,7 +50,7 @@ OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2024-03-21 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- 全部是安全修补，集中在接收模式与聊天模式的输入处理。
+- <span class="urg-tag urg-tag--soon">尽快</span>全部是安全修补，集中在接收模式与聊天模式的输入处理。
 - 历史记录项目的路径移除换行字符。
 - 接收模式的文本消息长度上限设为 524288 字符。
 - 用户名只允许特定 ASCII 字符并移除控制字符，另补上名称验证的异常处理，避免无声加入聊天室。

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,11 +8,21 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## 紧急程度怎么判断
+
+- <span class="urg-tag urg-tag--now">立刻</span>Tails 官方发出的紧急安全发布，版本号带第三码（例如 7.10.1）。上游判断不能等到下次排程，代表漏洞后果严重。
+- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，但修补涵盖内核提权、sandbox 逃逸或 Tor Browser 的重要安全更新。
+- <span class="urg-tag urg-tag--routine">一般</span>其余例行版本，以功能与硬件支持为主。
+
+Tails 上的漏洞后果跟一般操作系统不同。取得管理员权限等于失去匿名保护，攻击者看得到你在 Tails 里做的每一件事，所以这一页的「立刻」比其他页更值得当真。
+
+Tails 官方只区分紧急发布与排程发布，中间那一层是社群志愿者读完公告后补的判断。
+
 ## Tails 7.11
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
 
-- 例行排程版本，同时带入 Linux 内核的安全更新。
+- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，同时带入 Linux 内核的安全更新。
 - Tor Browser 升至 15.0.20（基于 Firefox ESR 140.14）。
 - 内核升至 6.12.101，涵盖 Debian 安全公告 DSA-6415-1 的 24 个漏洞，影响包含提权、拒绝服务与信息泄露。
 - 修正部分电脑上 Persistent Storage 无法解锁的问题。启用流程原本会等待 `udevadm settle`，无关的硬件问题会让这一步超时或失败，现已不再等待。
@@ -25,7 +35,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}
 
-- 紧急安全更新，修补 Linux 内核与 expat XML 库的重大漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>紧急安全更新，修补 Linux 内核与 expat XML 库的重大漏洞。
 - 内核升至 6.12.100，修补 CVE-2026-64560。此漏洞可让 Tails 内的 Tor Browser 取得管理员权限，访问的恶意网站若成功利用，可能完整接管 Tails 并进行去匿名化。攻击难度高，具备政府或商业黑客团队等级的资源才办得到，目前尚未发现实际被利用案例。
 - expat XML 库升至 2.8.2，修补 DSA-6404-1 这组漏洞。使用 expat 的应用程序（LibreOffice、Audacity、Git 等）被诱导开启恶意文件时，可能被用来取得管理员权限，后续同样可能导致接管与去匿名化。目前尚未发现实际被利用案例。
 - 移除未使用的 firmware，USB image 与自动升级文件各缩小 70 MB。
@@ -36,7 +46,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
 
-- 例行排程版本，带来新的关机流程与视频播放器。
+- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，带来新的关机流程与视频播放器。
 - 改用 GNOME 标准关机流程。关机前会提醒尚未保存的文档与开启中的应用程序，并在 60 秒后自动关机。速度略慢，换来更好的数据保护。紧急关机选项仍保留，供需要快速断电时使用。
 - 视频播放器改用 Celluloid，更现代也更可靠，且不具网络访问权限。要在线看视频请改用 Tor Browser，或额外安装 VLC。此播放器不支持 2011 年（含）以前制造的电脑。
 - Tor Browser 升至 15.0.19。
@@ -47,7 +57,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-01 · [上游公告](https://tails.net/news/version_7.9.1/){target="_blank"}
 
-- 紧急安全更新，修补 Linux 内核两个本地提权漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>紧急安全更新，修补 Linux 内核两个本地提权漏洞。
 - 修补 CVE-2026-43503（DirtyClone）与 CVE-2026-46331（PACKET_EDIT_MEME），内核升至 6.12.94。此类漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。目前尚未发现实际被利用案例。
 - Tor Browser 升至 15.0.17，Tor 客户端升至 0.4.9.11。
 - 此版为安全专用发布，除 Tor Browser、内核与 Tor 客户端外沿用 7.9 的软件组合。可从 Tails 7.0 以后版本自动升级。
@@ -56,7 +66,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
 
-- 例行排程版本，非紧急安全发布。
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非紧急安全发布。
 - Tor Browser 升至 15.0.16。
 - 更新部分 firmware 套件，改善较新硬件的支持，包含显卡、Wi-Fi 等。
 - 修正在 Secure Boot 证书已是最新的少数情境下，仍误跳「证书过期」通知的问题。
@@ -66,7 +76,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}
 
-- 紧急安全更新，修补 Linux 内核重大漏洞与 Tor 客户端的多个安全漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>紧急安全更新，修补 Linux 内核重大漏洞与 Tor 客户端的多个安全漏洞。
 - 修补 Linux 内核漏洞 CVE-2026-43503（内核升至 6.12.90-2），此漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。目前尚未发现实际被利用案例。
 - Tor 客户端升至 0.4.9.9，修补多个安全漏洞。
 - 此版为安全专用的紧急发布，未变动 Tor Browser、Thunderbird 与 Debian 底层版本，沿用 7.8 的软件组合。可从 Tails 7.0 以后版本自动升级。
@@ -75,7 +85,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
 
-- Tor Browser 升至 15.0.14（基于 Firefox ESR 140.11）。
+- <span class="urg-tag urg-tag--soon">尽快</span>Tor Browser 升至 15.0.14（基于 Firefox ESR 140.11）。
 - 修补 Linux 内核本地提权漏洞「Fragnesia」（同步缓解「Drity Frag」）。此类漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。
 - 修补 Flatpak 通过 Yelp 逃逸沙箱的问题，yelp 升至 42.2-4tails1。
 - 修补 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
@@ -92,28 +102,28 @@ icon: material/usb-flash-drive-outline
 
 > 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻译文章](../blog/posts/2026-tails-7-6.md)
 
-- 自动 Tor 桥接（依用户区域获取）、GNOME Secrets 取代 KeePassXC 作为内置密码管理器、例行组件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
+- <span class="urg-tag urg-tag--routine">一般</span>自动 Tor 桥接（依用户区域获取）、GNOME Secrets 取代 KeePassXC 作为内置密码管理器、例行组件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
 
 ## Tails 7.1
 
 > 2025-10-15 · [上游公告](https://tails.net/news/version_7.1/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-1-released.md)
 
-- Tor Browser 首页改为离线版本（移除启动时的 metadata 泄露）、Snowflake 桥接更新方式翻新、例行组件更新（Tor Browser 14.5.8、Tor 客户端 0.4.8.19、Thunderbird 140.3.0）。
+- <span class="urg-tag urg-tag--routine">一般</span>Tor Browser 首页改为离线版本（移除启动时的 metadata 泄露）、Snowflake 桥接更新方式翻新、例行组件更新（Tor Browser 14.5.8、Tor 客户端 0.4.8.19、Thunderbird 140.3.0）。
 
 ## Tails 7.0
 
 > 2025-09-20 · [上游公告](https://tails.net/news/version_7.0/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-released.md)
 
-- 首个以 Debian 13（Trixie）与 GNOME 48（Bengaluru）为基底的大版本，桌面与系统组件全面升级。
+- <span class="urg-tag urg-tag--routine">一般</span>首个以 Debian 13（Trixie）与 GNOME 48（Bengaluru）为基底的大版本，桌面与系统组件全面升级。
 
 ## Tails 7.0~rc2
 
 > 2025-08-29 · [上游公告](https://tails.net/news/test_7.0-rc2/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-rc.md)
 
-- Tails 7.0 第二个发行候选版（RC2），开放社群协助测试 Debian 13 与 GNOME 48 新基底、自动升级流程、持久存储迁移。
+- <span class="chan-tag chan-tag--alpha">RC 测试版</span>Tails 7.0 第二个发行候选版（RC2），开放社群协助测试 Debian 13 与 GNOME 48 新基底、自动升级流程、持久存储迁移。
 
 ## Tails 6.18
 
 > 2025-07-31 · [上游公告](https://tails.net/news/version_6.18/){target="_blank"} · [完整翻译文章](../blog/posts/tails-6-18-webtunnel.md)
 
-- 新增 WebTunnel 桥接协议支持，把 Tor 流量伪装成 HTTPS，对无法直接连入 Tor 的网络环境多一条进入路径。
+- <span class="urg-tag urg-tag--routine">一般</span>新增 WebTunnel 桥接协议支持，把 Tor 流量伪装成 HTTPS，对无法直接连入 Tor 的网络环境多一条进入路径。

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,11 +8,18 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## 两个发布通道
+
+- <span class="chan-tag chan-tag--stable">稳定版</span>一般用户用这个，版本号形如 15.0.20。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>仅供测试，可能含影响可用性、安全与隐私的错误，版本号带 a（例如 16.0a10）。需要强匿名保护的人不要用。
+
+Alpha 从 16.0a9 起改为跟着 Firefox beta 逐步 rebase，版本跳动比过去频繁。稳定版几乎每次发布都带 Firefox 或 tor daemon 的安全修补，看到新版就更新即可。
+
 ## Tor Browser 16.0a10（Alpha 测试通道）
 
 > 2026-08-27 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
 
-- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
 - 新增「使用通用窗口标题」选项，在设置的隐私与安全、高级设置、防范第三方应用程序那一组，开启后所有窗口标题一律显示 Tor Browser Alpha。窗口标题默认跟着网页的 title 变动，操作系统与其他程序不需特殊权限就读得到，可以当成侧录浏览记录的旁路通道。此功能已上游进 Firefox，一般 Firefox 用户可在 `about:config` 把 `privacy.exposeContentTitleInWindow` 与 `privacy.exposeContentTitleInWindow.pbm` 设为 false。官方原本希望 16.0 稳定版就默认开启，顾虑无障碍软件与非标准桌面环境的兼容性，改为先开放测试。
 - 桌面版内置手册改版，把更新过的官方说明内容打包进浏览器取代旧版手册，地址栏输入 `about:manual` 可直接打开，界面上的「Learn more」也都指向新版。
 - 设置页改用 Mozilla 的新版 `about:preferences` 设计并默认启用，连接、letterboxing、安全等级等自定义项目都已搬到新版面。
@@ -25,7 +32,7 @@ icon: simple/torbrowser
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
 
-- 以 Firefox 安全修补为主的小版本。
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本。
 - Firefox 基底 rebase 至 140.14.0esr（tor-browser#45204），桌面版与 Android 版 GeckoView 同步升至 140.14.0esr。
 - 从 Firefox 154 backport 安全修补（tor-browser#45219）。
 - libevent 升至 2.1.13（tor-browser-build#41839）。
@@ -36,7 +43,7 @@ icon: simple/torbrowser
 
 > 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
 
-- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
 - Firefox 基底大幅 rebase 至 153.0esr（前一版为 140.0esr），Android 版 GeckoView 同步升至 153.0esr（tor-browser#45101）。
 - 官方宣布 Alpha 通道日后改为持续追踪 Firefox beta 版本、逐步小步 rebase，取代过去一次跳过整年版本的做法，目标让 16.0 稳定版于 9 月提前发布。
 - NoScript 升至 13.6.30.90201984，构建工具链的 Go 升至 1.26.5，libevent 升至 2.1.13。
@@ -47,7 +54,7 @@ icon: simple/torbrowser
 
 > 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
 
-- 以 Firefox 安全修补为主的小版本，带入来自 Firefox 的重要安全更新。
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本，带入来自 Firefox 的重要安全更新。
 - Firefox 基底 rebase 至 140.13.0esr（tor-browser#45117），桌面版与 Android 版 GeckoView 同步升至 140.13.0esr。
 - 从 Firefox 153 backport 安全修补（tor-browser#45124）。
 - NoScript 升至 13.6.31.1984。
@@ -57,7 +64,7 @@ icon: simple/torbrowser
 
 > 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
 
-- 以 Firefox 安全修补为主的小版本。
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本。
 - Firefox 基底维持 140.12.0esr，改以 cherry-pick 带入 firefox/esr140 分支的后续修补（tor-browser#45111），未做 rebase。
 - NoScript 升至 13.6.30.1984，构建工具链的 Go 升至 1.25.12（Windows、Linux、Android）。
 - 构建流程更新 boklm 的 GPG 子密钥（tor-browser-build#41821）。
@@ -66,7 +73,7 @@ icon: simple/torbrowser
 
 > 2026-07-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}
 
-- Alpha 通道仅供测试，可能含影响可用性、安全与隐私的错误，一般用户请继续用稳定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道仅供测试，可能含影响可用性、安全与隐私的错误，一般用户请继续用稳定版（15.x）。
 - 重要的 Firefox 安全更新，rebase 至 Firefox 152.0a1（前一个 Alpha 16.0a7 为 151.0a1），Android 版 GeckoView 同步升至 152.0a1。
 - tor 客户端升至 0.4.9.11、NoScript 升至 13.6.25.90301984、OpenSSL 升至 3.5.7、构建工具链的 Go 升至 1.26.4。
 - 修补跨站 oracle 漏洞，Safer Mode 下拒绝 worklet。16.0 系列停用 XSLT。
@@ -76,7 +83,7 @@ icon: simple/torbrowser
 
 > 2026-06-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
 
-- 以 tor 安全更新为主的小版本，未变动 Firefox 基底。
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 tor 安全更新为主的小版本，未变动 Firefox 基底。
 - tor 客户端升至 0.4.9.11，NoScript 升至 13.6.25.1984。
 - 构建流程更新 boklm 的 GPG 子密钥与 morgan 的续期密钥（tor-browser-build#41821、#41827）。
 
@@ -84,7 +91,7 @@ icon: simple/torbrowser
 
 > 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
 
-- 重要的 Firefox 安全更新。
+- <span class="chan-tag chan-tag--stable">稳定版</span>重要的 Firefox 安全更新。
 - rebase 至 Firefox 140.12.0esr（tor-browser#45046），backport 自 Firefox 152 的安全修补（tor-browser#45054），Android 版 GeckoView 同步升至 140.12.0esr。
 - NoScript 升至 13.6.24.1984，修正前一版 13.6.19.902 在 DocStartInjection 上的 regression（tor-browser#45044），OpenSSL 升至 3.5.7。
 - 签章流程移除对 tor daemon 的依赖（tor-browser-build#41802），构建工具链的 Go 升至 1.25.11。
@@ -93,7 +100,7 @@ icon: simple/torbrowser
 
 > 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
 
-- tor daemon 重要安全更新，修正部分审查规避问题。
+- <span class="chan-tag chan-tag--stable">稳定版</span>tor daemon 重要安全更新，修正部分审查规避问题。
 - tor 客户端升至 0.4.9.9，NoScript 升至 13.6.20.1984。
 - Moat 模块支持设置多组 (front, reflector) domain fronting 配对（tor-browser#42436）。
 - 修正桌面版 Captcha 无法运行的问题（tor-browser#44997），并通知 Linux i686 用户不再提供更新（tor-browser#44886）。
@@ -102,7 +109,7 @@ icon: simple/torbrowser
 
 > 2026-06-03 · [dist 目录](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
 
-- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。已在 dist 提供二进制文件，官方博客尚未发布对应公告。改以 Firefox 151.0a1 为基础（前一个 Alpha 16.0a6 为 150.0a1）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。已在 dist 提供二进制文件，官方博客尚未发布对应公告。改以 Firefox 151.0a1 为基础（前一个 Alpha 16.0a6 为 150.0a1）。
 
 !!! info "更早的 Tor Browser 版本"
 

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -69,7 +69,8 @@
    淡底深字、过 AA。颜色只是辅助，标签本身带文字，色盲与单色打印都读得到）
    浅色三组对比 5.72 / 5.81 / 8.35，深色 6.41 / 9.33 / 7.24，全部过 AA 4.5
    ========================================================================== */
-.urg-tag {
+.urg-tag,
+.chan-tag {
   display: inline-block;
   font-size: 0.66rem;
   font-weight: 700;
@@ -88,6 +89,12 @@
 [data-md-color-scheme="slate"] .urg-tag--now     { background: rgba(211,47,47,.18);  color: #ef9a9a; border-color: rgba(211,47,47,.45); }
 [data-md-color-scheme="slate"] .urg-tag--soon    { background: rgba(230,145,0,.18);  color: #ffcc80; border-color: rgba(230,145,0,.45); }
 [data-md-color-scheme="slate"] .urg-tag--routine { background: rgba(120,144,156,.20); color: #b0bec5; border-color: rgba(120,144,156,.45); }
+
+.chan-tag--stable { background: #e8f5e9; color: #1b5e20; border-color: #a5d6a7; }
+.chan-tag--alpha  { background: #f3e5f5; color: #6a1b9a; border-color: #ce93d8; }
+
+[data-md-color-scheme="slate"] .chan-tag--stable { background: rgba(76,175,80,.18);  color: #81c784; border-color: rgba(76,175,80,.42); }
+[data-md-color-scheme="slate"] .chan-tag--alpha  { background: rgba(123,31,162,.24); color: #ce93d8; border-color: rgba(123,31,162,.50); }
 
 /* 议程表：场次图示与标题也套上分类色（对齐 .sess-tag，只在活动页议程表出现；
    :has(+ strong) 精准选到标题前的场次图示，描述列的箭头图示维持中性） */

--- a/docs/zh-TW/changelog/onionshare.md
+++ b/docs/zh-TW/changelog/onionshare.md
@@ -10,18 +10,25 @@ icon: material/share-variant
 
 OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 之間隔了十五個月。長時間沒有新版屬於正常狀態，重點放在每次釋出的安全修補有沒有打到自己的用法。
 
+## 急迫程度怎麼判斷
+
+- <span class="urg-tag urg-tag--soon">儘快</span>該版含安全修補。OnionShare 的服務在執行期間是對外可觸及的，修補通常關係到誰讀得到你分享的內容。
+- <span class="urg-tag urg-tag--routine">一般</span>功能、相依套件與打包更新。
+
+發版節奏慢，目前沒有出現過需要當天更新的等級，所以這一頁還沒有「立刻」。
+
 ## OnionShare 2.6.5
 
 > 2026-07-28 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- 相依套件更新，涵蓋內建的 tor、Python 套件與網頁端相依。
+- <span class="urg-tag urg-tag--routine">一般</span>相依套件更新，涵蓋內建的 tor、Python 套件與網頁端相依。
 - 沒有新功能與行為變更。2.6.4 的兩個安全修補仍是這一輪的重點，還停在 2.6.3 的人可以直接升到 2.6.5。
 
 ## OnionShare 2.6.4
 
 > 2026-06-09 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
 
-- 修補兩個安全問題，影響 2.6.3 與更早的版本，桌面版與 `onionshare-cli` 都受影響，兩者共用同一份 web 模組。
+- <span class="urg-tag urg-tag--soon">儘快</span>修補兩個安全問題，影響 2.6.3 與更早的版本，桌面版與 `onionshare-cli` 都受影響，兩者共用同一份 web 模組。
 - CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式與網站模式會跟著資料夾裡的符號連結（symlink）走，把連結指向的檔案一併提供出去。分享的資料夾裡若有他人放進來或來源不明的符號連結，取得 onion 網址的對方就能讀到 OnionShare 行程權限範圍內的其他本機檔案。嚴重度評為中等，利用前提是對方要先有辦法把符號連結放進你分享的資料夾。
 - CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾選「停用檔案上傳」之後，限制沒有落實到實際寫檔那一段。送出特製的 multipart 請求仍會把檔案寫進磁碟，路由處理只是不把它計入上傳紀錄。設定成純文字訊息端點的服務因此可能被寫入非預期的檔案。同一版順手修掉空的 POST 請求會建立空資料夾的問題。
 - 相依套件更新，包含內建的 tor 與 flatpak runtime。
@@ -31,7 +38,7 @@ OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2025-02-25 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- CLI 新增 `--log-filenames`，分享模式與網站模式可以看到哪些網址被造訪過。
+- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式與網站模式可以看到哪些網址被造訪過。
 - 儲存下來的持續性 onion 分頁，可在 OnionShare 啟動並連上 Tor 之後自動開始服務。
 - 修好無法取得橋接、無法使用 meek 傳輸的問題，以及橋接查詢沒有回傳結果時的致命錯誤。
 - 修好 CLI 關閉時執行緒競爭造成的 segfault，以及分享模式在有人造訪過之後自動停止計時器失效的問題。
@@ -43,7 +50,7 @@ OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2024-03-21 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- 全部是安全修補，集中在接收模式與聊天模式的輸入處理。
+- <span class="urg-tag urg-tag--soon">儘快</span>全部是安全修補，集中在接收模式與聊天模式的輸入處理。
 - 歷史紀錄項目的路徑移除換行字元。
 - 接收模式的文字訊息長度上限設為 524288 字元。
 - 使用者名稱只允許特定 ASCII 字元並移除控制字元，另補上名稱驗證的例外處理，避免無聲加入聊天室。

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,11 +8,21 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## 急迫程度怎麼判斷
+
+- <span class="urg-tag urg-tag--now">立刻</span>Tails 官方發出的緊急安全釋出，版本號帶第三碼（例如 7.10.1）。上游判斷不能等到下次排程，代表漏洞後果嚴重。
+- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，但修補涵蓋核心提權、sandbox 逃逸或 Tor Browser 的重要安全更新。
+- <span class="urg-tag urg-tag--routine">一般</span>其餘例行版本，以功能與硬體支援為主。
+
+Tails 上的漏洞後果跟一般作業系統不同。取得管理員權限等於失去匿名保護，攻擊者看得到你在 Tails 裡做的每一件事，所以這一頁的「立刻」比其他頁更值得當真。
+
+Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志工讀完公告後補的判斷。
+
 ## Tails 7.11
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
 
-- 例行排程版本，同時帶入 Linux 核心的安全更新。
+- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，同時帶入 Linux 核心的安全更新。
 - Tor Browser 升至 15.0.20（基於 Firefox ESR 140.14）。
 - 核心升至 6.12.101，涵蓋 Debian 安全公告 DSA-6415-1 的 24 個漏洞，影響包含提權、阻斷服務與資訊外洩。
 - 修正部分電腦上 Persistent Storage 無法解鎖的問題。啟用流程原本會等待 `udevadm settle`，無關的硬體問題會讓這一步逾時或失敗，現已不再等待。
@@ -25,7 +35,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-08-05 · [上游公告](https://tails.net/news/version_7.10.1/){target="_blank"}
 
-- 緊急安全更新，修補 Linux 核心與 expat XML 函式庫的重大漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Linux 核心與 expat XML 函式庫的重大漏洞。
 - 核心升至 6.12.100，修補 CVE-2026-64560。此漏洞可讓 Tails 內的 Tor Browser 取得管理員權限，造訪的惡意網站若成功利用，可能完整接管 Tails 並進行去匿名化。攻擊難度高，具備政府或商業駭客團隊等級的資源才辦得到，目前尚未發現實際被利用案例。
 - expat XML 函式庫升至 2.8.2，修補 DSA-6404-1 這組漏洞。使用 expat 的應用程式（LibreOffice、Audacity、Git 等）被誘導開啟惡意檔案時，可能被用來取得管理員權限，後續同樣可能導致接管與去匿名化。目前尚未發現實際被利用案例。
 - 移除未使用的 firmware，USB image 與自動升級檔各縮小 70 MB。
@@ -36,7 +46,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
 
-- 例行排程版本，帶來新的關機流程與影片播放器。
+- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，帶來新的關機流程與影片播放器。
 - 改用 GNOME 標準關機流程。關機前會提醒尚未儲存的文件與開啟中的應用程式，並在 60 秒後自動關機。速度略慢，換來更好的資料保護。緊急關機選項仍保留，供需要快速斷電時使用。
 - 影片播放器改用 Celluloid，更現代也更可靠，且不具網路存取權限。要線上看影片請改用 Tor Browser，或額外安裝 VLC。此播放器不支援 2011 年（含）以前製造的電腦。
 - Tor Browser 升至 15.0.19。
@@ -47,7 +57,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-07-01 · [上游公告](https://tails.net/news/version_7.9.1/){target="_blank"}
 
-- 緊急安全更新，修補 Linux 核心兩個本機提權漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Linux 核心兩個本機提權漏洞。
 - 修補 CVE-2026-43503（DirtyClone）與 CVE-2026-46331（PACKET_EDIT_MEME），核心升至 6.12.94。此類漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
 - Tor Browser 升至 15.0.17。
 - Tor 用戶端升至 0.4.9.11。
@@ -57,7 +67,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
 
-- 例行排程版本，非緊急安全釋出。
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非緊急安全釋出。
 - Tor Browser 升至 15.0.16。
 - 更新部分 firmware 套件，改善較新硬體的支援，包含顯示卡、Wi-Fi 等。
 - 修正在 Secure Boot 憑證已是最新的少數情境下，仍誤跳「憑證過期」通知的問題。
@@ -67,7 +77,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}
 
-- 緊急安全更新，修補 Linux 核心重大漏洞與 Tor 用戶端的多個安全漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Linux 核心重大漏洞與 Tor 用戶端的多個安全漏洞。
 - 修補 Linux 核心漏洞 CVE-2026-43503（核心升至 6.12.90-2），此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
 - Tor 用戶端升至 0.4.9.9，修補多個安全漏洞。
 - 此版為安全專用的緊急釋出，未變動 Tor Browser、Thunderbird 與 Debian 底層版本，沿用 7.8 的軟體組合。可從 Tails 7.0 以後版本自動升級。
@@ -76,7 +86,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
 
-- Tor Browser 升至 15.0.14（基於 Firefox ESR 140.11）。
+- <span class="urg-tag urg-tag--soon">儘快</span>Tor Browser 升至 15.0.14（基於 Firefox ESR 140.11）。
 - 修補 Linux 核心本機提權漏洞「Fragnesia」（同步緩解「Drity Frag」）。此類漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。
 - 修補 Flatpak 透過 Yelp 逃逸 sandbox 的問題，yelp 升至 42.2-4tails1。
 - 修補 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
@@ -89,7 +99,7 @@ icon: material/usb-flash-drive-outline
 
 > 2026-05-12 · [上游公告](https://tails.net/news/version_7.7.3/){target="_blank"}
 
-- 緊急安全更新，修補 Linux 核心與 Tor 相關元件的重大漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Linux 核心與 Tor 相關元件的重大漏洞。
 - 修補 Linux 核心漏洞「Dirty Frag」（核心升至 6.12.86），此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
 - Tor Browser 升至 15.0.12。
 - Tor 用戶端升至 0.4.9.8。
@@ -99,14 +109,14 @@ icon: material/usb-flash-drive-outline
 
 > 2026-05-04 · [上游公告](https://tails.net/news/version_7.7.2/){target="_blank"}
 
-- 緊急安全更新，修補 Linux 核心漏洞「Copy Fail」（核心升至 6.12.85）。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Linux 核心漏洞「Copy Fail」（核心升至 6.12.85）。
 - 此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
 
 ## Tails 7.7.1
 
 > 2026-04-30 · [上游公告](https://tails.net/news/version_7.7.1/){target="_blank"}
 
-- 緊急安全更新，修補 Tor Browser 多個漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Tor Browser 多個漏洞。
 - Tor Browser 升至 15.0.11，修補 Firefox 140.10.1 多個漏洞。
 - Thunderbird 升至 140.10.0。
 - 停止支援以 ISO 映像從 USB 隨身碟開機，ISO 映像僅供 DVD 與虛擬機使用，USB 隨身碟請改用 USB image（自 2019 年起為推薦做法）。

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,11 +8,18 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## 兩個發布通道
+
+- <span class="chan-tag chan-tag--stable">穩定版</span>一般使用者用這個，版本號形如 15.0.20。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>僅供測試，可能含影響可用性、安全與隱私的錯誤，版本號帶 a（例如 16.0a10）。需要強匿名保護的人不要用。
+
+Alpha 從 16.0a9 起改為跟著 Firefox beta 逐步 rebase，版本跳動比過去頻繁。穩定版幾乎每次發布都帶 Firefox 或 tor daemon 的安全修補，看到新版就更新即可。
+
 ## Tor Browser 16.0a10（Alpha 測試通道）
 
 > 2026-08-27 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a10/){target="_blank"}
 
-- Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
 - 新增「使用通用視窗標題」選項，在設定的隱私與安全性、進階設定、防範第三方應用程式那一組，開啟後所有視窗標題一律顯示 Tor Browser Alpha。視窗標題預設跟著網頁的 title 變動，作業系統與其他程式不需特殊權限就讀得到，可以當成側錄瀏覽紀錄的旁通道。此功能已上游進 Firefox，一般 Firefox 使用者可在 `about:config` 把 `privacy.exposeContentTitleInWindow` 與 `privacy.exposeContentTitleInWindow.pbm` 設為 false。官方原本希望 16.0 穩定版就預設開啟，顧慮無障礙軟體與非標準桌面環境的相容性，改為先開放測試。
 - 桌面版內建手冊改版，把更新過的官方說明內容包進瀏覽器取代舊版手冊，網址列輸入 `about:manual` 可直接開啟，介面上的「Learn more」也都指向新版。
 - 設定頁改用 Mozilla 的新版 `about:preferences` 設計並預設啟用，連線、letterboxing、安全性等級等自訂項目都已搬到新版面。
@@ -25,7 +32,7 @@ icon: simple/torbrowser
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}
 
-- 以 Firefox 安全修補為主的小版本。
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本。
 - Firefox 基底 rebase 至 140.14.0esr（tor-browser#45204），桌面版與 Android 版 GeckoView 同步升至 140.14.0esr。
 - 從 Firefox 154 backport 安全修補（tor-browser#45219）。
 - libevent 升至 2.1.13（tor-browser-build#41839）。
@@ -36,7 +43,7 @@ icon: simple/torbrowser
 
 > 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
 
-- Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
 - Firefox 基底大幅 rebase 至 153.0esr（前一版為 140.0esr），Android 版 GeckoView 同步升至 153.0esr（tor-browser#45101）。
 - 官方宣布 Alpha 通道日後改為持續追蹤 Firefox beta 版本、逐步小步 rebase，取代過去一次跳過整年版本的做法，目標讓 16.0 穩定版於 9 月提前發布。
 - NoScript 升至 13.6.30.90201984，建置工具鏈的 Go 升至 1.26.5，libevent 升至 2.1.13。
@@ -47,7 +54,7 @@ icon: simple/torbrowser
 
 > 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
 
-- 以 Firefox 安全修補為主的小版本，帶入來自 Firefox 的重要安全更新。
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本，帶入來自 Firefox 的重要安全更新。
 - Firefox 基底 rebase 至 140.13.0esr（tor-browser#45117），桌面版與 Android 版 GeckoView 同步升至 140.13.0esr。
 - 從 Firefox 153 backport 安全修補（tor-browser#45124）。
 - NoScript 升至 13.6.31.1984。
@@ -57,7 +64,7 @@ icon: simple/torbrowser
 
 > 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
 
-- 以 Firefox 安全修補為主的小版本。
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本。
 - Firefox 基底維持 140.12.0esr，改以 cherry-pick 帶入 firefox/esr140 分支的後續修補（tor-browser#45111），未做 rebase。
 - NoScript 升至 13.6.30.1984。
 - 建置工具鏈的 Go 升至 1.25.12（Windows、Linux、Android）。
@@ -67,7 +74,7 @@ icon: simple/torbrowser
 
 > 2026-07-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}
 
-- Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
 - 重要的 Firefox 安全更新，rebase 至 Firefox 152.0a1（前一個 Alpha 16.0a7 為 151.0a1）。
 - Android 版 GeckoView 同步升至 152.0a1。
 - tor 用戶端升至 0.4.9.11。
@@ -83,7 +90,7 @@ icon: simple/torbrowser
 
 > 2026-06-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
 
-- 以 tor 安全更新為主的小版本，未變動 Firefox 基底。
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 tor 安全更新為主的小版本，未變動 Firefox 基底。
 - tor 用戶端升至 0.4.9.11。
 - NoScript 升至 13.6.25.1984。
 - 建置流程更新 boklm 的 GPG 子金鑰與 morgan 的續期金鑰（tor-browser-build#41821、#41827）。
@@ -92,7 +99,7 @@ icon: simple/torbrowser
 
 > 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
 
-- 重要的 Firefox 安全更新。
+- <span class="chan-tag chan-tag--stable">穩定版</span>重要的 Firefox 安全更新。
 - rebase 至 Firefox 140.12.0esr（tor-browser#45046），並 backport 自 Firefox 152 的安全修補（tor-browser#45054）。
 - Android 版 GeckoView 同步升至 140.12.0esr。
 - NoScript 升至 13.6.24.1984，修正前一版 13.6.19.902 在 DocStartInjection 上的 regression（tor-browser#45044）。
@@ -104,7 +111,7 @@ icon: simple/torbrowser
 
 > 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
 
-- tor daemon 重要安全更新，並修正部分審查規避問題。
+- <span class="chan-tag chan-tag--stable">穩定版</span>tor daemon 重要安全更新，並修正部分審查規避問題。
 - tor 用戶端升至 0.4.9.9。
 - NoScript 升至 13.6.20.1984。
 - Moat 模組支援設定多組 (front, reflector) domain fronting 配對（tor-browser#42436）。
@@ -115,7 +122,7 @@ icon: simple/torbrowser
 
 > 2026-06-03 · [dist 目錄](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
 
-- Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
 - 已在 dist 釋出二進位檔，官方部落格尚未發布對應公告。
 - 改以 Firefox 151.0a1 為基底（前一個 Alpha 16.0a6 為 150.0a1）。
 
@@ -123,7 +130,7 @@ icon: simple/torbrowser
 
 > 2026-05-19 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
 
-- 重要 Firefox 安全更新，backport 自 Firefox 151 的修補（tor-browser#44958）。
+- <span class="chan-tag chan-tag--stable">穩定版</span>重要 Firefox 安全更新，backport 自 Firefox 151 的修補（tor-browser#44958）。
 - rebase 至 Firefox 140.11.0esr。
 - Android 版 GeckoView 同步升至 140.11.0esr。
 - 建置工具鏈的 Go 升至 1.25.10。
@@ -132,14 +139,14 @@ icon: simple/torbrowser
 
 > 2026-05-08 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15013/){target="_blank"}
 
-- tor 用戶端升至 0.4.9.8。
+- <span class="chan-tag chan-tag--stable">穩定版</span>tor 用戶端升至 0.4.9.8。
 - NoScript 升至 13.6.19.1984。
 
 ## Tor Browser 16.0a6（Alpha 測試通道）
 
 > 2026-05-07 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/){target="_blank"}
 
-- Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
 - 自此版起，Tor Browser Alpha 改以 Firefox beta 通道（150.0a1）為基底，過去是以 Firefox ESR 為基底。
 - tor 用戶端升至 0.4.9.7。
 - NoScript 升至 13.6.18.90101984。
@@ -152,7 +159,7 @@ icon: simple/torbrowser
 
 > 2026-05-07 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15012/){target="_blank"}
 
-- 重要 Firefox 安全更新（rebase 至 Firefox 140.10.2esr）。
+- <span class="chan-tag chan-tag--stable">穩定版</span>重要 Firefox 安全更新（rebase 至 Firefox 140.10.2esr）。
 - tor 用戶端升至 0.4.9.7。
 - Android 版 GeckoView 同步升至 140.10.2esr。
 - 桌面與 Android 版加入 Funding the Commons 整合（tor-browser#44746、#44747）。
@@ -161,6 +168,6 @@ icon: simple/torbrowser
 
 > 2026-04-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15011/){target="_blank"}
 
-- 重要 Firefox 安全更新（rebase 至 Firefox 140.10.1esr）。
+- <span class="chan-tag chan-tag--stable">穩定版</span>重要 Firefox 安全更新（rebase 至 Firefox 140.10.1esr）。
 - NoScript 升至 13.6.18.1984。
 - Android 版 GeckoView 同步升至 140.10.1esr。

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -69,7 +69,8 @@
    淡底深字、過 AA。顏色只是輔助，標籤本身帶文字，色盲與單色列印都讀得到）
    淺色六組對比 5.72 / 5.81 / 8.35，深色 6.41 / 9.33 / 7.24，全部過 AA 4.5
    ========================================================================== */
-.urg-tag {
+.urg-tag,
+.chan-tag {
   display: inline-block;
   font-size: 0.66rem;
   font-weight: 700;
@@ -88,6 +89,12 @@
 [data-md-color-scheme="slate"] .urg-tag--now     { background: rgba(211,47,47,.18);  color: #ef9a9a; border-color: rgba(211,47,47,.45); }
 [data-md-color-scheme="slate"] .urg-tag--soon    { background: rgba(230,145,0,.18);  color: #ffcc80; border-color: rgba(230,145,0,.45); }
 [data-md-color-scheme="slate"] .urg-tag--routine { background: rgba(120,144,156,.20); color: #b0bec5; border-color: rgba(120,144,156,.45); }
+
+.chan-tag--stable { background: #e8f5e9; color: #1b5e20; border-color: #a5d6a7; }
+.chan-tag--alpha  { background: #f3e5f5; color: #6a1b9a; border-color: #ce93d8; }
+
+[data-md-color-scheme="slate"] .chan-tag--stable { background: rgba(76,175,80,.18);  color: #81c784; border-color: rgba(76,175,80,.42); }
+[data-md-color-scheme="slate"] .chan-tag--alpha  { background: rgba(123,31,162,.24); color: #ce93d8; border-color: rgba(123,31,162,.50); }
 
 /* 議程表：場次圖示與標題也套上分類色（對齊 .sess-tag，只在活動頁議程表出現；
    :has(+ strong) 精準選到標題前的場次圖示，描述列的箭頭圖示維持中性） */


### PR DESCRIPTION
## 判斷：三頁套，三頁不套

iOS 那組標籤上線後，逐頁看了一遍該不該沿用。答案不是全部照搬。

| 頁面 | 套用 | 理由 |
|---|---|---|
| Tails | 急迫程度三級 | 條目本來就分緊急與例行，天然對應 |
| Tor Browser | 通道兩級 | 該頁的決策點是通道，不是急迫程度 |
| OnionShare | 急迫程度兩級 | 安全修補與例行更新有明顯差別 |
| Arti | 不套 | 開發中的實作，重點是 c-tor 移植進度 |
| OONI Probe | 不套 | 量測工具，安全急迫性低 |
| GrapheneOS | 不套 | 自動更新，頁首已寫明不需行動 |

## Tails 最適合

十條裡六條是上游發的緊急安全釋出（版本號帶第三碼），三條例行但修補涵蓋核心提權或 sandbox 逃逸，一條純例行。分級直接對應上游自己的分類，不是我們硬套的框架。

頁首另外寫明一件事：Tails 的漏洞後果跟一般作業系統不同，取得管理員權限等於失去匿名保護，攻擊者看得到你在 Tails 裡做的每一件事。所以這一頁的「立刻」比 iOS 那頁更值得當真。

## Tor Browser 換一組標籤

它幾乎每個穩定版都帶 Firefox 或 tor daemon 的安全修補，全部標「儘快」等於沒有分級。這一頁真正的決策點是通道：誤裝 Alpha 才是實際風險，官方明說僅供測試、可能含影響可用性與安全的錯誤。

所以新增 `.chan-tag`，共用 `.urg-tag` 的 chip 規格（基礎選擇器改成兩者共用，不重複定義）。綠色穩定版與紫色 Alpha 的對比是 7.00 與 7.75，深色模式 6.85 與 5.77，都過 AA。

## 涵蓋範圍

三語系各三頁，條目標籤數與 `## ` 標題數逐頁比對過完全一致。過程中發現 zh-CN 與 en 的 `tails.md` 收錄範圍比 zh-TW 更早（多了 7.6、7.1、7.0、7.0~rc2、6.18），那幾條也補上了。`7.0~rc2` 用 Alpha 那組標籤，因為它是釋出候選版，性質跟 Tor Browser 的 Alpha 一樣。

## 驗證

- `docs_style_lint.py` 掃九個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：標籤數等於「條目數加判準說明那節」，inline HTML 沒有被跳脫，例如 zh-TW 的 `tails` 是 10 條目加 3 判準共 13 個

🤖 Generated with [Claude Code](https://claude.com/claude-code)