### PR TITLE
feat(changelog): 新增 tor daemon 更新日誌，給中繼與 onion 服務營運者

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: Software Changelog
-description: Concise English summaries of Tor, Tails, OONI, Arti, OnionShare, iOS, and GrapheneOS releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
+description: Concise English summaries of Tor, tor daemon, Tails, OONI, Arti, OnionShare, iOS, and GrapheneOS releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
 icon: material/history
 ---
 
@@ -14,7 +14,8 @@ Most of our release translations begin life in zh-TW and reach English on a roll
 
 Condensed release-by-release from upstream changelogs, keeping version numbers and issue references.
 
-- :simple-torbrowser: [Tor changelog](./tor.md) — Tor Browser, Tor daemon, Onion services
+- :simple-torbrowser: [Tor changelog](./tor.md) — Tor Browser stable and alpha channels
+- :material-server-network: [tor daemon changelog](./tor-daemon.md) — c-tor security releases, for relay and onion service operators
 - :material-code-tags: [Arti changelog](./arti.md) — Tor Project's Rust implementation
 - :material-access-point-network: [OONI changelog](./ooni.md) — OONI Probe, Explorer, Run
 - :material-share-variant: [OnionShare changelog](./onionshare.md) — OnionShare file sharing and onion sites

--- a/docs/en/changelog/tor-daemon.md
+++ b/docs/en/changelog/tor-daemon.md
@@ -1,0 +1,76 @@
+---
+title: tor daemon Changelog
+description: "English summaries of tor daemon releases: what each security release fixes and whether relay and onion service operators need to upgrade immediately."
+icon: material/server-network
+---
+
+# :material-server-network: tor daemon Changelog
+
+The tor daemon (commonly called c-tor) is the C implementation of [Tor](../tools/what-is-tor.md), and relays, bridges, and onion services all run on it. This page covers what each release fixes and whether you need to upgrade right away. It is aimed at people running their own relay or onion service. If you just browse with Tor Browser, you do not need this page: the browser ships its own bundled version and those changes are covered in the [Tor changelog](./tor.md).
+
+Newest at the top. Source data comes from the official [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/main/ChangeLog){target="_blank"}.
+
+## How we rate urgency
+
+- <span class="urg-tag urg-tag--now">Now</span>Marked by upstream as a security release, usually carrying TROVE identifiers. Relays and onion services are long-lived targets, and issues at this level are usually remotely reachable.
+- <span class="urg-tag urg-tag--soon">Soon</span>Affects connection quality or network health without a remotely exploitable security issue.
+- <span class="urg-tag urg-tag--routine">Routine</span>Everything else.
+
+Nearly every release in the first half of 2026 lands on "Now". Security scrutiny of Tor intensified during this period and produced a run of remotely reachable fixes, so the ratings reflect what actually happened. Relay operators genuinely did need to follow every release this half-year.
+
+## Two maintenance lines
+
+`0.4.9.x` is the current line and `0.4.8.x` is long-term support, with security fixes backported to both. Distribution packages often sit on 0.4.8.x, so seeing two versions ship the same day is normal. Which one you install depends on your package source.
+
+## tor 0.4.9.11
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>A security release two days after the previous one. Upstream cited further high-priority issues, one of them affecting onion services.
+- Fixes a race condition where, under the right circumstances, a rendezvous point could impersonate the onion service a client was trying to reach, putting itself in the middle. Anyone running an onion service should take this one (bug 41297, present since 0.3.5.3-alpha).
+- Clients no longer assert and exit when an onion service encodes an all-zero public key for one of its introduction points (bug 41295).
+- Directory authorities no longer accept port 0 in exit policy lines. A secondary check parsed `0` as the range `1-0`, which tripped an assert while generating a networkstatus vote.
+
+## tor 0.4.9.10
+
+> 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>A security release upstream strongly recommends installing promptly.
+- TROVE-2026-025: rejects a `CONFLUX_LINK` cell arriving on a circuit that already has attached streams. A malicious client could send `RELAY_COMMAND_BEGIN` before `CONFLUX_LINK`, leaving the attached exit stream orphaned with a dangling circuit back-pointer, and a use-after-free when the circuit is freed (bug 41258).
+- Restores the warning about unsafe SOCKS protocols (socks4, or socks5 without a hostname) when `SafeSocks` is unset. The warning had been silently missing, and what it guards against is leaking the name you are resolving beyond your own machine (bug 41290).
+- Entry guards expire consistently at 48 to 60 days again.
+
+## tor 0.4.9.9
+
+> 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>A security release covering three major issues at once.
+- TROVE-2026-022: the compression bomb check could be bypassed. An attacker concatenates many gzip or zlib sub-streams, each just under the per-stream detection threshold, and the whole payload slips past (bug 41275, present since 0.3.1.1-alpha).
+- TROVE-2026-021: an infinite loop when decompressing a truncated zlib/gzip stream. A truncated stream never reaches `Z_STREAM_END`, and the `Z_BUF_ERROR` zlib returns was mistaken for a full output buffer, so the code retried forever (bug 41274).
+- TROVE-2026-017: a NULL write after free when sending a `CONFLUX_SWITCH` cell fails. The failure closes the circuit and removes the leg, but the return value was ignored, so the caller went on to write into freed memory and crashed (bug 41263).
+
+## tor 0.4.9.8
+
+> 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>An emergency follow-up to the previous release, after a silent error in the CI build emptied the entire fallback directory list.
+- The impact falls on fresh installs: with no fallback directories available, new clients bootstrap directly against the directory authorities, which hurts both the load on those machines and how observable that traffic is.
+- Regenerates the fallback directory list as of 7 May 2026.
+
+## tor 0.4.9.7, 0.4.8.24
+
+> 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>A security release shipped on both maintenance lines.
+- TROVE-2026-011: an out-of-bounds read handling END, TRUNCATE, and TRUNCATED cells whose payload carries no reason field. The bug had been present since 0.1.1.1-alpha (bug 41254).
+- TROVE-2026-008: no longer attempts or accepts `BEGIN_DIR` over conflux legs (bug 41243).
+- TROVE-2026-010: corrects accounting when clearing the conflux out-of-order queue (bug 41251).
+
+## tor 0.4.9.6, 0.4.8.23
+
+> 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>A security release covering two issues that could crash a relay remotely.
+- TROVE-2026-003: a malicious `CREATED2` causes an 11-byte stack overflow, resulting in a remote crash (bug 41231).
+- TROVE-2026-004: a memory comparison in the conflux subsystem used the wrong length, another path to a remote crash (bug 41232).
+- Also fixes a batch of defence-in-depth issues and the polyval implementation on big-endian platforms.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
       - !ENV [NAV_CHANGELOG, "軟體更新日誌"]:
           - changelog/index.md
           - changelog/tor.md
+          - changelog/tor-daemon.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -124,6 +124,7 @@ nav:
       - !ENV [NAV_CHANGELOG, "软件更新日志"]:
           - changelog/index.md
           - changelog/tor.md
+          - changelog/tor-daemon.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -122,6 +122,7 @@ nav:
       - !ENV [NAV_CHANGELOG, "Software Changelog"]:
           - changelog/index.md
           - changelog/tor.md
+          - changelog/tor-daemon.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 软件更新日志
-description: Tor、Tails、OONI、Arti、OnionShare、iOS 与 GrapheneOS 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
+description: Tor、tor daemon、Tails、OONI、Arti、OnionShare、iOS 与 GrapheneOS 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
 icon: material/history
 ---
 
@@ -12,7 +12,8 @@ icon: material/history
 
 从上游 changelog 逐版摘译，保留版本号与跟踪编号。
 
-- :simple-torbrowser: [Tor 更新日志](./tor.md)：Tor Browser、Tor daemon、Onion 服务
+- :simple-torbrowser: [Tor 更新日志](./tor.md)：Tor Browser 的稳定版与 Alpha 通道
+- :material-server-network: [tor daemon 更新日志](./tor-daemon.md)：c-tor 的安全发布，给中继与 onion 服务运营者
 - :material-code-tags: [Arti 更新日志](./arti.md)：Tor Project 的 Rust 实现
 - :material-access-point-network: [OONI 更新日志](./ooni.md)：OONI Probe、Explorer、Run
 - :material-share-variant: [OnionShare 更新日志](./onionshare.md)：OnionShare 文件分享与匿名网站

--- a/docs/zh-CN/changelog/tor-daemon.md
+++ b/docs/zh-CN/changelog/tor-daemon.md
@@ -1,0 +1,76 @@
+---
+title: tor daemon 更新日志
+description: Tor 的 C 语言实现 tor daemon 各版本的中文重点整理，说明每次安全发布修了什么、中继与 onion 服务运营者需不需要立刻升级。
+icon: material/server-network
+---
+
+# :material-server-network: tor daemon 更新日志
+
+tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C 语言实现，中继、网桥与 onion 服务都运作在它上面。这一页整理每次发布修了什么、需不需要立刻升级，读者主要是自己架设中继或 onion 服务的人。用 Tor Browser 上网的读者不需要看这一页，浏览器会自己带着对应版本，那些变动整理在 [Tor 更新日志](./tor.md)。
+
+新版本永远在最上面。原始数据来自官方的 [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/main/ChangeLog){target="_blank"}。
+
+## 紧急程度怎么判断
+
+- <span class="urg-tag urg-tag--now">立刻</span>官方标为安全发布（security release），通常带 TROVE 编号。中继与 onion 服务是长期在线的目标，这一级的问题多半可以被远程触发。
+- <span class="urg-tag urg-tag--soon">尽快</span>影响连接质量或网络健康，但没有可被远程利用的安全问题。
+- <span class="urg-tag urg-tag--routine">一般</span>其余维护性发布。
+
+2026 年上半的发布几乎都落在「立刻」。这段期间 Tor 的安全审视强度提高，连续修出多个可被远程触发的问题，分级反映的就是实际状况。运营中继的人这半年确实需要每次都跟上。
+
+## 两条维护线
+
+`0.4.9.x` 是目前的主线，`0.4.8.x` 是长期支持线，安全修补会同步 backport。发行版软件包常常停在 0.4.8.x，看到同一天发两个版本是正常的，装哪一条看你的软件源。
+
+## tor 0.4.9.11
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>距离上一版只隔两天的安全发布，官方说明是又发现高优先级的问题，其中一个影响 onion 服务。
+- 修掉一个竞态条件：在特定情况下，会合点（rendezvous point）可以冒充客户端想连的那个 onion 服务，形成中间人。架设 onion 服务的人这一版务必要升（bug 41297，问题从 0.3.5.3-alpha 就存在）。
+- 客户端遇到 onion 服务把某个引介点的公钥编成全零时，不再直接中止退出（bug 41295）。
+- 目录权威不再接受出口策略里把端口写成 0 的写法。原本的次要检查误把 `0` 解析成 `1-0` 这个端口范围，生成 networkstatus 投票时会触发 assert。
+
+## tor 0.4.9.10
+
+> 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，官方强烈建议尽快升级。
+- TROVE-2026-025：拒绝在已经有附挂流的电路上收到的 `CONFLUX_LINK` 信元。恶意客户端可以先发 `RELAY_COMMAND_BEGIN` 再发 `CONFLUX_LINK`，挂上的出口流最后会变成孤儿，留下悬空的电路反向指针，电路被释放时形成 use-after-free（bug 41258）。
+- 未设置 `SafeSocks` 时，恢复对不安全 SOCKS 协议（socks4 或不带主机名的 socks5）的警告。这个警告消失了很久，而它防的是把要解析的域名直接泄漏给本机以外的地方（bug 41290）。
+- 客户端的入口守卫（entry guard）过期时间回到一致的 48 到 60 天。
+
+## tor 0.4.9.9
+
+> 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，一次修掉三个主要问题。
+- TROVE-2026-022：压缩炸弹检查可以被绕过。攻击者把多个 gzip 或 zlib 子流接在一起，每一段都刚好低于单流的检测门槛，整体就闪过了检查（bug 41275，问题从 0.3.1.1-alpha 就存在）。
+- TROVE-2026-021：解压被截断的 zlib/gzip 流时陷入无穷循环。截断的流永远到不了 `Z_STREAM_END`，zlib 返回的 `Z_BUF_ERROR` 被误判成输出缓冲区满了，于是无限重试（bug 41274）。
+- TROVE-2026-017：发出 `CONFLUX_SWITCH` 信元失败时的 NULL write after free。发送失败会关闭电路并移除该条腿，但返回值被忽略，调用端接着往已经释放的内存写入而崩溃（bug 41263）。
+
+## tor 0.4.9.8
+
+> 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>前一版发出后的紧急补发，起因是 CI 构建过程的一个无声错误，把备援目录（fallback directory）清单整份清空了。
+- 影响的是新安装的客户端：没有备援目录可用时，只能直接对目录权威做 bootstrap，那几台机器的负载与可观测性都因此变差。
+- 重新生成 2026 年 5 月 7 日版本的备援目录清单。
+
+## tor 0.4.9.7、0.4.8.24
+
+> 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两条维护线同时发布。
+- TROVE-2026-011：处理 END、TRUNCATE 与 TRUNCATED 信元时，若载荷里没有原因字段会发生越界读取。这个问题从 0.1.1.1-alpha 存在到现在（bug 41254）。
+- TROVE-2026-008：不再通过 conflux 的分腿尝试或接受 `BEGIN_DIR`（bug 41243）。
+- TROVE-2026-010：清空 conflux 的乱序队列时修正计数（bug 41251）。
+
+## tor 0.4.9.6、0.4.8.23
+
+> 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两个问题都可能让中继被远程弄崩。
+- TROVE-2026-003：恶意的 `CREATED2` 造成 11 个字节的栈溢出，结果是远程崩溃（bug 41231）。
+- TROVE-2026-004：conflux 子系统的内存比对用错长度，同样可能导致远程崩溃（bug 41232）。
+- 另外修了一批纵深防御性质的问题，以及 big-endian 平台上的 polyval 实现。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: 軟體更新日誌
-description: Tor、Tails、OONI、Arti、OnionShare、iOS 與 GrapheneOS 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
+description: Tor、tor daemon、Tails、OONI、Arti、OnionShare、iOS 與 GrapheneOS 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
 icon: material/history
 ---
 
@@ -12,7 +12,8 @@ icon: material/history
 
 從上游 changelog 逐版摘譯，保留版本號與追蹤編號。
 
-- :simple-torbrowser: [Tor 更新日誌](./tor.md)：Tor Browser、Tor daemon、Onion 服務
+- :simple-torbrowser: [Tor 更新日誌](./tor.md)：Tor Browser 的穩定版與 Alpha 通道
+- :material-server-network: [tor daemon 更新日誌](./tor-daemon.md)：c-tor 的安全釋出，給中繼與 onion 服務營運者
 - :material-code-tags: [Arti 更新日誌](./arti.md)：Tor Project 的 Rust 實作
 - :material-access-point-network: [OONI 更新日誌](./ooni.md)：OONI Probe、Explorer、Run
 - :material-share-variant: [OnionShare 更新日誌](./onionshare.md)：OnionShare 檔案分享與匿名網站

--- a/docs/zh-TW/changelog/tor-daemon.md
+++ b/docs/zh-TW/changelog/tor-daemon.md
@@ -1,0 +1,76 @@
+---
+title: tor daemon 更新日誌
+description: Tor 的 C 語言實作 tor daemon 各版本的中文重點整理，說明每次安全釋出修了什麼、中繼與 onion 服務營運者需不需要立刻升級。
+icon: material/server-network
+---
+
+# :material-server-network: tor daemon 更新日誌
+
+tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C 語言實作，中繼、橋接與 onion 服務都運作在它上面。這一頁整理每次釋出修了什麼、需不需要立刻升級，讀者主要是自己架設中繼或 onion 服務的人。用 Tor Browser 上網的讀者不需要看這一頁，瀏覽器會自己帶著對應版本，那些變動整理在 [Tor 更新日誌](./tor.md)。
+
+新版本永遠在最上面。原始資料來自官方的 [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/main/ChangeLog){target="_blank"}。
+
+## 急迫程度怎麼判斷
+
+- <span class="urg-tag urg-tag--now">立刻</span>官方標為安全釋出（security release），通常帶 TROVE 編號。中繼與 onion 服務是長期在線的目標，這一級的問題多半可以被遠端觸發。
+- <span class="urg-tag urg-tag--soon">儘快</span>影響連線品質或網路健康，但沒有可被遠端利用的安全問題。
+- <span class="urg-tag urg-tag--routine">一般</span>其餘維護性釋出。
+
+2026 年上半的釋出幾乎都落在「立刻」。這段期間 Tor 的安全審視強度提高，連續修出多個可被遠端觸發的問題，分級反映的就是實際狀況。營運中繼的人這半年確實需要每次都跟上。
+
+## 兩條維護線
+
+`0.4.9.x` 是目前的主線，`0.4.8.x` 是長期支援線，安全修補會同步 backport。發行版套件常常停在 0.4.8.x，看到同一天發兩個版本是正常的，裝哪一條看你的套件來源。
+
+## tor 0.4.9.11
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>距離上一版只隔兩天的安全釋出，官方說明是又發現高優先級的問題，其中一個影響 onion 服務。
+- 修掉一個競態條件：在特定情況下，會合點（rendezvous point）可以冒充用戶端想連的那個 onion 服務，形成中間人。架設 onion 服務的人這一版務必要升（bug 41297，問題從 0.3.5.3-alpha 就存在）。
+- 用戶端遇到 onion 服務把某個引介點的公鑰編成全零時，不再直接中止結束（bug 41295）。
+- 目錄權威不再接受離開政策裡把埠寫成 0 的寫法。原本的次要檢查誤把 `0` 解析成 `1-0` 這個埠範圍，產生 networkstatus 投票時會觸發 assert。
+
+## tor 0.4.9.10
+
+> 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，官方強烈建議盡快升級。
+- TROVE-2026-025：拒絕在已經有附掛串流的電路上收到的 `CONFLUX_LINK` 資料元。惡意用戶端可以先送 `RELAY_COMMAND_BEGIN` 再送 `CONFLUX_LINK`，掛上的離開串流最後會變成孤兒，留下懸空的電路反向指標，電路被釋放時形成 use-after-free（bug 41258）。
+- 未設定 `SafeSocks` 時，恢復對不安全 SOCKS 協定（socks4 或不帶主機名的 socks5）的警告。這個警告消失了很久，而它防的是把要解析的網域直接洩漏給本機以外的地方（bug 41290）。
+- 用戶端的入口守衛（entry guard）過期時間回到一致的 48 到 60 天。
+
+## tor 0.4.9.9
+
+> 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，一次修掉三個主要問題。
+- TROVE-2026-022：壓縮炸彈檢查可以被繞過。攻擊者把多個 gzip 或 zlib 子串流接在一起，每一段都剛好低於單串流的偵測門檻，整體就閃過了檢查（bug 41275，問題從 0.3.1.1-alpha 就存在）。
+- TROVE-2026-021：解壓被截斷的 zlib/gzip 串流時陷入無窮迴圈。截斷的串流永遠到不了 `Z_STREAM_END`，zlib 回傳的 `Z_BUF_ERROR` 被誤判成輸出緩衝區滿了，於是無限重試（bug 41274）。
+- TROVE-2026-017：送出 `CONFLUX_SWITCH` 資料元失敗時的 NULL write after free。送出失敗會關閉電路並移除該條腿，但回傳值被忽略，呼叫端接著往已經釋放的記憶體寫入而崩潰（bug 41263）。
+
+## tor 0.4.9.8
+
+> 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>前一版發出後的緊急補發，起因是 CI 建置過程的一個無聲錯誤，把備援目錄（fallback directory）清單整份清空了。
+- 影響的是新安裝的用戶端：沒有備援目錄可用時，只能直接對目錄權威做 bootstrap，那幾台機器的負載與可觀測性都因此變差。
+- 重新產生 2026 年 5 月 7 日版本的備援目錄清單。
+
+## tor 0.4.9.7、0.4.8.24
+
+> 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩條維護線同時發布。
+- TROVE-2026-011：處理 END、TRUNCATE 與 TRUNCATED 資料元時，若酬載裡沒有原因欄位會發生越界讀取。這個問題從 0.1.1.1-alpha 存在到現在（bug 41254）。
+- TROVE-2026-008：不再透過 conflux 的分腿嘗試或接受 `BEGIN_DIR`（bug 41243）。
+- TROVE-2026-010：清空 conflux 的亂序佇列時修正計數（bug 41251）。
+
+## tor 0.4.9.6、0.4.8.23
+
+> 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩個問題都可能讓中繼被遠端弄崩。
+- TROVE-2026-003：惡意的 `CREATED2` 造成 11 個位元組的堆疊溢位，結果是遠端崩潰（bug 41231）。
+- TROVE-2026-004：conflux 子系統的記憶體比對用錯長度，同樣可能導致遠端崩潰（bug 41232）。
+- 另外修了一批深度防禦性質的問題，以及 big-endian 平台上的 polyval 實作。


### PR DESCRIPTION
## 為什麼獨立一頁

`tor.md` 的標題一直宣稱涵蓋「Tor Browser、Tor daemon、Onion 服務」，實際上 15 條全是 Tor Browser。補這個缺口有兩種做法，我選獨立成頁而不是混進去，因為讀者不同：中繼營運者要知道這次是不是可遠端觸發、要不要馬上重啟服務，用 Tor Browser 上網的人不需要看到 TROVE 編號。混在一個時間軸會讓兩邊都撈不到自己要的東西。

頁首直接寫明「用 Tor Browser 上網的讀者不需要看這一頁」，並指回 `tor.md`。

## 收錄內容

2026-03-25 到 06-25 共六則，六個立刻、一個儘快：

| 版本 | 重點 |
|---|---|
| 0.4.9.11 | 會合點可冒充 onion 服務形成中間人（bug 41297） |
| 0.4.9.10 | conflux 的 use-after-free（TROVE-2026-025） |
| 0.4.9.9 | 壓縮炸彈檢查被繞過、解壓無窮迴圈、NULL write after free |
| 0.4.9.8 | CI 無聲錯誤清空備援目錄清單的補發 |
| 0.4.9.7、0.4.8.24 | 越界讀取、conflux 的 BEGIN_DIR 與佇列計數 |
| 0.4.9.6、0.4.8.23 | `CREATED2` 堆疊溢位、conflux 記憶體比對長度錯誤 |

每則都保留 TROVE 編號與 bug 號，要追細節的營運者找得到。0.4.9.11 那則特別標出架設 onion 服務的人必須升級。

## 頁首交代兩件事

一是兩條維護線並存（`0.4.9.x` 主線、`0.4.8.x` LTS），發行版套件常停在 0.4.8.x，看到同一天發兩個版本容易困惑。二是分級為何幾乎全是「立刻」：這半年 Tor 的安全審視強度提高，連續修出可被遠端觸發的問題，分級反映的是實際狀況，不是標準寬鬆。

順帶修正 `tor.md` 在索引頁的描述，它現在只涵蓋 Tor Browser 的兩個通道。

## 驗證

- `docs_style_lint.py` 掃六個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：標籤分佈 6 立刻 / 2 儘快 / 1 一般（含判準說明），icon 正常，內部連結全部指得到

🤖 Generated with [Claude Code](https://claude.com/claude-code)