### PR TITLE
feat(changelog): 新增抗審查傳輸更新日誌

### DIFF
--- a/docs/en/changelog/anti-censorship.md
+++ b/docs/en/changelog/anti-censorship.md
@@ -1,0 +1,68 @@
+---
+title: Anti-Censorship Transports Changelog
+description: "English summaries of Snowflake, WebTunnel, and lyrebird releases: what each update means for getting past blocking, and which transport suits which situation."
+icon: material/shield-key-outline
+---
+
+# :material-shield-key-outline: Anti-Censorship Transports Changelog
+
+Release summaries for the pluggable transports you switch to when you cannot reach the Tor network directly. Most updates here adjust how traffic disguises itself, which is an ongoing back-and-forth with whoever is doing the blocking, so the thing to watch is whether the disguise keeps up rather than whether a security hole got patched. For how to use them, see [Tor Browser advanced settings](../tools/tor-browser-advanced.md) and [Snowflake](../tools/tor-snowflake.md).
+
+Newest at the top.
+
+## Which transport suits which situation
+
+- **Snowflake**: needs no bridge address in advance. Pick it in Tor Browser and it works, relaying through volunteers' browsers around the world. Good where blocking is not especially thorough, or when you need a connection right now. Unstable speed is normal for it.
+- **WebTunnel**: wraps Tor traffic to look like ordinary HTTPS web traffic, which gives it the best odds on networks that only allow port 443 and run deep packet inspection. Requires a bridge address in advance.
+- **obfs4**: the long-standing option, turning traffic into featureless random bytes. Success rates drop in regions that have built up signatures for it. The program that runs it is now lyrebird.
+
+All three are in Tor Browser's connection settings, with nothing extra to install. Bridge addresses come from [bridges.torproject.org](https://bridges.torproject.org/){target="_blank"} or automatically via Moat.
+
+## WebTunnel 0.0.6
+
+> 2026-07-23 · [Project page](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- Adds Debian packages, so people running a WebTunnel bridge no longer have to build it themselves.
+- WebTunnel does not maintain a separate changelog. Entries here are assembled from version tags and commit messages, so they carry less detail than the other two projects.
+
+## WebTunnel 0.0.5
+
+> 2026-07-02 · [Project page](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- Adds a Trusted Proxy Hops setting. When a bridge sits behind a CDN or reverse proxy, this decides how many layers of forwarding headers to trust, which determines whether the client address you record is the real one.
+
+## Snowflake 2.14.1
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- Checks type assertions and validates incoming WebRTC offers and answers (issue 40546). That input arrives from the peer, and processing it unvalidated gave a path to crashing the proxy. Reported by Bogdan Barchuk and Alexander Kucher.
+- Probetest gains a SOCKS5-based interactive connectivity test for diagnosing proxies that cannot connect.
+
+## Snowflake 2.14.0
+
+> 2026-06-09 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- Updates covert-dtls and tidies its public API. covert-dtls makes the DTLS handshake look like an ordinary WebRTC application, which is central to how Snowflake avoids signature detection.
+- covert-dtls configuration gains a `none` option so a proxy can turn the disguise off.
+- Broker poll intervals can now be loaded from a file and are expressed in milliseconds, so proxies no longer need rebuilding to change how often they report.
+- Fixes a potential nil-pointer dereference in the broker, and a missing listen-error report when metrics fail to start.
+
+## Snowflake 2.13.0
+
+> 2026-04-08 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- Proxy covert-dtls now defaults to `randomizemimic` (issue 40530), so the DTLS handshake looks different every time. That is harder to build a signature against than consistently imitating one implementation.
+- The broker gains a poll interval field and a `NextPoll` message, telling proxies when to report next.
+
+## Snowflake 2.13.1, 2.12.1
+
+> 2026-03-10 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- Both releases only update the Go version used by the release pipeline (1.24 and 1.23 respectively). No functional changes.
+
+## lyrebird 0.8.1
+
+> 2026-01-14 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/main/ChangeLog){target="_blank"}
+
+- Fixes the chrome120 imitation profile. lyrebird uses uTLS to imitate a specific browser's TLS fingerprint, and once the profile drifts from what real Chrome sends, it becomes a distinguishing feature instead of cover.
+- lyrebird is the single binary behind obfs4, meek, WebTunnel, and Snowflake, and is what ships inside Tor Browser. 0.7.0 added certificate hash chain pinning, multiple server names, and an SNI imitation option for WebTunnel; 0.8.0 let meek use multiple url/front pairs.

--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -16,6 +16,7 @@ Condensed release-by-release from upstream changelogs, keeping version numbers a
 
 - :simple-torbrowser: [Tor changelog](./tor.md) — Tor Browser stable and alpha channels
 - :material-server-network: [tor daemon changelog](./tor-daemon.md) — c-tor security releases, for relay and onion service operators
+- :material-shield-key-outline: [anti-censorship transports changelog](./anti-censorship.md) — Snowflake, WebTunnel, obfs4: what to switch to when Tor is blocked
 - :material-code-tags: [Arti changelog](./arti.md) — Tor Project's Rust implementation
 - :material-access-point-network: [OONI changelog](./ooni.md) — OONI Probe, Explorer, Run
 - :material-share-variant: [OnionShare changelog](./onionshare.md) — OnionShare file sharing and onion sites

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
           - changelog/index.md
           - changelog/tor.md
           - changelog/tor-daemon.md
+          - changelog/anti-censorship.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -125,6 +125,7 @@ nav:
           - changelog/index.md
           - changelog/tor.md
           - changelog/tor-daemon.md
+          - changelog/anti-censorship.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -123,6 +123,7 @@ nav:
           - changelog/index.md
           - changelog/tor.md
           - changelog/tor-daemon.md
+          - changelog/anti-censorship.md
           - changelog/tails.md
           - changelog/arti.md
           - changelog/ooni.md

--- a/docs/zh-CN/changelog/anti-censorship.md
+++ b/docs/zh-CN/changelog/anti-censorship.md
@@ -1,0 +1,68 @@
+---
+title: 抗审查传输更新日志
+description: Snowflake、WebTunnel、lyrebird 各版本的中文重点整理，说明每次更新对绕过封锁有什么影响，以及三种传输各自适合什么情况。
+icon: material/shield-key-outline
+---
+
+# :material-shield-key-outline: 抗审查传输更新日志
+
+连不上 Tor 网络时要换的那几种传输方式（pluggable transports）的版本整理。这里的更新多半在调整伪装手法，跟封锁方的检测是持续来回的过程，所以看更新的重点放在「伪装有没有跟上」，而不是安全修补。相关的使用说明见 [Tor Browser 进阶设置](../tools/tor-browser-advanced.md)与 [Snowflake](../tools/tor-snowflake.md)。
+
+新版本永远在最上面。
+
+## 三种传输适合什么情况
+
+- **Snowflake**：不需要事先获取网桥地址，在 Tor Browser 里选了就能用，靠世界各地志愿者的浏览器当临时中转。适合封锁不算严密、或临时需要连接的情况。速度不稳定是它的常态。
+- **WebTunnel**：把 Tor 流量包装成一般的 HTTPS 网站流量，在只放行 443 端口又做深度包检测的网络里最有机会。需要事先获取网桥地址。
+- **obfs4**：老牌选项，把流量变成没有特征的随机字节。在已经针对它建立特征库的地区成功率会下降，运行它的程序现在是 lyrebird。
+
+三种都在 Tor Browser 的连接设置里，不必另外安装。网桥地址可以从 [bridges.torproject.org](https://bridges.torproject.org/){target="_blank"} 或 Moat 自动获取。
+
+## WebTunnel 0.0.6
+
+> 2026-07-23 · [项目页](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- 加入 Debian 软件包，架设 WebTunnel 网桥的人不必再自己编译。
+- WebTunnel 没有维护独立的 changelog，这一页的条目是从版本标签与提交信息整理的，细节比其他两个项目少。
+
+## WebTunnel 0.0.5
+
+> 2026-07-02 · [项目页](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- 新增可信代理跳数（Trusted Proxy Hops）设置。网桥架在 CDN 或反向代理后面时，这个设置决定要信任几层转发标头，关系到记录下来的客户端地址正不正确。
+
+## Snowflake 2.14.1
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 检查类型断言，并验证收到的 WebRTC offer 与 answer（issue 40546）。这类输入来自对面的节点，没有验证就处理有机会让代理端崩溃，报告者是 Bogdan Barchuk 与 Alexander Kucher。
+- Probetest 加入以 SOCKS5 为基础的交互连接测试，用来排查代理端连不上的问题。
+
+## Snowflake 2.14.0
+
+> 2026-06-09 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 更新 covert-dtls 并整理公开接口。covert-dtls 负责让 DTLS 握手看起来像一般的 WebRTC 应用，是 Snowflake 避开特征检测的关键一环。
+- covert-dtls 配置新增 `none` 选项，代理端可以关掉伪装。
+- Broker 的轮询间隔改为可从文件加载并以毫秒表示，代理端不必再重新编译就能调整上报频率。
+- 修掉 Broker 一个可能的 nil 指针解引用，以及计量启动失败时没有报告监听错误的问题。
+
+## Snowflake 2.13.0
+
+> 2026-04-08 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 代理端的 covert-dtls 默认值改为 `randomizemimic`（issue 40530），DTLS 握手的特征每次都不一样，比固定模仿单一实现更难被建成特征。
+- Broker 加入轮询间隔字段与 `NextPoll` 消息，让代理端知道下次该什么时候上报。
+
+## Snowflake 2.13.1、2.12.1
+
+> 2026-03-10 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 两个版本都只修发布流程使用的 Go 版本（分别是 1.24 与 1.23），功能没有变动。
+
+## lyrebird 0.8.1
+
+> 2026-01-14 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/main/ChangeLog){target="_blank"}
+
+- 修正 chrome120 模仿配置文件。lyrebird 用 uTLS 模仿特定浏览器的 TLS 指纹，模仿配置一旦跟真实的 Chrome 对不上，反而变成可辨识的特征。
+- lyrebird 是 obfs4、meek、WebTunnel 与 Snowflake 的统一可执行程序，Tor Browser 内置的就是它。0.7.0 为 WebTunnel 加了证书哈希链固定、多重服务器名称与 SNI 模仿选项，0.8.0 让 meek 支持多组网址与 front 配对。

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -14,6 +14,7 @@ icon: material/history
 
 - :simple-torbrowser: [Tor 更新日志](./tor.md)：Tor Browser 的稳定版与 Alpha 通道
 - :material-server-network: [tor daemon 更新日志](./tor-daemon.md)：c-tor 的安全发布，给中继与 onion 服务运营者
+- :material-shield-key-outline: [抗审查传输更新日志](./anti-censorship.md)：Snowflake、WebTunnel、obfs4，连不上 Tor 时要换的那几种
 - :material-code-tags: [Arti 更新日志](./arti.md)：Tor Project 的 Rust 实现
 - :material-access-point-network: [OONI 更新日志](./ooni.md)：OONI Probe、Explorer、Run
 - :material-share-variant: [OnionShare 更新日志](./onionshare.md)：OnionShare 文件分享与匿名网站

--- a/docs/zh-TW/changelog/anti-censorship.md
+++ b/docs/zh-TW/changelog/anti-censorship.md
@@ -1,0 +1,68 @@
+---
+title: 抗審查傳輸更新日誌
+description: Snowflake、WebTunnel、lyrebird 各版本的中文重點整理，說明每次更新對繞過封鎖有什麼影響，以及三種傳輸各自適合什麼情況。
+icon: material/shield-key-outline
+---
+
+# :material-shield-key-outline: 抗審查傳輸更新日誌
+
+連不上 Tor 網路時要換的那幾種傳輸方式（pluggable transports）的版本整理。這裡的更新多半在調整偽裝手法，跟封鎖方的偵測是持續來回的過程，所以看更新的重點放在「偽裝有沒有跟上」，而不是安全修補。相關的使用說明見 [Tor Browser 進階設定](../tools/tor-browser-advanced.md)與 [Snowflake](../tools/tor-snowflake.md)。
+
+新版本永遠在最上面。
+
+## 三種傳輸適合什麼情況
+
+- **Snowflake**：不需要事先取得橋接位址，在 Tor Browser 裡選了就能用，靠世界各地志願者的瀏覽器當臨時中轉。適合封鎖不算嚴密、或臨時需要連線的情況。速度不穩定是它的常態。
+- **WebTunnel**：把 Tor 流量包裝成一般的 HTTPS 網站流量，在只放行 443 埠又做深度封包檢測的網路裡最有機會。需要事先取得橋接位址。
+- **obfs4**：老牌選項，把流量變成沒有特徵的隨機位元組。在已經針對它建立特徵庫的地區成功率會下降，執行它的程式現在是 lyrebird。
+
+三種都在 Tor Browser 的連線設定裡，不必另外安裝。橋接位址可以從 [bridges.torproject.org](https://bridges.torproject.org/){target="_blank"} 或 Moat 自動取得。
+
+## WebTunnel 0.0.6
+
+> 2026-07-23 · [專案頁](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- 加入 Debian 套件，架設 WebTunnel 橋接的人不必再自己編譯。
+- WebTunnel 沒有維護獨立的 changelog，這一頁的條目是從版本標籤與提交訊息整理的，細節比其他兩個專案少。
+
+## WebTunnel 0.0.5
+
+> 2026-07-02 · [專案頁](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel){target="_blank"}
+
+- 新增可信任代理跳數（Trusted Proxy Hops）設定。橋接架在 CDN 或反向代理後面時，這個設定決定要信任幾層轉發標頭，關係到記錄下來的用戶端位址正不正確。
+
+## Snowflake 2.14.1
+
+> 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 檢查型別斷言，並驗證收到的 WebRTC offer 與 answer（issue 40546）。這類輸入來自對面的節點，沒有驗證就處理有機會讓代理端崩潰，回報者是 Bogdan Barchuk 與 Alexander Kucher。
+- Probetest 加入以 SOCKS5 為基礎的互動連線測試，用來排查代理端連不上的問題。
+
+## Snowflake 2.14.0
+
+> 2026-06-09 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 更新 covert-dtls 並整理公開介面。covert-dtls 負責讓 DTLS 交握看起來像一般的 WebRTC 應用，是 Snowflake 避開特徵偵測的關鍵一環。
+- covert-dtls 設定新增 `none` 選項，代理端可以關掉偽裝。
+- Broker 的輪詢間隔改為可從檔案載入並以毫秒表示，代理端不必再重新編譯就能調整回報頻率。
+- 修掉 Broker 一個可能的 nil 指標解參考，以及計量啟動失敗時沒有回報監聽錯誤的問題。
+
+## Snowflake 2.13.0
+
+> 2026-04-08 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 代理端的 covert-dtls 預設值改為 `randomizemimic`（issue 40530），DTLS 交握的特徵每次都不一樣，比固定模仿單一實作更難被建成特徵。
+- Broker 加入輪詢間隔欄位與 `NextPoll` 訊息，讓代理端知道下次該什麼時候回報。
+
+## Snowflake 2.13.1、2.12.1
+
+> 2026-03-10 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/blob/main/ChangeLog){target="_blank"}
+
+- 兩個版本都只修發布流程使用的 Go 版本（分別是 1.24 與 1.23），功能沒有變動。
+
+## lyrebird 0.8.1
+
+> 2026-01-14 · [ChangeLog](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/main/ChangeLog){target="_blank"}
+
+- 修正 chrome120 模仿設定檔。lyrebird 用 uTLS 模仿特定瀏覽器的 TLS 指紋，模仿設定檔一旦跟真實的 Chrome 對不上，反而變成可辨識的特徵。
+- lyrebird 是 obfs4、meek、WebTunnel 與 Snowflake 的統一執行程式，Tor Browser 內建的就是它。0.7.0 為 WebTunnel 加了憑證雜湊鏈釘選、多重伺服器名稱與 SNI 模仿選項，0.8.0 讓 meek 支援多組網址與 front 配對。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -14,6 +14,7 @@ icon: material/history
 
 - :simple-torbrowser: [Tor 更新日誌](./tor.md)：Tor Browser 的穩定版與 Alpha 通道
 - :material-server-network: [tor daemon 更新日誌](./tor-daemon.md)：c-tor 的安全釋出，給中繼與 onion 服務營運者
+- :material-shield-key-outline: [抗審查傳輸更新日誌](./anti-censorship.md)：Snowflake、WebTunnel、obfs4，連不上 Tor 時要換的那幾種
 - :material-code-tags: [Arti 更新日誌](./arti.md)：Tor Project 的 Rust 實作
 - :material-access-point-network: [OONI 更新日誌](./ooni.md)：OONI Probe、Explorer、Run
 - :material-share-variant: [OnionShare 更新日誌](./onionshare.md)：OnionShare 檔案分享與匿名網站


### PR DESCRIPTION
## 這頁不套急迫程度標籤

Snowflake、WebTunnel、lyrebird 的更新沒有安全修補的急迫性，多半在調整偽裝手法，跟封鎖方的偵測是持續來回的過程。掛「立刻／儘快」上去只會是裝飾。

白話的重點改成「三種傳輸適合什麼情況」，那才是連不上 Tor 的人真正需要的判斷：

- **Snowflake**：不需要事先取得橋接位址，選了就能用，速度不穩是常態
- **WebTunnel**：偽裝成 HTTPS，在只放行 443 又做深度封包檢測的網路裡最有機會
- **obfs4**：老牌，但在已建立特徵庫的地區成功率會掉，執行它的程式現在是 lyrebird

## 條目

三個專案混排，2026-01 到 07 共八則。寫的是更新對繞過封鎖的實際影響，而不是逐條翻譯提交訊息。兩則值得特別看：

- Snowflake 2.13.0 把代理端的 covert-dtls 預設改成 `randomizemimic`，每次 DTLS 交握的特徵都不同，比固定模仿單一實作更難被建成特徵
- lyrebird 0.8.1 修 chrome120 模仿設定檔，同樣的道理：模仿檔一旦跟真實 Chrome 對不上，反而變成可辨識的特徵

Snowflake 2.14.1 那則的型別斷言與 WebRTC 輸入驗證有回報者署名，照上游的紀錄保留。

## 資料源的坦白說明

WebTunnel 沒有維護獨立的 changelog（`ChangeLog` 檔案在 repo 裡是 404），條目是從版本標籤與提交訊息整理的。這件事直接寫在它第一則條目裡，讀者才知道為何細節比另外兩個專案少。

## 驗證

- `docs_style_lint.py` 掃六個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：icon 正常，內部連結（`tools/tor-browser-advanced`、`tools/tor-snowflake`）全部指得到

🤖 Generated with [Claude Code](https://claude.com/claude-code)