### PR TITLE
docs(changelog): OONI 那頁補上量測引擎（probe-cli）

### DIFF
--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -6,7 +6,9 @@ icon: material/access-point-network
 
 # :material-access-point-network: OONI Changelog
 
-[OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
+[OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries, along with the underlying measurement engine. Newest at the top.
+
+The app and the engine version independently. The cross-platform app is 6.x, while the measurement engine and command-line tool (OONI Probe CLI) are 3.x, and each app build bundles one engine version. If you analyse data or schedule your own measurements, read the engine entries: that is where changes to measurement behaviour land.
 
 ## OONI Probe 6.2.0
 
@@ -21,6 +23,16 @@ icon: material/access-point-network
 - Added an indexed query for counting unviewed completed results.
 - Dependency updates: Kotlin to 2.4.10 and the Android Gradle Plugin to 9.1.1.
 - Updated translations.
+
+## OONI Probe CLI v3.30.0
+
+> 2026-07-27 · [Upstream release](https://github.com/ooni/probe-cli/releases/tag/v3.30.0){target="_blank"}
+
+- The measurement engine and the command-line tool share one version number, and this is what the cross-platform app has bundled since 6.2.0.
+- The CLI gains an anonymous credentials submission path, matching the mechanism the app introduced in 6.1.0.
+- Removes a stray debug print left in `GetFeatureFlag`.
+- Android, iOS, and desktop `pom.xml` files are split apart, so releases on one platform no longer drag the others along.
+- Toolchain updates: Go 1.25.3, the latest stable Android NDK, and bundled assets at probe-assets v0.31.
 
 ## OONI Probe 6.1.1
 
@@ -63,3 +75,18 @@ icon: material/access-point-network
 !!! info "Earlier OONI Probe versions"
 
     OONI Probe 6.0.1, 6.0.0, and 5.3.0 release notes, plus the OONI Probe Desktop 6.0.1 beta and OONI Explorer thematic censorship pages translations, are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/ooni/){target="_blank"}. English versions will be added as the community translates them.
+## OONI Probe CLI v3.29.1
+
+> 2026-05-12 · [Upstream release](https://github.com/ooni/probe-cli/releases/tag/v3.29.1){target="_blank"}
+
+- A maintenance release; upstream published no list of changes. App versions 6.0.x and 6.1.x all bundle the v3.29.x line.
+
+## OONI Probe CLI v3.29.0
+
+> 2026-02-10 · [Upstream release](https://github.com/ooni/probe-cli/releases/tag/v3.29.0){target="_blank"}
+
+- Psiphon support ends. Per upstream's plan (issue 1761), both the psiphon tunnel and the psiphon experiment stopped working on 1 January 2026. Anyone analysing censorship measurement data should note that this test produces no new data from that point.
+- Adds the internal `userauth` package, the foundation for anonymous credentials, which let a submitter prove they are entitled to submit without revealing who they are.
+- Caps how much of an HTTP response body is read, so an abnormal or malicious response cannot exhaust memory.
+- Updates bundled certificates and C dependencies.
+

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -22,6 +22,16 @@ icon: material/access-point-network
 - 依赖项更新，Kotlin 升至 2.4.10，Android Gradle Plugin 升至 9.1.1。
 - 翻译更新。
 
+## OONI Probe CLI v3.30.0
+
+> 2026-07-27 · [上游发布页](https://github.com/ooni/probe-cli/releases/tag/v3.30.0){target="_blank"}
+
+- 测量引擎与命令行工具共用同一个版本号，跨平台应用从 6.2.0 起带的就是这一版。
+- 命令行版新增匿名凭证（anonymous credentials）的提交路径，跟 app 端在 6.1.0 引入的机制对应。
+- 移除 `GetFeatureFlag` 里误留的调试输出。
+- Android、iOS 与桌面版的 `pom.xml` 拆开，各平台的发布不再互相牵动。
+- 构建工具链更新：Go 升至 1.25.3、Android NDK 升到最新稳定版，内置资产升至 probe-assets v0.31。
+
 ## OONI Probe 6.1.1
 
 > 2026-07-07 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}
@@ -64,11 +74,26 @@ icon: material/access-point-network
 
     OONI Probe 6.0.1、6.0.0、5.3.0 等版本的发布条目目前仅在 [正体中文版](https://anoni.net/docs/changelog/ooni/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。下方保留早期的策展条目。
 
+## OONI Probe CLI v3.29.1
+
+> 2026-05-12 · [上游发布页](https://github.com/ooni/probe-cli/releases/tag/v3.29.1){target="_blank"}
+
+- 维护性发布，上游没有列出变更项目。跨平台应用 6.0.x 与 6.1.x 带的都是 v3.29.x 这条线。
+
 ## OONI Probe Desktop 6.0.1 beta
 
 > 2026-04-11 · [GitHub 发布页](https://github.com/ooni/probe-multiplatform/releases/v6.0.1){target="_blank"} · [完整翻译文章](../blog/posts/2026-ooni-probe-desktop-beta.md)
 
 - 推出全新跨平台 OONI Probe Desktop 与仪表板，邀请社群下载内测版回报问题与建议。
+
+## OONI Probe CLI v3.29.0
+
+> 2026-02-10 · [上游发布页](https://github.com/ooni/probe-cli/releases/tag/v3.29.0){target="_blank"}
+
+- 停止支持 psiphon。按照上游的规划（issue 1761），2026 年 1 月 1 日起 psiphon 通道与 psiphon 实验都不再运作。做审查观测数据分析的人要留意，那个测项从此不会有新数据。
+- 新增 `userauth` 内部包，是匿名凭证机制的基础。匿名凭证让提交端证明自己有权提交，同时不揭露身份。
+- HTTP 响应正文加上读取上限，避免异常或恶意的响应把内存吃光。
+- 更新内置证书与 C 依赖。
 
 ## OONI Explorer 主题审查页面
 

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -6,7 +6,9 @@ icon: material/access-point-network
 
 # :material-access-point-network: OONI 更新日誌
 
-[OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
+[OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）與底層量測引擎的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
+
+App 與引擎的版本號各走各的。跨平台應用是 6.x，量測引擎與命令列工具（OONI Probe CLI）是 3.x，app 內建的就是某一版引擎。做資料分析或自己排量測的人看引擎那幾則，量測行為的變動寫在那裡。
 
 ## OONI Probe 6.2.0
 
@@ -21,6 +23,16 @@ icon: material/access-point-network
 - 新增未讀完成結果的計數查詢索引。
 - 依賴項目更新，Kotlin 升至 2.4.10，Android Gradle Plugin 升至 9.1.1。
 - 翻譯更新。
+
+## OONI Probe CLI v3.30.0
+
+> 2026-07-27 · [上游發布頁](https://github.com/ooni/probe-cli/releases/tag/v3.30.0){target="_blank"}
+
+- 量測引擎與命令列工具共用同一個版本號，跨平台應用從 6.2.0 起帶的就是這一版。
+- 命令列版新增匿名憑證（anonymous credentials）的提交路徑，跟 app 端在 6.1.0 引入的機制對應。
+- 移除 `GetFeatureFlag` 裡誤留的除錯輸出。
+- Android、iOS 與桌面版的 `pom.xml` 拆開，各平台的發布不再互相牽動。
+- 建置工具鏈更新：Go 升至 1.25.3、Android NDK 升到最新穩定版，內建資產升至 probe-assets v0.31。
 
 ## OONI Probe 6.1.1
 
@@ -60,6 +72,12 @@ icon: material/access-point-network
 - Java 升級至 25，依賴項目（Kotlin、Ktor、Sentry SDK、Compose）同步更新。
 - 多項 bug 修正與穩定性提升。
 
+## OONI Probe CLI v3.29.1
+
+> 2026-05-12 · [上游發布頁](https://github.com/ooni/probe-cli/releases/tag/v3.29.1){target="_blank"}
+
+- 維護性釋出，上游沒有列出變更項目。跨平台應用 6.0.x 與 6.1.x 帶的都是 v3.29.x 這條線。
+
 ## OONI Probe 6.0.1
 
 > 2026-03-10 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.1){target="_blank"}
@@ -77,6 +95,15 @@ icon: material/access-point-network
 - 測試畫面新增搜尋功能。
 - 量測結果可依「執行批次」聚合檢視。
 - IP geolocation 資料庫支援自動更新。
+
+## OONI Probe CLI v3.29.0
+
+> 2026-02-10 · [上游發布頁](https://github.com/ooni/probe-cli/releases/tag/v3.29.0){target="_blank"}
+
+- 停止支援 psiphon。依照上游的規劃（issue 1761），2026 年 1 月 1 日起 psiphon 通道與 psiphon 實驗都不再運作。做審查觀測資料分析的人要留意，那個測項從此不會有新資料。
+- 新增 `userauth` 內部套件，是匿名憑證機制的基礎。匿名憑證讓提交端證明自己有權提交，同時不揭露身分。
+- HTTP 回應本文加上讀取上限，避免異常或惡意的回應把記憶體吃光。
+- 更新內建憑證與 C 相依。
 
 ## OONI Probe 5.3.0
 


### PR DESCRIPTION
## 補的缺口

`ooni.md` 的標題宣稱涵蓋「OONI Probe、Explorer、Run」，實際條目全是跨平台 app。但真正會改變量測行為的是底層引擎 `probe-cli`，做資料分析或自己排量測的人看的是那一層。

補三則引擎條目，依日期插進既有的 app 條目之間（app 6.x 與引擎 3.x 交錯排列）。

## v3.29.0 是這次最該讓人看到的

停止支援 psiphon。上游 release notes 只有一行 PR 標題 `chore: sunset psiphon support` 帶過，我追到 issue 1761 才看到完整說明：**2026 年 1 月 1 日起，psiphon 通道與 psiphon 實驗都不再運作**。

對照 OONI 資料做分析的人必須知道這件事，那個測項從此不會有新資料。同一版另有 `feat: upgrade psiphon deps` 看似矛盾，查過 release issue 1763 的摘要確認淘汰才是這一版的定調，相依升級是收尾。

其餘兩則：v3.30.0 加了 CLI 的匿名憑證提交路徑（對應 app 6.1.0 的機制），v3.29.1 是上游沒列變更的維護性釋出，照實寫。

## 頁首

說明 app 與引擎的版本號各走各的（6.x 對 3.x），app 內建的是某一版引擎，避免讀者以為版本號對不上是寫錯。也指出想看量測行為變動的人該讀哪幾則。

## 驗證

- `docs_style_lint.py` 掃三個檔案，0 error 0 warn
- 三語系建置皆通過
- 插入後的條目順序逐語系確認過依日期遞減，三語系各自的既有條目（zh-CN 有 Explorer 與 Desktop beta、en 較少）都沒有被打亂

🤖 Generated with [Claude Code](https://claude.com/claude-code)