### PR TITLE
feat(changelog): 新增 macOS 安全更新

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -27,4 +27,5 @@ Your device is part of the attack surface. This group skips the line-by-line tra
 
 - :material-usb-flash-drive-outline: [Tails changelog](./tails.md) — Tails operating system
 - :material-apple-ios: [iOS security updates](./ios.md) — iPhone and iPad, with urgency ratings and older-model support
+- :material-apple: [macOS security updates](./macos.md) — Mac, with urgency ratings and the state of the three maintenance lines
 - :material-cellphone-lock: [GrapheneOS monthly summary](./grapheneos.md) — hardened Android on Pixel, aggregated by month

--- a/docs/en/changelog/macos.md
+++ b/docs/en/changelog/macos.md
@@ -1,0 +1,74 @@
+---
+title: macOS Security Updates
+description: "Plain-language summaries of Mac security updates: what each one fixes, whether you need to install it now, and where the three maintenance lines stand."
+icon: material/apple
+---
+
+# :material-apple: macOS Security Updates
+
+Security update summaries for the Mac. An Apple update routinely covers a hundred or more CVEs, and reading the list start to finish still leaves you unsure what to do, so this page skips the line-by-line translation and answers three questions instead: do you need to update now, which common attack paths does the fix cover, and do older systems still get it. Newest at the top.
+
+Source data comes from Apple's [security releases page](https://support.apple.com/en-us/100100){target="_blank"}. The rating method matches the [iOS security updates](./ios.md) page.
+
+## How we rate urgency
+
+- <span class="urg-tag urg-tag--now">Now</span>Apple notes the issue may have been actively exploited, or the CVE appears in the US CISA Known Exploited Vulnerabilities catalog. Install the same day.
+- <span class="urg-tag urg-tag--soon">Soon</span>The fixes cover memory corruption in WebKit or Kernel, or include gaining root, bypassing Gatekeeper, or bypassing privacy preferences. Install within a few days.
+- <span class="urg-tag urg-tag--routine">Routine</span>Everything else. Install on your normal schedule.
+
+These ratings come from community volunteers reading the advisories. Apple does not label releases this way. Where the call is unclear, we round up.
+
+The bypass category deserves particular attention on macOS. Gatekeeper is what stops unsigned software running, and privacy preferences (the access permissions in System Settings) are what stop an app reading your screen, microphone, and files. When either layer is bypassed, nothing looks wrong on screen.
+
+## Three maintenance lines
+
+Apple maintains the current release plus the two before it. Security fixes ship to all three, but only the current line gets new features and the complete set of fixes.
+
+| Line | Version | Status |
+|---|---|---|
+| Tahoe | 26.x | Current, most complete fixes |
+| Sequoia | 15.x | Previous, security fixes keep pace |
+| Sonoma | 14.x | Two back, receives the fewest fixes |
+
+All three shipping the same day is normal, and so is the gap in fix counts. See the 2026-07-27 entry below for the comparison. If your hardware cannot run Tahoe, staying on Sequoia or Sonoma still gets you security fixes, but note that the Sonoma line drops out of support after roughly one more cycle.
+
+## macOS Tahoe 26.6.2
+
+> 2026-08-17 · [Upstream advisory](https://support.apple.com/en-us/148281){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>28 fixes, 19 of them in WebKit, mostly memory corruption or crashes from processing malicious web content.
+- ImageIO has one "processing an image may lead to arbitrary code execution", the kind of flaw used in attacks that trigger by sending you a picture.
+- Kernel accounts for 3 and IOGPUFamily for 1. This round shipped for Tahoe only, with no matching Sequoia or Sonoma release.
+
+## macOS Tahoe 26.6.1, Sequoia 15.7.9, Sonoma 14.8.9
+
+> 2026-08-06 · [26.6.1](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9](https://support.apple.com/en-us/148172){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>All three lines shipped the same day with a single fix each. Spending three releases on one issue means Apple decided it could not wait for the next scheduled update.
+- CVE-2026-65400: an attacker on your network could authenticate to Screen Sharing without valid credentials. The cause was a state management flaw in the authentication flow.
+- Prioritise this if you have Screen Sharing enabled. System Settings, General, Sharing shows whether it is on, and turning it off when you do not use it is the most direct fix available.
+
+## macOS Tahoe 26.6, Sequoia 15.7.8, Sonoma 14.8.8
+
+> 2026-07-27 · [26.6](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8](https://support.apple.com/en-us/128072){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>The largest round of the year: 153 fixes for Tahoe, 138 for Sequoia, 127 for Sonoma. That spread is the concrete evidence that older lines receive fewer fixes.
+- Kernel dominates, with 27 for Tahoe, 21 for Sequoia, and 20 for Sonoma.
+- Accounts has one where an app could gain root privileges. Assets has one where a malicious application could bypass privacy preferences, meaning it takes permissions you never granted.
+- AppleDouble can terminate an app unexpectedly when processing a malicious file. Model I/O and HFS each carry several file-parsing issues, the kind you trigger by opening a file someone sent you.
+
+## macOS Tahoe 26.5.2
+
+> 2026-06-29 · [Upstream advisory](https://support.apple.com/en-us/127595){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>24 of the 38 fixes are in WebKit and 4 more in WebRTC, so this release is almost entirely browser engine work.
+- The impact reaches beyond Safari. Every app that renders web content through a WebView uses the same engine, including mail previews and the in-app browsers in many chat clients.
+
+## macOS Tahoe 26.5
+
+> 2026-05-11 · [Upstream advisory](https://support.apple.com/en-us/127115){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>87 fixes, 22 in WebKit and 9 in Kernel.
+- CUPS has one where an app could gain root privileges. CUPS is the printing system, easy to forget about, and it runs by default.
+- BOM has one where a maliciously crafted ZIP archive bypasses Gatekeeper checks. Unpacking an archive someone sent you is an everyday action, which makes this one worth knowing.
+- Accounts has an issue bypassing certain privacy preferences, and mDNSResponder accounts for 4.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/macos.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -131,6 +131,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/macos.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -129,6 +129,7 @@ nav:
           - changelog/ooni.md
           - changelog/onionshare.md
           - changelog/ios.md
+          - changelog/macos.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -25,6 +25,7 @@ icon: material/history
 
 - :material-usb-flash-drive-outline: [Tails 更新日志](./tails.md)：Tails 操作系统
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 与 iPad，含紧急程度与旧机支持状况
+- :material-apple: [macOS 安全更新](./macos.md)：Mac，含紧急程度与三条维护线的状态
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的强化 Android，按月聚合
 
 ## 想找完整翻译文章

--- a/docs/zh-CN/changelog/macos.md
+++ b/docs/zh-CN/changelog/macos.md
@@ -1,0 +1,74 @@
+---
+title: macOS 安全更新
+description: Mac 每次安全更新的白话整理，说明这次修了什么、需不需要马上更新，以及三条维护线各自的状态。
+icon: material/apple
+---
+
+# :material-apple: macOS 安全更新
+
+Mac 的安全更新整理。Apple 一次更新动辄上百个 CVE，逐条读完也很难判断该怎么做，所以这一页不做逐条翻译，只回答三个问题：需不需要马上更新、修补打到哪些常见的攻击路径、旧系统还收不收得到。新版本永远在最上面。
+
+原始数据来自 Apple 的[安全更新发布页](https://support.apple.com/en-us/100100){target="_blank"}。判断方式与 [iOS 安全更新](./ios.md)那一页一致。
+
+## 紧急程度怎么判断
+
+- <span class="urg-tag urg-tag--now">立刻</span>Apple 在公告里标注该问题可能已被实际利用，或漏洞被美国 CISA 的已知遭利用漏洞目录收录。看到这一级，当天就更新。
+- <span class="urg-tag urg-tag--soon">尽快</span>修补涵盖 WebKit 或 Kernel 的内存损坏类问题，或有取得 root 权限、绕过 Gatekeeper 与隐私偏好的项目。几天内更新。
+- <span class="urg-tag urg-tag--routine">一般</span>其余修补，跟着平常的节奏更新即可。
+
+分级是社群志愿者读完公告后的整理，Apple 自己不做这种标示。判断不确定时以较高一级为准。
+
+macOS 上特别值得留意的是绕过类问题。Gatekeeper 挡的是没有签名的程序，隐私偏好（系统设置里的访问权限）挡的是 app 读取屏幕、麦克风与文件。这两层被绕过时，界面上不会有任何异状。
+
+## 三条维护线
+
+Apple 同时维护最新版与前两代，安全修补三条线都发，但只有最新线拿得到新功能与完整的修补集。
+
+| 线 | 版本号 | 状态 |
+|---|---|---|
+| Tahoe | 26.x | 最新，修补最完整 |
+| Sequoia | 15.x | 前一代，安全修补跟上 |
+| Sonoma | 14.x | 再前一代，收到的修补数量最少 |
+
+同一天三条线一起发是常态，数量落差很正常，见下面 2026-07-27 那则的比较。硬件太旧升不上 Tahoe 的话，留在 Sequoia 或 Sonoma 仍然收得到安全修补，但要注意 Sonoma 这条线再过一轮就会停止支持。
+
+## macOS Tahoe 26.6.2
+
+> 2026-08-17 · [上游公告](https://support.apple.com/en-us/148281){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>28 个修补，其中 19 个在 WebKit，多数是处理恶意网页内容造成的内存损坏或崩溃。
+- ImageIO 有一个「处理图像可能导致任意代码执行」，这一类常被用在传一张图过去就能触发的攻击。
+- Kernel 有 3 个、IOGPUFamily 有 1 个。这一波只发给 Tahoe，Sequoia 与 Sonoma 没有对应版本。
+
+## macOS Tahoe 26.6.1、Sequoia 15.7.9、Sonoma 14.8.9
+
+> 2026-08-06 · [26.6.1 公告](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9 公告](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9 公告](https://support.apple.com/en-us/148172){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>三条线同时发，各自只修一个问题。单一修补动用三条线，代表 Apple 认为不能等到下次排程。
+- CVE-2026-65400：同一网络上的攻击者可以在没有有效凭证的情况下通过屏幕共享（Screen Sharing）的验证。成因是验证流程的状态管理问题。
+- 有开启屏幕共享的人优先处理。系统设置里的「通用」、「共享」可以确认自己有没有开，平常用不到就关掉，那是最直接的处理方式。
+
+## macOS Tahoe 26.6、Sequoia 15.7.8、Sonoma 14.8.8
+
+> 2026-07-27 · [26.6 公告](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8 公告](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8 公告](https://support.apple.com/en-us/128072){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>年度最大的一波，Tahoe 补 153 个、Sequoia 138 个、Sonoma 127 个。三条线的数量落差就是旧线收到的修补比较少的具体证据。
+- Kernel 是重点，Tahoe 占 27 个、Sequoia 21 个、Sonoma 20 个。
+- Accounts 有一个 app 可能取得 root 权限。Assets 有一个恶意应用程序可以绕过隐私偏好，也就是不必经过你同意就取得原本要授权的权限。
+- AppleDouble 处理恶意文件时可能导致应用程序异常退出。Model I/O 与 HFS 各有多个文件解析类的问题，这一类的触发方式通常是打开一个别人给的文件。
+
+## macOS Tahoe 26.5.2
+
+> 2026-06-29 · [上游公告](https://support.apple.com/en-us/127595){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>38 个修补里有 24 个在 WebKit、4 个在 WebRTC，整包几乎都是浏览器引擎。
+- 影响范围不只 Safari。系统上任何用 WebView 显示网页内容的 app 都走同一套引擎，包含邮件预览与许多聊天软件的内置浏览器。
+
+## macOS Tahoe 26.5
+
+> 2026-05-11 · [上游公告](https://support.apple.com/en-us/127115){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>87 个修补，WebKit 占 22 个、Kernel 占 9 个。
+- CUPS 有一个 app 可能取得 root 权限。CUPS 是打印系统，平常不会想到它，而它默认就在运行。
+- BOM 有一个恶意的 ZIP 压缩文件可以绕过 Gatekeeper 检查。解压别人寄来的文件是很日常的动作，这条值得知道。
+- Accounts 有一个绕过部分隐私偏好的问题，mDNSResponder 有 4 个。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -25,6 +25,7 @@ icon: material/history
 
 - :material-usb-flash-drive-outline: [Tails 更新日誌](./tails.md)：Tails 作業系統
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 與 iPad，含急迫程度與舊機支援狀況
+- :material-apple: [macOS 安全更新](./macos.md)：Mac，含急迫程度與三條維護線的狀態
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的強化 Android，按月聚合
 
 ## 想找完整翻譯文章

--- a/docs/zh-TW/changelog/macos.md
+++ b/docs/zh-TW/changelog/macos.md
@@ -1,0 +1,74 @@
+---
+title: macOS 安全更新
+description: Mac 每次安全更新的白話整理，說明這次修了什麼、需不需要馬上更新，以及三條維護線各自的狀態。
+icon: material/apple
+---
+
+# :material-apple: macOS 安全更新
+
+Mac 的安全更新整理。Apple 一次更新動輒上百個 CVE，逐條讀完也很難判斷該怎麼做，所以這一頁不做逐條翻譯，只回答三個問題：需不需要馬上更新、修補打到哪些常見的攻擊路徑、舊系統還收不收得到。新版本永遠在最上面。
+
+原始資料來自 Apple 的[安全性更新發布頁](https://support.apple.com/en-us/100100){target="_blank"}。判斷方式與 [iOS 安全更新](./ios.md)那一頁一致。
+
+## 急迫程度怎麼判斷
+
+- <span class="urg-tag urg-tag--now">立刻</span>Apple 在公告裡標注該問題可能已被實際利用，或漏洞被美國 CISA 的已知遭利用漏洞目錄收錄。看到這一級，當天就更新。
+- <span class="urg-tag urg-tag--soon">儘快</span>修補涵蓋 WebKit 或 Kernel 的記憶體損毀類問題，或有取得 root 權限、繞過 Gatekeeper 與隱私偏好的項目。幾天內更新。
+- <span class="urg-tag urg-tag--routine">一般</span>其餘修補，跟著平常的節奏更新即可。
+
+分級是社群志工讀完公告後的整理，Apple 自己不做這種標示。判斷不確定時以較高一級為準。
+
+macOS 上特別值得留意的是繞過類問題。Gatekeeper 擋的是沒有簽章的程式，隱私偏好（系統設定裡的取用權限）擋的是 app 讀取螢幕、麥克風與檔案。這兩層被繞過時，畫面上不會有任何異狀。
+
+## 三條維護線
+
+Apple 同時維護最新版與前兩代，安全修補三條線都發，但只有最新線拿得到新功能與完整的修補集。
+
+| 線 | 版本號 | 狀態 |
+|---|---|---|
+| Tahoe | 26.x | 最新，修補最完整 |
+| Sequoia | 15.x | 前一代，安全修補跟上 |
+| Sonoma | 14.x | 再前一代，收到的修補數量最少 |
+
+同一天三條線一起發是常態，數量落差很正常，見下面 2026-07-27 那則的比較。硬體太舊升不上 Tahoe 的話，留在 Sequoia 或 Sonoma 仍然收得到安全修補，但要注意 Sonoma 這條線再過一輪就會停止支援。
+
+## macOS Tahoe 26.6.2
+
+> 2026-08-17 · [上游公告](https://support.apple.com/en-us/148281){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>28 個修補，其中 19 個在 WebKit，多數是處理惡意網頁內容造成的記憶體損毀或崩潰。
+- ImageIO 有一個「處理影像可能導致任意程式碼執行」，這一類常被用在傳一張圖過去就能觸發的攻擊。
+- Kernel 有 3 個、IOGPUFamily 有 1 個。這一波只發給 Tahoe，Sequoia 與 Sonoma 沒有對應版本。
+
+## macOS Tahoe 26.6.1、Sequoia 15.7.9、Sonoma 14.8.9
+
+> 2026-08-06 · [26.6.1 公告](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9 公告](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9 公告](https://support.apple.com/en-us/148172){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>三條線同時發，各自只修一個問題。單一修補動用三條線，代表 Apple 認為不能等到下次排程。
+- CVE-2026-65400：同一網路上的攻擊者可以在沒有有效憑證的情況下通過螢幕共享（Screen Sharing）的驗證。成因是驗證流程的狀態管理問題。
+- 有開啟螢幕共享的人優先處理。系統設定裡的「一般」、「共享」可以確認自己有沒有開，平常用不到就關掉，那是最直接的處理方式。
+
+## macOS Tahoe 26.6、Sequoia 15.7.8、Sonoma 14.8.8
+
+> 2026-07-27 · [26.6 公告](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8 公告](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8 公告](https://support.apple.com/en-us/128072){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>年度最大的一波，Tahoe 補 153 個、Sequoia 138 個、Sonoma 127 個。三條線的數量落差就是舊線收到的修補比較少的具體證據。
+- Kernel 是重點，Tahoe 佔 27 個、Sequoia 21 個、Sonoma 20 個。
+- Accounts 有一個 app 可能取得 root 權限。Assets 有一個惡意應用程式可以繞過隱私偏好，也就是不必經過你同意就取得原本要授權的權限。
+- AppleDouble 處理惡意檔案時可能導致應用程式異常結束。Model I/O 與 HFS 各有多個檔案解析類的問題，這一類的觸發方式通常是打開一個別人給的檔案。
+
+## macOS Tahoe 26.5.2
+
+> 2026-06-29 · [上游公告](https://support.apple.com/en-us/127595){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>38 個修補裡有 24 個在 WebKit、4 個在 WebRTC，整包幾乎都是瀏覽器引擎。
+- 影響範圍不只 Safari。系統上任何用 WebView 顯示網頁內容的 app 都走同一套引擎，包含郵件預覽與許多聊天軟體的內建瀏覽器。
+
+## macOS Tahoe 26.5
+
+> 2026-05-11 · [上游公告](https://support.apple.com/en-us/127115){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>87 個修補，WebKit 佔 22 個、Kernel 佔 9 個。
+- CUPS 有一個 app 可能取得 root 權限。CUPS 是列印系統，平常不會想到它，而它預設就在執行。
+- BOM 有一個惡意的 ZIP 壓縮檔可以繞過 Gatekeeper 檢查。解壓縮別人寄來的檔案是很日常的動作，這條值得知道。
+- Accounts 有一個繞過部分隱私偏好的問題，mDNSResponder 有 4 個。


### PR DESCRIPTION
## 沿用 iOS 的結構，加兩件 macOS 特有的事

判斷方式與 `changelog/ios.md` 一致（立刻／儘快／一般，判準寫在頁首），另外補上兩點：

**繞過類問題單獨提出來。** Gatekeeper 擋的是沒有簽章的程式，隱私偏好擋的是 app 讀取螢幕、麥克風與檔案。這兩層被繞過時畫面上不會有任何異狀，所以判準把它們跟 WebKit/Kernel 的記憶體損毀放在同一級。26.5 的 BOM 讓惡意 ZIP 繞過 Gatekeeper，解壓別人寄來的檔案是日常動作，那條特別點出來。

**三條維護線的落差用數字說。** 7/27 那波 Tahoe 補 153 個、Sequoia 138 個、Sonoma 127 個。這個數字本身就是「舊線收到的修補比較少」的證據，比空講支援政策有用。頁首的表格列出三條線的狀態，並提醒 Sonoma 再過一輪就會停止支援。

## 8/6 那則最該注意

三條線同時發、各自只修一個問題（CVE-2026-65400）：同一網路上的攻擊者不需要有效憑證就能通過螢幕共享的驗證。單一修補動用三條線，代表 Apple 認為不能等到下次排程。

條目直接寫出系統設定裡去哪裡關掉螢幕共享，因為對用不到這個功能的人來說，關掉比更新更快生效。

## 收錄範圍

2026-05-11 到 08-17 共六則，同日發的多條線併成一則。全部是「儘快」，近五個月沒有標注實際遭利用的項目，跟 iOS 那頁的情況一致。

## 驗證

- `docs_style_lint.py` 掃六個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：標籤與維護線表格都正常渲染，icon 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)