### PR TITLE
feat(changelog): 新增 Windows 安全更新

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -28,4 +28,5 @@ Your device is part of the attack surface. This group skips the line-by-line tra
 - :material-usb-flash-drive-outline: [Tails changelog](./tails.md) — Tails operating system
 - :material-apple-ios: [iOS security updates](./ios.md) — iPhone and iPad, with urgency ratings and older-model support
 - :material-apple: [macOS security updates](./macos.md) — Mac, with urgency ratings and the state of the three maintenance lines
+- :material-microsoft-windows: [Windows security updates](./windows.md) — monthly Patch Tuesday, sorted by desktop versus server impact
 - :material-cellphone-lock: [GrapheneOS monthly summary](./grapheneos.md) — hardened Android on Pixel, aggregated by month

--- a/docs/en/changelog/windows.md
+++ b/docs/en/changelog/windows.md
@@ -1,0 +1,68 @@
+---
+title: Windows Security Updates
+description: "Plain-language summaries of monthly Windows updates: whether anything is being actively exploited, whether it hits desktops or servers, and whether you need to update now."
+icon: material/microsoft-windows
+---
+
+# :material-microsoft-windows: Windows Security Updates
+
+Summaries of Windows monthly updates. Microsoft ships on the second Tuesday of each month, known as Patch Tuesday, and a single month runs to thousands of entries. August 2026 carried 1,506, of which 359 were Edge vulnerabilities carried over from Chromium. Reading through them is neither possible nor necessary.
+
+This page answers three questions: is anything being actively exploited this month, do those flaws hit desktops or servers, and do you need to update now. Newest at the top.
+
+Source data comes from Microsoft's [MSRC Security Update Guide](https://msrc.microsoft.com/update-guide){target="_blank"}, with the counts derived from its CVRF data.
+
+## How we rate urgency
+
+- <span class="urg-tag urg-tag--now">Now</span>The month includes a flaw flagged as actively exploited whose scope covers desktop Windows.
+- <span class="urg-tag urg-tag--soon">Soon</span>Something is flagged as actively exploited, but only in server products or auto-updating components. Desktop users can proceed on their normal schedule; server administrators should prioritise.
+- <span class="urg-tag urg-tag--routine">Routine</span>Nothing flagged as exploited that month.
+
+Microsoft publishes an `Exploited:Yes` field of its own. These ratings build on that field, with one added judgement about who is affected.
+
+## Check which kind of product is affected first
+
+A large share of the actively exploited flaws each month land in server products such as SharePoint, Exchange, and Active Directory Federation Services. If you run ordinary desktop Windows, none of those touch you. When a headline says Microsoft patched a critical flaw under active attack, the first thing to establish is which product it was in.
+
+Microsoft Defender is another common misunderstanding. Its fixes ship through automatic antimalware definition updates rather than Patch Tuesday, and require nothing from you.
+
+One more thing worth knowing if you run Tor Browser or other anonymity tools on Windows: once the operating system is compromised, nothing running on top of it can protect you. Privilege escalation fixes matter as much in that scenario as browser flaws do.
+
+## August 2026
+
+> 2026-08-11 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>1,506 entries, 721 rated Critical, one flagged as actively exploited.
+- CVE-2026-68820: privilege escalation in the Ancillary Function Driver for WinSock. It affects desktop Windows 10 1809 and later plus Windows Server 2019 and later, so ordinary users are in scope.
+- Privilege escalation flaws are typically chained: something else (a browser, a document) gets code running first, and this takes it to system privileges. On its own it needs local execution, but chained it completes the takeover.
+
+## July 2026
+
+> 2026-07-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>2,003 entries, the largest of these five months, with 953 rated Critical and three flagged as actively exploited.
+- All three are in server products: Active Directory Federation Services privilege escalation, SharePoint Server privilege escalation, and SharePoint remote code execution.
+- Desktop users are unaffected by those three. Anyone running SharePoint or AD FS should prioritise, as the SharePoint remote code execution is the kind that needs no credentials to trigger.
+
+## June 2026
+
+> 2026-06-09 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">Routine</span>1,284 entries, 650 rated Critical, nothing flagged as actively exploited.
+- A high Critical count does not mean urgency. Microsoft's severity rates how bad exploitation would be, which is a separate question from whether anyone is exploiting it. This page rates the latter.
+
+## May 2026
+
+> 2026-05-12 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">Soon</span>1,129 entries, 318 rated Critical, three flagged as actively exploited.
+- Two are in the Microsoft Defender protection engine (denial of service and privilege escalation) and ship through automatic definition updates, so users need do nothing.
+- The third is an Exchange Server spoofing flaw, affecting only organisations running their own Exchange.
+
+## April 2026
+
+> 2026-04-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">Now</span>682 entries, 216 rated Critical, two flagged as actively exploited.
+- CVE-2026-32202: a Windows Shell spoofing flaw affecting desktop Windows 10 1809 and later plus Windows Server 2019 and later. Shell is the layer behind File Explorer and shortcut handling, and spoofing flaws there make a malicious file look like something ordinary on screen.
+- The other is a SharePoint Server spoofing flaw, servers only.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
           - changelog/onionshare.md
           - changelog/ios.md
           - changelog/macos.md
+          - changelog/windows.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -132,6 +132,7 @@ nav:
           - changelog/onionshare.md
           - changelog/ios.md
           - changelog/macos.md
+          - changelog/windows.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -130,6 +130,7 @@ nav:
           - changelog/onionshare.md
           - changelog/ios.md
           - changelog/macos.md
+          - changelog/windows.md
           - changelog/grapheneos.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -26,6 +26,7 @@ icon: material/history
 - :material-usb-flash-drive-outline: [Tails 更新日志](./tails.md)：Tails 操作系统
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 与 iPad，含紧急程度与旧机支持状况
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含紧急程度与三条维护线的状态
+- :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面还是服务器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的强化 Android，按月聚合
 
 ## 想找完整翻译文章

--- a/docs/zh-CN/changelog/windows.md
+++ b/docs/zh-CN/changelog/windows.md
@@ -1,0 +1,68 @@
+---
+title: Windows 安全更新
+description: Windows 每月更新的白话整理，说明这个月有没有正在被利用的漏洞、影响的是桌面还是服务器，以及需不需要马上更新。
+icon: material/microsoft-windows
+---
+
+# :material-microsoft-windows: Windows 安全更新
+
+Windows 每月更新的整理。微软固定在每月第二个星期二发布（社群惯称 Patch Tuesday），单月的项目数以千计，2026 年 8 月那一轮就有 1506 项，其中 359 项是从 Chromium 转载过来的 Edge 漏洞。逐条读完不可能，也没有必要。
+
+这一页只回答三个问题：这个月有没有正在被实际利用的漏洞、那些漏洞影响桌面还是服务器、需不需要马上更新。新版本永远在最上面。
+
+原始数据来自微软的 [MSRC 安全更新指南](https://msrc.microsoft.com/update-guide){target="_blank"}，数字是从它的 CVRF 数据整理的。
+
+## 紧急程度怎么判断
+
+- <span class="urg-tag urg-tag--now">立刻</span>该月有标为已被实际利用的漏洞，且影响范围包含桌面版 Windows。
+- <span class="urg-tag urg-tag--soon">尽快</span>有标为已被实际利用的漏洞，但只影响服务器产品或自动更新的组件。桌面用户跟着平常节奏即可，管理服务器的人优先处理。
+- <span class="urg-tag urg-tag--routine">一般</span>该月没有已被利用的项目。
+
+微软自己有标 `Exploited:Yes`，这一页的分级就建立在那个字段上，再加一层「影响谁」的判断。
+
+## 先看清楚受影响的是哪一种产品
+
+每个月被实际利用的漏洞里，很大一部分落在 SharePoint、Exchange、Active Directory Federation Services 这类服务器产品上。用一般桌面 Windows 的读者不受那些影响，看到新闻标题写「微软修补正在被利用的重大漏洞」不必先紧张，要先确认的是那个漏洞在什么产品上。
+
+另一个常见的误会是 Microsoft Defender。它的漏洞修补走的是杀毒定义文件的自动更新，不跟着 Patch Tuesday，也不需要用户做任何事。
+
+在 Windows 上使用 Tor Browser 或其他匿名工具的人另外要知道：操作系统被取得权限之后，上面运行的任何工具都保护不了你。提权类的修补对这个情境的重要性不亚于浏览器本身的漏洞。
+
+## 2026 年 8 月
+
+> 2026-08-11 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>1506 个项目，721 个标为 Critical，一个标为已被实际利用。
+- CVE-2026-68820：WinSock 的辅助功能驱动程序（Ancillary Function Driver）提权。影响 Windows 10 1809 以后的桌面版与 Windows Server 2019 以后，一般用户也在范围内。
+- 提权类漏洞的典型用法是接在别的漏洞后面，先从浏览器或文档取得执行机会，再用它取得系统权限。单独看它需要本机执行条件，串起来就是完整的接管。
+
+## 2026 年 7 月
+
+> 2026-07-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>2003 个项目，是这五个月里最大的一轮，953 个标为 Critical，三个标为已被实际利用。
+- 三个都在服务器产品上：Active Directory Federation Services 提权、SharePoint Server 提权、SharePoint 远程执行代码。
+- 桌面用户不受这三个影响。管理 SharePoint 或 AD FS 的人要优先处理，SharePoint 的远程执行代码是不需要凭证就能触发的那一类。
+
+## 2026 年 6 月
+
+> 2026-06-09 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">一般</span>1284 个项目，650 个标为 Critical，没有标为已被实际利用的项目。
+- Critical 的数量高不代表紧急。微软的严重度评的是「如果被利用会多严重」，跟「有没有人在用」是两回事，这一页的分级看的是后者。
+
+## 2026 年 5 月
+
+> 2026-05-12 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">尽快</span>1129 个项目，318 个标为 Critical，三个标为已被实际利用。
+- 两个在 Microsoft Defender 的防护引擎上（拒绝服务与提权），走定义文件自动更新，用户不需要做任何事。
+- 一个是 Exchange Server 的伪冒漏洞，只影响自建 Exchange 的组织。
+
+## 2026 年 4 月
+
+> 2026-04-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>682 个项目，216 个标为 Critical，两个标为已被实际利用。
+- CVE-2026-32202：Windows Shell 的伪冒漏洞，影响 Windows 10 1809 以后的桌面版与 Windows Server 2019 以后。Shell 是文件资源管理器与快捷方式处理的那一层，伪冒类问题让恶意文件在界面上看起来像正常的东西。
+- 另一个是 SharePoint Server 的伪冒漏洞，只影响服务器。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -26,6 +26,7 @@ icon: material/history
 - :material-usb-flash-drive-outline: [Tails 更新日誌](./tails.md)：Tails 作業系統
 - :material-apple-ios: [iOS 安全更新](./ios.md)：iPhone 與 iPad，含急迫程度與舊機支援狀況
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含急迫程度與三條維護線的狀態
+- :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面還是伺服器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的強化 Android，按月聚合
 
 ## 想找完整翻譯文章

--- a/docs/zh-TW/changelog/windows.md
+++ b/docs/zh-TW/changelog/windows.md
@@ -1,0 +1,68 @@
+---
+title: Windows 安全更新
+description: Windows 每月更新的白話整理，說明這個月有沒有正在被利用的漏洞、影響的是桌面還是伺服器，以及需不需要馬上更新。
+icon: material/microsoft-windows
+---
+
+# :material-microsoft-windows: Windows 安全更新
+
+Windows 每月更新的整理。微軟固定在每月第二個星期二發布（社群慣稱 Patch Tuesday），單月的項目數以千計，2026 年 8 月那一輪就有 1506 項，其中 359 項是從 Chromium 轉載過來的 Edge 漏洞。逐條讀完不可能，也沒有必要。
+
+這一頁只回答三個問題：這個月有沒有正在被實際利用的漏洞、那些漏洞影響桌面還是伺服器、需不需要馬上更新。新版本永遠在最上面。
+
+原始資料來自微軟的 [MSRC 安全更新指南](https://msrc.microsoft.com/update-guide){target="_blank"}，數字是從它的 CVRF 資料整理的。
+
+## 急迫程度怎麼判斷
+
+- <span class="urg-tag urg-tag--now">立刻</span>該月有標為已被實際利用的漏洞，且影響範圍包含桌面版 Windows。
+- <span class="urg-tag urg-tag--soon">儘快</span>有標為已被實際利用的漏洞，但只影響伺服器產品或自動更新的元件。桌面使用者跟著平常節奏即可，管理伺服器的人優先處理。
+- <span class="urg-tag urg-tag--routine">一般</span>該月沒有已被利用的項目。
+
+微軟自己有標 `Exploited:Yes`，這一頁的分級就建立在那個欄位上，再加一層「影響誰」的判斷。
+
+## 先看清楚受影響的是哪一種產品
+
+每個月被實際利用的漏洞裡，很大一部分落在 SharePoint、Exchange、Active Directory Federation Services 這類伺服器產品上。用一般桌面 Windows 的讀者不受那些影響，看到新聞標題寫「微軟修補正在被利用的重大漏洞」不必先緊張，要先確認的是那個漏洞在什麼產品上。
+
+另一個常見的誤會是 Microsoft Defender。它的漏洞修補走的是防毒定義檔的自動更新，不跟著 Patch Tuesday，也不需要使用者做任何事。
+
+在 Windows 上使用 Tor Browser 或其他匿名工具的人另外要知道：作業系統被取得權限之後，上面執行的任何工具都保護不了你。提權類的修補對這個情境的重要性不亞於瀏覽器本身的漏洞。
+
+## 2026 年 8 月
+
+> 2026-08-11 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>1506 個項目，721 個標為 Critical，一個標為已被實際利用。
+- CVE-2026-68820：WinSock 的輔助功能驅動程式（Ancillary Function Driver）提權。影響 Windows 10 1809 以後的桌面版與 Windows Server 2019 以後，一般使用者也在範圍內。
+- 提權類漏洞的典型用法是接在別的漏洞後面，先從瀏覽器或文件取得執行機會，再用它取得系統權限。單獨看它需要本機執行條件，串起來就是完整的接管。
+
+## 2026 年 7 月
+
+> 2026-07-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>2003 個項目，是這五個月裡最大的一輪，953 個標為 Critical，三個標為已被實際利用。
+- 三個都在伺服器產品上：Active Directory Federation Services 提權、SharePoint Server 提權、SharePoint 遠端執行程式碼。
+- 桌面使用者不受這三個影響。管理 SharePoint 或 AD FS 的人要優先處理，SharePoint 的遠端執行程式碼是不需要憑證就能觸發的那一類。
+
+## 2026 年 6 月
+
+> 2026-06-09 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">一般</span>1284 個項目，650 個標為 Critical，沒有標為已被實際利用的項目。
+- Critical 的數量高不代表急迫。微軟的嚴重度評的是「如果被利用會多嚴重」，跟「有沒有人在用」是兩回事，這一頁的分級看的是後者。
+
+## 2026 年 5 月
+
+> 2026-05-12 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--soon">儘快</span>1129 個項目，318 個標為 Critical，三個標為已被實際利用。
+- 兩個在 Microsoft Defender 的防護引擎上（阻斷服務與提權），走定義檔自動更新，使用者不需要做任何事。
+- 一個是 Exchange Server 的偽冒漏洞，只影響自架 Exchange 的組織。
+
+## 2026 年 4 月
+
+> 2026-04-14 · [MSRC](https://msrc.microsoft.com/update-guide){target="_blank"}
+
+- <span class="urg-tag urg-tag--now">立刻</span>682 個項目，216 個標為 Critical，兩個標為已被實際利用。
+- CVE-2026-32202：Windows Shell 的偽冒漏洞，影響 Windows 10 1809 以後的桌面版與 Windows Server 2019 以後。Shell 是檔案總管與捷徑處理的那一層，偽冒類問題讓惡意檔案在畫面上看起來像正常的東西。
+- 另一個是 SharePoint Server 的偽冒漏洞，只影響伺服器。


### PR DESCRIPTION
## 難處在量，解法不是壓縮而是換維度

2026 年 8 月那一輪 1506 項，其中 359 項只是從 Chromium 轉載的 Edge 漏洞。逐條翻譯不可能。Critical 數量也不能拿來當急迫程度：微軟的嚴重度評的是「被利用會多嚴重」，跟「有沒有人在用」是兩回事，6 月有 650 個 Critical 卻沒有任何一個在被利用。

分級改建立在微軟自己的 `Exploited:Yes` 欄位上，再加一層「影響誰」的判斷。

## 加的那一層才是重點

五個月裡九個被實際利用的漏洞，六個落在 SharePoint、Exchange、AD FS 這類伺服器產品，桌面使用者完全不受影響：

| 月份 | 項目數 | 被利用 | 落點 |
|---|---|---|---|
| 2026-08 | 1506 | 1 | WinSock AFD 提權，**含桌面** |
| 2026-07 | 2003 | 3 | AD FS、SharePoint ×2，伺服器 |
| 2026-06 | 1284 | 0 | 無 |
| 2026-05 | 1129 | 3 | Defender ×2（自動更新）、Exchange |
| 2026-04 | 682 | 2 | Windows Shell **含桌面**、SharePoint |

所以看到新聞寫「微軟修補正在被利用的重大漏洞」不必先緊張，先確認那是什麼產品。頁首把這件事直接講明。

另一個常見誤會是 Microsoft Defender：它的修補走防毒定義檔的自動更新，不跟 Patch Tuesday，使用者不需要做任何事。五月那則就是這種情況，所以只給「儘快」。

## 站台脈絡

頁首寫明在 Windows 上使用 Tor Browser 或其他匿名工具的人該知道的事：作業系統被取得權限之後，上面執行的任何工具都保護不了你。提權類修補在這個情境的重要性不亞於瀏覽器本身的漏洞。

## 資料來源

全部從 MSRC 的 CVRF API 抓下來自己算，包括每月項目數、Critical 數、`Exploited:Yes` 的項目。每個被利用的 CVE 都查過 `ProductStatuses` 的受影響產品清單，才判斷是桌面還是伺服器。Chromium 轉載那 359 項也是實際數出來的。

## 驗證

- `docs_style_lint.py` 掃六個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：標籤分佈 3 立刻 / 3 儘快 / 2 一般（含判準說明），icon 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)