### PR TITLE
fix(changelog): 索引頁拿掉對不上內容的說明

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -8,7 +8,7 @@ icon: material/history
 
 Release-by-release summaries of the anonymity tools our community follows, plus the operating systems people run them on. Routine point releases accumulate here as compact entries. Major events (security audits, architectural shifts, region-specific implications) get full posts in [Updates](../blog/index.md).
 
-Most of our release translations begin life in zh-TW and reach English on a rolling basis, so this English page is sparser than the Chinese versions for now. The links below point to whichever language version is currently available.
+Most of our release translations begin life in zh-TW and reach English on a rolling basis, so these English pages carry fewer entries than the Chinese versions. Every entry links back to the upstream announcement.
 
 ## Anonymity tools
 

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -6,7 +6,7 @@ icon: material/history
 
 # :material-history: 软件更新日志
 
-匿名网络工具与常用操作系统每次版本发布的重点整理，由社群志愿者从上游 changelog 翻译精简而来。例行版本更新会以条目形式累积在此页面，遇到重大事件（安全审计、新架构公告、有强烈在地脉络的功能）会在 [近期公告](../blog/index.md) 写成完整文章。
+匿名网络工具与常用操作系统每次版本发布的重点整理，由社群志愿者从上游 changelog 翻译精简而来。每一则都连回上游公告，内容是摘译。例行版本更新会以条目形式累积在此页面，遇到重大事件（安全审计、新架构公告、有强烈在地脉络的功能）会在 [近期公告](../blog/index.md) 写成完整文章。
 
 ## 匿名工具
 
@@ -28,7 +28,3 @@ icon: material/history
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含紧急程度与三条维护线的状态
 - :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面还是服务器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的强化 Android，按月聚合
-
-## 想找完整翻译文章
-
-每个条目都附「完整翻译文章」链接，可以回到当期完整翻译版本。也可以从 [近期公告](../blog/index.md) 直接浏览所有翻译与观点文章。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -6,7 +6,7 @@ icon: material/history
 
 # :material-history: 軟體更新日誌
 
-匿名網路工具與常用作業系統每次版本發布的重點整理，由社群志工從上游 changelog 翻譯精簡而來。例行版本更新會以條目形式累積在此頁面，遇到重大事件（安全稽核、新架構公告、有強烈台灣脈絡的功能）會在 [近期公告](../blog/index.md) 寫成完整文章。
+匿名網路工具與常用作業系統每次版本發布的重點整理，由社群志工從上游 changelog 翻譯精簡而來。每一則都連回上游公告，內容是摘譯。例行版本更新會以條目形式累積在此頁面，遇到重大事件（安全稽核、新架構公告、有強烈台灣脈絡的功能）會在 [近期公告](../blog/index.md) 寫成完整文章。
 
 ## 匿名工具
 
@@ -28,7 +28,3 @@ icon: material/history
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含急迫程度與三條維護線的狀態
 - :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面還是伺服器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的強化 Android，按月聚合
-
-## 想找完整翻譯文章
-
-每個條目都附「完整翻譯文章」連結，可以回到當期完整翻譯版本。也可以從 [近期公告](../blog/index.md) 直接瀏覽所有翻譯與觀點文章。


### PR DESCRIPTION
## 問題

`changelog/index.md` 底部寫著「每個條目都附『完整翻譯文章』連結，可以回到當期完整翻譯版本」。這句從一開始就沒有兌現：十一頁的條目全部只連上游公告，沒有任何一則連回翻譯文章。讀者照著找會撲空。

那一節的第二句（可以從近期公告瀏覽翻譯與觀點文章）跟頁首重複，所以整節拿掉，改在頁首補一句說明條目的性質：每一則都連回上游公告，內容是摘譯。

## en 版另有一句過時

「The links below point to whichever language version is currently available」是三語系還沒補齊時的寫法。現在三邊各十二個檔案都在（`ls docs/{zh-TW,zh-CN,en}/changelog/*.md` 都是 12），連結都指向自己語系的頁面，所以改成說明英文版的條目數比中文少，並補上「每一則都連回上游公告」。

## 驗證

- `docs_style_lint.py` 掃三個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：`h2` 剩「匿名工具」與「作業系統」兩節，舊說法（`完整翻譯文章`、`whichever language version`）在 zh-TW 與 en 產物裡都掃不到了

🤖 Generated with [Claude Code](https://claude.com/claude-code)