### PR TITLE
feat(changelog): 新增 Android 安全修補等級

### DIFF
--- a/docs/en/changelog/android.md
+++ b/docs/en/changelog/android.md
@@ -1,0 +1,69 @@
+---
+title: Android Security Patch Levels
+description: "Monthly Android security patch levels: how to check how far behind your device is, and what changed when Google stopped publishing vulnerability details in July 2026."
+icon: material/android
+---
+
+# :material-android: Android Security Patch Levels
+
+Summaries of Android's monthly security updates. This page works differently from the [iOS](./ios.md), [macOS](./macos.md), and [Windows](./windows.md) pages, for the reason given below. Newest month at the top.
+
+## Why this page has no urgency ratings
+
+Google's Android Security Bulletin changed in July 2026: the public pages no longer list vulnerability details. The June 2026 bulletin still carried 119 CVEs, split across Framework, System, Kernel, and the various chipset vendors, each tagged with a type and severity. The July and August pages contain nothing but explanatory text, right down to the boilerplate describing what the Type column of the details table means, while the table itself is absent. Rendering the page in a full browser gives the same result, so what is missing is the content itself.
+
+Without the details there is no way to tell whether anything is under active exploitation in a given month, and that is exactly what the iOS and Windows pages rate. Rather than force a rating on uncertain data, this page tracks three things that can be established: how far the patch level advanced, how many CVEs it covers and at what severity, and how far behind your own device is.
+
+CVE counts and severities come from the [GrapheneOS release notes](https://grapheneos.org/releases){target="_blank"}, which list the CVEs applied in each release. The numbers differ slightly from Google's bulletins because the counting scope is not identical.
+
+## First, check how far behind your device is
+
+The patch level a device actually runs is decided by its manufacturer, which is a separate matter from the date on Google's bulletin. Look under Settings, About phone, Android security update. Names vary between vendors, and what you see is a date like `2026-08-05`.
+
+How to read that date:
+
+- Within one month is normal. Every vendor needs time to integrate and test.
+- Three months or more behind means the vulnerabilities disclosed in that window are still unpatched on your device. Android vulnerability details land in AOSP once disclosed, so attackers and defenders read the same material.
+- A device that has stopped receiving updates will not get fixes for known vulnerabilities at all. If you handle sensitive contacts or reporting work, consider replacing it or installing a system that is still maintained.
+
+Vendor support periods vary widely. Checking a model's committed support window before buying costs less than discovering it afterwards.
+
+## August 2026
+
+> Patch level 2026-08-05 · [Google bulletin](https://source.android.com/docs/security/bulletin/2026/2026-08-01){target="_blank"} · [GrapheneOS releases](https://grapheneos.org/releases){target="_blank"}
+
+- Covers 196 CVEs: 34 Critical and 161 High.
+- Google's public bulletin carries no details, so there is no way to see which components these fixes land in, or whether anything is under active exploitation.
+- GrapheneOS separately closed two issues still unfixed upstream that month, making CredentialManager and the Play services FIDO activities opaque. See the [GrapheneOS monthly summary](./grapheneos.md).
+
+## July 2026
+
+> Patch level 2026-07-05 · [Google bulletin](https://source.android.com/docs/security/bulletin/2026/2026-07-01){target="_blank"} · [GrapheneOS releases](https://grapheneos.org/releases){target="_blank"}
+
+- Covers 165 CVEs: 30 Critical and 131 High.
+- This is the month the details disappeared. One month earlier there were complete sections with type annotations; from here on there is only a summary.
+- Neither the Android nor the Pixel bulletin lists additional patches at this level, making it a routine advance.
+
+## June 2026
+
+> Patch levels 2026-06-01 and 2026-06-05 · [Google bulletin](https://source.android.com/docs/security/bulletin/2026/2026-06-01){target="_blank"} · [GrapheneOS releases](https://grapheneos.org/releases){target="_blank"}
+
+- The last month with complete public details. Google's bulletin lists 119 CVEs; GrapheneOS counts 105 on their side.
+- **CVE-2025-48595** was flagged as possibly under limited, targeted exploitation. It sits in the Framework component, is an elevation of privilege, rated High, affecting Android 14, 15, 16, and 16-qpr2. When Google uses the phrase "limited, targeted", what usually sits behind it is commercial spyware aimed at specific individuals, and journalists and human rights workers are common targets.
+- Component split: System 37, Framework 30, Qualcomm closed-source 19, Unisoc 16, MediaTek 11.
+- Type split: 41 elevation of privilege, 22 denial of service, 7 information disclosure, 2 remote code execution. Elevation of privilege dominating is normal for Android: an attack chain usually gets code running first, then uses privilege escalation to reach system level.
+- The 2026-06-05 level shipped on 18 June alongside Android 17.
+
+## May 2026
+
+> Patch level 2026-05-05 · [Google bulletin](https://source.android.com/docs/security/bulletin/2026/2026-05-01){target="_blank"} · [GrapheneOS releases](https://grapheneos.org/releases){target="_blank"}
+
+- Covers 111 CVEs: 18 Critical and 92 High.
+- GrapheneOS hardware memory tagging caught a use-after-free in the Broadcom Wi-Fi driver and an out-of-bounds read in the DisplayPort driver that month, neither of which upstream had found.
+
+## April 2026
+
+> [GrapheneOS releases](https://grapheneos.org/releases){target="_blank"}
+
+- Covers 61 CVEs: 13 Critical and 48 High.
+- GrapheneOS did not advance the listed patch level this month, and the releases were mostly functional fixes.

--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -30,3 +30,4 @@ Your device is part of the attack surface. This group skips the line-by-line tra
 - :material-apple: [macOS security updates](./macos.md) — Mac, with urgency ratings and the state of the three maintenance lines
 - :material-microsoft-windows: [Windows security updates](./windows.md) — monthly Patch Tuesday, sorted by desktop versus server impact
 - :material-cellphone-lock: [GrapheneOS monthly summary](./grapheneos.md) — hardened Android on Pixel, aggregated by month
+- :material-android: [Android security patch levels](./android.md) — monthly patch levels and CVE counts, and how to check how far behind your device is

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
           - changelog/macos.md
           - changelog/windows.md
           - changelog/grapheneos.md
+          - changelog/android.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 關於我們是社群的一部分，收進去讓第一層再短一項。放在 community/index.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -134,6 +134,7 @@ nav:
           - changelog/macos.md
           - changelog/windows.md
           - changelog/grapheneos.md
+          - changelog/android.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       # 关于我们是社群的一部分，收进去让第一层再短一项。放在 community/index.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -132,6 +132,7 @@ nav:
           - changelog/macos.md
           - changelog/windows.md
           - changelog/grapheneos.md
+          - changelog/android.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
       # About is part of the community section. Placed after community/index.md rather

--- a/docs/zh-CN/changelog/android.md
+++ b/docs/zh-CN/changelog/android.md
@@ -1,0 +1,69 @@
+---
+title: Android 安全补丁级别
+description: Android 每月安全补丁级别的整理，说明怎么查自己的设备落后多少，以及 2026 年 7 月起公开公告不再列出漏洞明细的影响。
+icon: material/android
+---
+
+# :material-android: Android 安全补丁级别
+
+Android 每月安全更新的整理。这一页的做法跟 [iOS](./ios.md)、[macOS](./macos.md)、[Windows](./windows.md) 那几页不同，原因写在下一节。新的月份永远在最上面。
+
+## 这一页为什么没有紧急程度分级
+
+Google 的 Android 安全公告在 2026 年 7 月出现变化，公开页面不再列出漏洞明细。2026 年 6 月的公告还有 119 个 CVE，分成 Framework、System、Kernel 与各家芯片厂等分节，每一条都标了类型与严重度。7 月与 8 月的页面只剩说明文字，连「明细表的 Type 字段代表什么」这种模板解释都还留着，那张表格本身却不在页面上。用浏览器完整渲染过也一样，所以缺的是内容本身。
+
+没有明细就无法判断「这个月有没有正在被实际利用的漏洞」，而那正是 iOS 与 Windows 那两页分级的依据。与其用不确定的数据硬做分级，这一页改成追三件可以确定的事：每月的补丁级别推进到哪、涵盖多少 CVE 与严重度分布、你的设备落后多少。
+
+CVE 数量与严重度来自 [GrapheneOS 的发布说明](https://grapheneos.org/releases){target="_blank"}，他们每次发布都会列出当期套用的 CVE 清单。数字与 Google 的公告会有小幅差异，因为统计范围不完全相同。
+
+## 先查自己的设备落后多少
+
+Android 设备的实际补丁级别由手机厂决定，跟 Google 公告的日期不是同一件事。位置在设置、关于手机、Android 安全更新，各家界面名称略有差异，显示的是一个像 `2026-08-05` 的日期。
+
+怎么看那个日期：
+
+- 落后一个月以内属于正常，各厂都需要时间整合与测试。
+- 落后三个月以上，代表这段期间公开的漏洞在你的设备上都还没补。Android 的漏洞公开之后细节会进 AOSP，攻击方跟防守方取得的是同一份数据。
+- 完全停止更新的设备，已知漏洞不会再有修补。处理敏感联络或采访工作的话，该考虑换机或改装仍在维护的系统。
+
+原厂支持期长短差很多，买之前查清楚该型号的承诺支持年限，比买了之后才发现划算。
+
+## 2026 年 8 月
+
+> 补丁级别 2026-08-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-08-01){target="_blank"} · [GrapheneOS 发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 涵盖 196 个 CVE，其中 34 个 Critical、161 个 High。
+- Google 的公开公告没有明细，看不出这些修补落在哪些组件，也看不出有没有正在被利用的项目。
+- GrapheneOS 在同一个月另外修掉两个上游还没处理的漏洞，把凭证管理器与 Play 服务的 FIDO 界面改为不透明，详见 [GrapheneOS 月度更新摘要](./grapheneos.md)。
+
+## 2026 年 7 月
+
+> 补丁级别 2026-07-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-07-01){target="_blank"} · [GrapheneOS 发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 涵盖 165 个 CVE，其中 30 个 Critical、131 个 High。
+- 明细从这个月开始消失。往前一个月还有完整的分节与类型标示，往后就只剩摘要。
+- 这个级别在 Android 与 Pixel 两份公告里都没有额外的修补项目，属于例行推进。
+
+## 2026 年 6 月
+
+> 补丁级别 2026-06-01 与 2026-06-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-06-01){target="_blank"} · [GrapheneOS 发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 这是最后一个公开明细完整的月份，Google 公告列出 119 个 CVE，GrapheneOS 那侧统计为 105 个。
+- **CVE-2025-48595** 被标为可能正在被有限、针对性地利用。它在 Framework 组件，类型是提权，严重度 High，影响 Android 14、15、16 与 16-qpr2。Google 用「有限、针对性」这个说法时，背后通常是商业间谍软件对特定对象发动的攻击，记者与人权工作者是常见的目标。
+- 组件分布：System 37 个、Framework 30 个、Qualcomm 闭源组件 19 个、Unisoc 16 个、MediaTek 11 个。
+- 类型分布：提权 41 个、拒绝服务 22 个、信息泄露 7 个、远程执行代码 2 个。提权占最多是 Android 的常态，攻击链通常先取得执行机会，再靠提权升到系统权限。
+- 6 月 18 日的 2026-06-05 级别随 Android 17 一起发布。
+
+## 2026 年 5 月
+
+> 补丁级别 2026-05-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-05-01){target="_blank"} · [GrapheneOS 发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 涵盖 111 个 CVE，其中 18 个 Critical、92 个 High。
+- GrapheneOS 在这个月的硬件内存标记抓到 Broadcom Wi-Fi 驱动的 use-after-free 与 DisplayPort 驱动的越界读取，那些是上游没发现的问题。
+
+## 2026 年 4 月
+
+> [GrapheneOS 发布页](https://grapheneos.org/releases){target="_blank"}
+
+- 涵盖 61 个 CVE，其中 13 个 Critical、48 个 High。
+- GrapheneOS 在这个月没有推进标示的补丁级别，发布的内容以功能修正为主。

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -28,3 +28,4 @@ icon: material/history
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含紧急程度与三条维护线的状态
 - :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面还是服务器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的强化 Android，按月聚合
+- :material-android: [Android 安全补丁级别](./android.md)：每月补丁级别与 CVE 数，先查自己的设备落后多少

--- a/docs/zh-TW/changelog/android.md
+++ b/docs/zh-TW/changelog/android.md
@@ -1,0 +1,69 @@
+---
+title: Android 安全修補等級
+description: Android 每月安全修補等級的整理，說明怎麼查自己的裝置落後多少，以及 2026 年 7 月起公開公告不再列出漏洞明細的影響。
+icon: material/android
+---
+
+# :material-android: Android 安全修補等級
+
+Android 每月安全更新的整理。這一頁的做法跟 [iOS](./ios.md)、[macOS](./macos.md)、[Windows](./windows.md) 那幾頁不同，原因寫在下一節。新的月份永遠在最上面。
+
+## 這一頁為什麼沒有急迫程度分級
+
+Google 的 Android 安全公告在 2026 年 7 月出現變化，公開頁面不再列出漏洞明細。2026 年 6 月的公告還有 119 個 CVE，分成 Framework、System、Kernel 與各家晶片廠等分節，每一條都標了類型與嚴重度。7 月與 8 月的頁面只剩說明文字，連「明細表的 Type 欄位代表什麼」這種樣板解釋都還留著，那張表格本身卻不在頁面上。用瀏覽器完整渲染過也一樣，所以缺的是內容本身。
+
+沒有明細就無法判斷「這個月有沒有正在被實際利用的漏洞」，而那正是 iOS 與 Windows 那兩頁分級的依據。與其用不確定的資料硬做分級，這一頁改成追三件可以確定的事：每月的修補等級推進到哪、涵蓋多少 CVE 與嚴重度分佈、你的裝置落後多少。
+
+CVE 數量與嚴重度來自 [GrapheneOS 的發布說明](https://grapheneos.org/releases){target="_blank"}，他們每次釋出都會列出當期套用的 CVE 清單。數字與 Google 的公告會有小幅差異，因為統計範圍不完全相同。
+
+## 先查自己的裝置落後多少
+
+Android 裝置的實際修補等級由手機廠決定，跟 Google 公告的日期不是同一件事。位置在設定、關於手機、Android 安全性更新，各家介面名稱略有差異，顯示的是一個像 `2026-08-05` 的日期。
+
+怎麼看那個日期：
+
+- 落後一個月以內屬於正常，各廠都需要時間整合與測試。
+- 落後三個月以上，代表這段期間公開的漏洞在你的裝置上都還沒補。Android 的漏洞公開之後細節會進 AOSP，攻擊方跟防守方取得的是同一份資料。
+- 完全停止更新的裝置，已知漏洞不會再有修補。處理敏感聯絡或採訪工作的話，該考慮換機或改裝仍在維護的系統。
+
+原廠支援期長短差很多，買之前查清楚該型號的承諾支援年限，比買了之後才發現划算。
+
+## 2026 年 8 月
+
+> 修補等級 2026-08-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-08-01){target="_blank"} · [GrapheneOS 發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 涵蓋 196 個 CVE，其中 34 個 Critical、161 個 High。
+- Google 的公開公告沒有明細，看不出這些修補落在哪些元件，也看不出有沒有正在被利用的項目。
+- GrapheneOS 在同一個月另外修掉兩個上游還沒處理的漏洞，把憑證管理員與 Play 服務的 FIDO 畫面改為不透明，詳見 [GrapheneOS 月度更新摘要](./grapheneos.md)。
+
+## 2026 年 7 月
+
+> 修補等級 2026-07-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-07-01){target="_blank"} · [GrapheneOS 發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 涵蓋 165 個 CVE，其中 30 個 Critical、131 個 High。
+- 明細從這個月開始消失。往前一個月還有完整的分節與類型標示，往後就只剩摘要。
+- 這個等級在 Android 與 Pixel 兩份公告裡都沒有額外的修補項目，屬於例行推進。
+
+## 2026 年 6 月
+
+> 修補等級 2026-06-01 與 2026-06-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-06-01){target="_blank"} · [GrapheneOS 發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 這是最後一個公開明細完整的月份，Google 公告列出 119 個 CVE，GrapheneOS 那側統計為 105 個。
+- **CVE-2025-48595** 被標為可能正在被有限、針對性地利用。它在 Framework 元件，類型是提權，嚴重度 High，影響 Android 14、15、16 與 16-qpr2。Google 用「有限、針對性」這個說法時，背後通常是商業間諜軟體對特定對象發動的攻擊，記者與人權工作者是常見的目標。
+- 元件分佈：System 37 個、Framework 30 個、Qualcomm 閉源元件 19 個、Unisoc 16 個、MediaTek 11 個。
+- 類型分佈：提權 41 個、阻斷服務 22 個、資訊外洩 7 個、遠端執行程式碼 2 個。提權佔最多是 Android 的常態，攻擊鏈通常先取得執行機會，再靠提權升到系統權限。
+- 6 月 18 日的 2026-06-05 等級隨 Android 17 一起發布。
+
+## 2026 年 5 月
+
+> 修補等級 2026-05-05 · [Google 公告](https://source.android.com/docs/security/bulletin/2026/2026-05-01){target="_blank"} · [GrapheneOS 發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 涵蓋 111 個 CVE，其中 18 個 Critical、92 個 High。
+- GrapheneOS 在這個月的硬體記憶體標記抓到 Broadcom Wi-Fi 驅動的 use-after-free 與 DisplayPort 驅動的越界讀取，那些是上游沒發現的問題。
+
+## 2026 年 4 月
+
+> [GrapheneOS 發布頁](https://grapheneos.org/releases){target="_blank"}
+
+- 涵蓋 61 個 CVE，其中 13 個 Critical、48 個 High。
+- GrapheneOS 在這個月沒有推進標示的修補等級，釋出的內容以功能修正為主。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -28,3 +28,4 @@ icon: material/history
 - :material-apple: [macOS 安全更新](./macos.md)：Mac，含急迫程度與三條維護線的狀態
 - :material-microsoft-windows: [Windows 安全更新](./windows.md)：每月 Patch Tuesday，先分清楚桌面還是伺服器
 - :material-cellphone-lock: [GrapheneOS 月度更新摘要](./grapheneos.md)：Pixel 上的強化 Android，按月聚合
+- :material-android: [Android 安全修補等級](./android.md)：每月修補等級與 CVE 數，先查自己的裝置落後多少


### PR DESCRIPTION
## 為什麼是縮減版

先修正一件事：之前判定 Android 資料源不可用是誤判。URL 結構 2026 年起改了，多一層年份目錄（`/bulletin/2026/2026-08-01`），我先前試的三種路徑都是舊結構。

但拿到頁面之後發現真正的問題：**Google 從 2026 年 7 月起不再公開漏洞明細**。

| 月份 | 頁面裡的 CVE 數 | article 長度 |
|---|---|---|
| 2025-12（舊格式） | 106 | 13 個表格 |
| 2026-06 | 119 | 16554 字元 |
| 2026-07 | 0 | 5297 字元 |
| 2026-08 | 0 | 5089 字元 |

用 `google-chrome --headless --dump-dom` 完整渲染過也一樣，所以不是抓取方式的問題。頁面連「明細表的 Type 欄位代表什麼」這種樣板解釋都還留著，表格本身卻不在。

沒有明細就判斷不出「這個月有沒有正在被實際利用的漏洞」，而那是 iOS 與 Windows 兩頁分級的依據。與其用不確定的資料硬做分級，這一頁不套急迫程度標籤，改追三件可以確定的事，並在頁首把這個取捨對讀者講明。

## 內容

CVE 數量與嚴重度從 GrapheneOS 的發布說明反推（他們每次釋出都列出當期套用的清單），收 2026-04 到 08 五則。

**六月那則是全頁最重要的**：CVE-2025-48595 被標為可能正在被有限、針對性地利用，Framework 元件的提權，High，影響 Android 14 到 16-qpr2。Google 用「有限、針對性」這個說法時，背後通常是商業間諜軟體針對特定對象的攻擊，記者與人權工作者是常見目標。那也是最後一次在公開公告裡看得到這種標注。同月還有完整的元件分佈（System 37、Framework 30、Qualcomm 閉源 19）與類型分佈（提權 41、阻斷服務 22、資訊外洩 7、遠端執行程式碼 2）。

**「先查自己的裝置落後多少」那一節放在條目之前**，因為對多數讀者來說，自己的裝置落後三個月比這個月修了幾個 CVE 重要得多。內容包括怎麼查、落後多少算危險、為什麼落後三個月以上要當真（漏洞細節公開後會進 AOSP，攻防雙方讀的是同一份資料）。

## 驗證

- `docs_style_lint.py` 掃六個檔案，0 error 0 warn
- 三語系建置皆通過
- 產物檢查：icon 正常，內部連結（`ios`、`macos`、`windows`、`grapheneos`）全部指得到

🤖 Generated with [Claude Code](https://claude.com/claude-code)