### PR TITLE
fix(changelog): 每一則條目都寫明有沒有人在利用

### DIFF
--- a/docs/en/changelog/ios.md
+++ b/docs/en/changelog/ios.md
@@ -49,7 +49,7 @@ Older lines get fewer fixes and get them later. The 2026-04-22 entry below has a
 
 > 2026-07-27 · [Upstream advisory](https://support.apple.com/en-us/128066){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>86 fixes, with 19 in Kernel, 7 in WebKit, and 6 in ImageIO.
+- <span class="urg-tag urg-tag--soon">Soon</span>86 fixes, with 19 in Kernel, 7 in WebKit, and 6 in ImageIO.Apple flags none of these as actively exploited.
 - WebKit closes a browsing-history leak where a website could tell whether you had visited a given link. The same group also fixes malicious content violating iframe sandboxing policy (the sandbox keeps embedded pages in an isolated environment; break it and they reach things they should not), and UI spoofing via framed malicious content.
 - Kernel fixes an issue where connecting to a malicious NFS server could corrupt kernel memory, worth noting if you mount network storage you do not control.
 - Contacts gets three fixes, including apps adding contacts without authorisation and a maliciously crafted contact leaking sensitive data.
@@ -58,7 +58,7 @@ Older lines get fewer fixes and get them later. The 2026-04-22 entry below has a
 
 > 2026-06-29 · [Upstream advisory](https://support.apple.com/en-us/127594){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>24 of the 38 fixes are in WebKit and 4 more in WebRTC, so this release is almost entirely browser engine work.
+- <span class="urg-tag urg-tag--soon">Soon</span>24 of the 38 fixes are in WebKit and 4 more in WebRTC, so this release is almost entirely browser engine work.Apple flags none of these as actively exploited.
 - Several entries cover malicious sites exfiltrating data cross-origin and web content disclosing sensitive user information, which directly affects any service you stay logged into in the browser.
 - One entry covers a malicious website processing restricted web content outside the sandbox. The sandbox is the browser's last line of isolation, so breaking it removes a layer of protection.
 - A 26.5.1 also shipped on 1 June with no published CVE list, so it gets no entry here.
@@ -67,7 +67,7 @@ Older lines get fewer fixes and get them later. The 2026-04-22 entry below has a
 
 > 2026-05-11 · [26.5 advisory](https://support.apple.com/en-us/127110){target="_blank"} · [18.7.9 advisory](https://support.apple.com/en-us/127111){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>The 26.x line fixes 67 issues, 21 in WebKit and 6 in Kernel, including one where an app could gain root privileges (full control of the system, equivalent to owning the device).
+- <span class="urg-tag urg-tag--soon">Soon</span>The 26.x line fixes 67 issues, 21 in WebKit and 6 in Kernel, including one where an app could gain root privileges (full control of the system, equivalent to owning the device).Apple flags none of these as actively exploited.
 - The 18.x line fixes 49 issues and includes three notable privacy ones: an app circumventing App Privacy Report logging (the very report you would use to audit what an app connects to), an app enumerating installed applications (usable for profiling a user), and a Wi-Fi issue letting an app execute arbitrary code with kernel privileges.
 - The 17.7.11, 16.7.16, and 15.8.8 releases for older hardware carry a single fix each: the notification retention issue described in the 22 April entry below.
 
@@ -75,6 +75,6 @@ Older lines get fewer fixes and get them later. The 2026-04-22 entry below has a
 
 > 2026-04-22 · [26.4.2 advisory](https://support.apple.com/en-us/127002){target="_blank"} · [18.7.8 advisory](https://support.apple.com/en-us/127003){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">Routine</span>The privacy implication is worth knowing. The entire release fixes one issue.
+- <span class="urg-tag urg-tag--routine">Routine</span>The privacy implication is worth knowing. The entire release fixes one issue.Apple flags none of these as actively exploited.
 - CVE-2026-28950: notifications marked for deletion could be unexpectedly retained on the device. The cause was a logging issue, addressed with improved data redaction. Notification content you assumed disappeared when you swiped it away was still on the device, readable by anyone who obtained it.
 - The same fix did not reach the 17.x, 16.x, and 15.x lines until 11 May, 19 days later. Older hardware gets fewer fixes and gets them later.

--- a/docs/en/changelog/macos.md
+++ b/docs/en/changelog/macos.md
@@ -38,7 +38,7 @@ All three shipping the same day is normal, and so is the gap in fix counts. See 
 
 > 2026-08-17 · [Upstream advisory](https://support.apple.com/en-us/148281){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>28 fixes, 19 of them in WebKit, mostly memory corruption or crashes from processing malicious web content.
+- <span class="urg-tag urg-tag--soon">Soon</span>28 fixes, 19 of them in WebKit, mostly memory corruption or crashes from processing malicious web content.Apple flags none of these as actively exploited.
 - ImageIO has one "processing an image may lead to arbitrary code execution", the kind of flaw used in attacks that trigger by sending you a picture.
 - Kernel accounts for 3 and IOGPUFamily for 1. This round shipped for Tahoe only, with no matching Sequoia or Sonoma release.
 
@@ -46,7 +46,7 @@ All three shipping the same day is normal, and so is the gap in fix counts. See 
 
 > 2026-08-06 · [26.6.1](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9](https://support.apple.com/en-us/148172){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>All three lines shipped the same day with a single fix each. Spending three releases on one issue means Apple decided it could not wait for the next scheduled update.
+- <span class="urg-tag urg-tag--soon">Soon</span>All three lines shipped the same day with a single fix each. Spending three releases on one issue means Apple decided it could not wait for the next scheduled update.Apple flags none of these as actively exploited.
 - CVE-2026-65400: an attacker on your network could authenticate to Screen Sharing without valid credentials. The cause was a state management flaw in the authentication flow.
 - Prioritise this if you have Screen Sharing enabled. System Settings, General, Sharing shows whether it is on, and turning it off when you do not use it is the most direct fix available.
 
@@ -54,7 +54,7 @@ All three shipping the same day is normal, and so is the gap in fix counts. See 
 
 > 2026-07-27 · [26.6](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8](https://support.apple.com/en-us/128072){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>The largest round of the year: 153 fixes for Tahoe, 138 for Sequoia, 127 for Sonoma. That spread is the concrete evidence that older lines receive fewer fixes.
+- <span class="urg-tag urg-tag--soon">Soon</span>The largest round of the year: 153 fixes for Tahoe, 138 for Sequoia, 127 for Sonoma. That spread is the concrete evidence that older lines receive fewer fixes.Apple flags none of these as actively exploited.
 - Kernel dominates, with 27 for Tahoe, 21 for Sequoia, and 20 for Sonoma.
 - Accounts has one where an app could gain root privileges. Assets has one where a malicious application could bypass privacy preferences, meaning it takes permissions you never granted.
 - AppleDouble can terminate an app unexpectedly when processing a malicious file. Model I/O and HFS each carry several file-parsing issues, the kind you trigger by opening a file someone sent you.
@@ -63,14 +63,14 @@ All three shipping the same day is normal, and so is the gap in fix counts. See 
 
 > 2026-06-29 · [Upstream advisory](https://support.apple.com/en-us/127595){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>24 of the 38 fixes are in WebKit and 4 more in WebRTC, so this release is almost entirely browser engine work.
+- <span class="urg-tag urg-tag--soon">Soon</span>24 of the 38 fixes are in WebKit and 4 more in WebRTC, so this release is almost entirely browser engine work.Apple flags none of these as actively exploited.
 - The impact reaches beyond Safari. Every app that renders web content through a WebView uses the same engine, including mail previews and the in-app browsers in many chat clients.
 
 ## macOS Tahoe 26.5
 
 > 2026-05-11 · [Upstream advisory](https://support.apple.com/en-us/127115){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>87 fixes, 22 in WebKit and 9 in Kernel.
+- <span class="urg-tag urg-tag--soon">Soon</span>87 fixes, 22 in WebKit and 9 in Kernel.Apple flags none of these as actively exploited.
 - CUPS has one where an app could gain root privileges. CUPS is the printing system, easy to forget about, and it runs by default.
 - BOM has one where a maliciously crafted ZIP archive bypasses Gatekeeper checks. Unpacking an archive someone sent you is an everyday action, which makes this one worth knowing.
 - Accounts has an issue bypassing certain privacy preferences, and mDNSResponder accounts for 4.

--- a/docs/en/changelog/onionshare.md
+++ b/docs/en/changelog/onionshare.md
@@ -23,7 +23,7 @@ Releases are infrequent and none so far has warranted same-day installation, so 
 
 > 2026-07-28 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">Routine</span>Dependency updates covering the bundled tor, Python packages, and web-side dependencies. This rating is for people already on 2.6.4.
+- <span class="urg-tag urg-tag--routine">Routine</span>Dependency updates covering the bundled tor, Python packages, and web-side dependencies. This rating is for people already on 2.6.4.The advisories mention no active exploitation.
 - No new features or behaviour changes. If you are still on 2.6.3 or earlier, treat this as "Soon": moving up brings the two security fixes from 2.6.4 with it, and you can install 2.6.5 directly.
 
 ## OnionShare 2.6.4
@@ -40,7 +40,7 @@ Releases are infrequent and none so far has warranted same-day installation, so 
 
 > 2025-02-25 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">Routine</span>The CLI gained `--log-filenames`, showing which URLs are visited in Share and Website mode.
+- <span class="urg-tag urg-tag--routine">Routine</span>The CLI gained `--log-filenames`, showing which URLs are visited in Share and Website mode.This release contains no security fixes.
 - A saved persistent onion tab can now start automatically once OnionShare launches and Tor connects.
 - Fixed bridge requests and meek as a pluggable transport, plus a fatal error when censorship circumvention returned no bridges.
 - Fixed a thread race segfault on CLI shutdown, and the auto-stop timer failing in Share mode after someone had visited the share.
@@ -52,7 +52,7 @@ Releases are infrequent and none so far has warranted same-day installation, so 
 
 > 2024-03-21 · [Upstream release](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>An all-security release, concentrated on input handling in Receive mode and Chat mode.
+- <span class="urg-tag urg-tag--soon">Soon</span>An all-security release, concentrated on input handling in Receive mode and Chat mode.The advisories mention no active exploitation.
 - Newlines are stripped from History item paths.
 - Text messages in Receive mode are capped at 524288 characters.
 - Usernames are restricted to specific ASCII characters with control characters removed, and username validation exceptions are handled so users can no longer join silently.

--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -48,7 +48,7 @@ The Tails project only distinguishes emergency from scheduled releases. The midd
 
 > 2026-07-23 · [Upstream announcement](https://tails.net/news/version_7.10/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>A scheduled release introducing a new shutdown procedure and a new video player.
+- <span class="urg-tag urg-tag--soon">Soon</span>A scheduled release introducing a new shutdown procedure and a new video player.Upstream mentions no real-world attacks involving these.
 - Adopts GNOME's standard shutdown procedure. The Power Off dialog now warns about unsaved documents and open applications, and shutdown completes automatically after 60 seconds. It is a bit slower in exchange for better data protection. An emergency shutdown option remains for a faster power-off.
 - The video player is now Celluloid, more modern and reliable, and it has no network access. To watch videos online, use Tor Browser or install VLC as additional software. Celluloid does not work on computers manufactured in 2011 or earlier.
 - Tor Browser updated to 15.0.19.
@@ -68,7 +68,7 @@ The Tails project only distinguishes emergency from scheduled releases. The midd
 
 > 2026-06-18 · [Upstream announcement](https://tails.net/news/version_7.9/){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">Routine</span>Regular scheduled release, not an emergency security update.
+- <span class="urg-tag urg-tag--routine">Routine</span>Regular scheduled release, not an emergency security update.Upstream mentions no real-world attacks involving these.
 - Tor Browser updated to 15.0.16.
 - Updated some firmware packages, improving support for newer hardware such as graphics and Wi-Fi.
 - Fixed a bug where the "outdated Secure Boot certificate" prompt could appear in the rare case when the certificates were already up to date.
@@ -87,7 +87,7 @@ The Tails project only distinguishes emergency from scheduled releases. The midd
 
 > 2026-05-21 · [Upstream announcement](https://tails.net/news/version_7.8/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>Tor Browser updated to 15.0.14 (based on Firefox ESR 140.11).
+- <span class="urg-tag urg-tag--soon">Soon</span>Tor Browser updated to 15.0.14 (based on Firefox ESR 140.11).Upstream mentions no real-world attacks involving these.
 - Mitigates the Linux kernel local privilege escalation "Fragnesia" (alongside the earlier "Drity Frag" mitigation). Such flaws let an application inside Tails gain administrator privileges, which combined with other unknown vulnerabilities could fully compromise Tails and deanonymize the user.
 - Mitigates a Flatpak sandbox escape via Yelp; yelp updated to 42.2-4tails1.
 - Patches CVE-2026-46529 (evince), CVE-2026-41989 (libgcrypt20), and CVE-2026-41054 (haveged).
@@ -100,7 +100,7 @@ The Tails project only distinguishes emergency from scheduled releases. The midd
 
 > 2026-03-26 · [Upstream announcement](https://tails.net/news/version_7.6/){target="_blank"} · [Full translation](../blog/posts/2026-tails-7-6.md)
 
-- <span class="urg-tag urg-tag--routine">Routine</span>Automatic Tor bridges (region-aware via Moat API), GNOME Secrets replaces KeePassXC as the built-in password manager, routine component bumps (Tor Browser 15.0.8, Thunderbird 140.8.0, Electrum 4.7.0).
+- <span class="urg-tag urg-tag--routine">Routine</span>Automatic Tor bridges (region-aware via Moat API), GNOME Secrets replaces KeePassXC as the built-in password manager, routine component bumps (Tor Browser 15.0.8, Thunderbird 140.8.0, Electrum 4.7.0).Upstream mentions no real-world attacks involving these.
 
 !!! info "Earlier versions"
 

--- a/docs/en/changelog/tor-daemon.md
+++ b/docs/en/changelog/tor-daemon.md
@@ -32,7 +32,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">Now</span>A security release two days after the previous one. Upstream cited further high-priority issues, one of them affecting onion services.
+- <span class="urg-tag urg-tag--now">Now</span>A security release two days after the previous one. Upstream cited further high-priority issues, one of them affecting onion services.Upstream does not mention active exploitation.
 - Fixes a race condition where, under the right circumstances, a rendezvous point could impersonate the onion service a client was trying to reach, putting itself in the middle. Anyone running an onion service should take this one (bug 41297, present since 0.3.5.3-alpha).
 - Clients no longer assert and exit when an onion service encodes an all-zero public key for one of its introduction points (bug 41295).
 - Directory authorities no longer accept port 0 in exit policy lines. A secondary check parsed `0` as the range `1-0`, which tripped an assert while generating a networkstatus vote.
@@ -41,7 +41,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">Now</span>A security release upstream strongly recommends installing promptly.
+- <span class="urg-tag urg-tag--now">Now</span>A security release upstream strongly recommends installing promptly.Upstream does not mention active exploitation.
 - TROVE-2026-025: rejects a `CONFLUX_LINK` cell arriving on a circuit that already has attached streams. A malicious client could send `RELAY_COMMAND_BEGIN` before `CONFLUX_LINK`, leaving the attached exit stream orphaned with a dangling circuit back-pointer, and a use-after-free when the circuit is freed, meaning memory handed back and then used again, which crashes the relay (bug 41258).
 - Restores the warning about unsafe SOCKS protocols (socks4, or socks5 without a hostname) when `SafeSocks` is unset. The warning had been silently missing, and what it guards against is leaking the name you are resolving beyond your own machine (bug 41290).
 - Entry guards expire consistently at 48 to 60 days again.
@@ -50,7 +50,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">Now</span>A security release covering three major issues at once.
+- <span class="urg-tag urg-tag--now">Now</span>A security release covering three major issues at once.Upstream does not mention active exploitation.
 - TROVE-2026-022: the compression bomb check could be bypassed. An attacker concatenates many gzip or zlib sub-streams, each just under the per-stream detection threshold, and the whole payload slips past (bug 41275, present since 0.3.1.1-alpha).
 - TROVE-2026-021: an infinite loop when decompressing a truncated zlib/gzip stream. A truncated stream never reaches `Z_STREAM_END`, and the `Z_BUF_ERROR` zlib returns was mistaken for a full output buffer, so the code retried forever (bug 41274).
 - TROVE-2026-017: a NULL write after free when sending a `CONFLUX_SWITCH` cell fails. The failure closes the circuit and removes the leg, but the return value was ignored, so the caller went on to write into freed memory and crashed (bug 41263).
@@ -59,7 +59,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">Soon</span>An emergency follow-up to the previous release, after a silent error in the CI build emptied the entire fallback directory list.
+- <span class="urg-tag urg-tag--soon">Soon</span>An emergency follow-up to the previous release, after a silent error in the CI build emptied the entire fallback directory list.This release fixes no security issue, so the question of exploitation does not arise.
 - The impact falls on fresh installs: with no fallback directories available, new clients bootstrap directly against the directory authorities, which hurts both the load on those machines and how observable that traffic is.
 - Regenerates the fallback directory list as of 7 May 2026.
 
@@ -67,7 +67,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">Now</span>A security release shipped on both maintenance lines.
+- <span class="urg-tag urg-tag--now">Now</span>A security release shipped on both maintenance lines.Upstream does not mention active exploitation.
 - TROVE-2026-011: an out-of-bounds read handling END, TRUNCATE, and TRUNCATED cells whose payload carries no reason field, meaning it reads memory it should not, which can crash the relay or leak memory contents. The bug had been present since 0.1.1.1-alpha (bug 41254).
 - TROVE-2026-008: no longer attempts or accepts `BEGIN_DIR` over conflux legs (bug 41243).
 - TROVE-2026-010: corrects accounting when clearing the conflux out-of-order queue (bug 41251).
@@ -76,7 +76,7 @@ Several entries below fix conflux. It lets a client send one connection's data o
 
 > 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">Now</span>A security release covering two issues that could crash a relay remotely.
+- <span class="urg-tag urg-tag--now">Now</span>A security release covering two issues that could crash a relay remotely.Upstream does not mention active exploitation.
 - TROVE-2026-003: a malicious `CREATED2` causes an 11-byte stack overflow, resulting in a remote crash (bug 41231).
 - TROVE-2026-004: a memory comparison in the conflux subsystem used the wrong length, another path to a remote crash (bug 41232).
 - Also fixes a batch of defence-in-depth issues and the polyval implementation on big-endian platforms.

--- a/docs/zh-CN/changelog/ios.md
+++ b/docs/zh-CN/changelog/ios.md
@@ -49,7 +49,7 @@ Apple 同一天常常发好几条更新线，版本号差很多，内容也不�
 
 > 2026-07-27 · [上游公告](https://support.apple.com/en-us/128066){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>86 个修补，Kernel 占 19 个、WebKit 占 7 个、ImageIO 占 6 个。
+- <span class="urg-tag urg-tag--soon">尽快</span>86 个修补，Kernel 占 19 个、WebKit 占 7 个、ImageIO 占 6 个。Apple 没有标注任何一项已被实际利用。
 - WebKit 修掉一个浏览记录外泄：网站有办法知道你是否访问过某个链接。同一组还修了恶意内容违反 iframe 沙盒策略（沙盒是把嵌入的网页关在隔离环境里，破得掉就能碰到不该碰的东西），以及网页内嵌恶意内容造成的界面伪装。
 - Kernel 有一个连到恶意 NFS 服务器就可能造成内核内存损坏的问题，接不明网络存储空间的人要留意。
 - Contacts 修了三个问题，包含 app 未经授权新增联系人，以及处理恶意联系人数据造成的数据外泄。
@@ -58,7 +58,7 @@ Apple 同一天常常发好几条更新线，版本号差很多，内容也不�
 
 > 2026-06-29 · [上游公告](https://support.apple.com/en-us/127594){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>38 个修补里有 24 个在 WebKit、4 个在 WebRTC，整包几乎都是浏览器引擎。
+- <span class="urg-tag urg-tag--soon">尽快</span>38 个修补里有 24 个在 WebKit、4 个在 WebRTC，整包几乎都是浏览器引擎。Apple 没有标注任何一项已被实际利用。
 - 多个「恶意网站跨源窃取数据」与「处理恶意网页内容泄漏敏感用户信息」，这一类直接影响在浏览器里登录的服务。
 - 有一个恶意网站可以在沙盒外处理受限网页内容，沙盒是浏览器隔离网页的最后一道，破得掉就等于少一层防护。
 - 6 月 1 日另有 26.5.1，Apple 没有发布 CVE 清单，本页不另立条目。
@@ -67,7 +67,7 @@ Apple 同一天常常发好几条更新线，版本号差很多，内容也不�
 
 > 2026-05-11 · [26.5 公告](https://support.apple.com/en-us/127110){target="_blank"} · [18.7.9 公告](https://support.apple.com/en-us/127111){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>26.x 线补 67 个，WebKit 占 21 个、Kernel 占 6 个。Kernel 那组有一个 app 可能取得 root 权限（系统的最高控制权，取得之后等同设备的主人）。
+- <span class="urg-tag urg-tag--soon">尽快</span>26.x 线补 67 个，WebKit 占 21 个、Kernel 占 6 个。Kernel 那组有一个 app 可能取得 root 权限（系统的最高控制权，取得之后等同设备的主人）。Apple 没有标注任何一项已被实际利用。
 - 18.x 线补 49 个，另外修了三个值得注意的隐私问题：app 可能绕过 App 隐私报告的记录（那份报告本来就是拿来审查 app 在背后连了哪里）、app 可能列举设备上已安装的应用程序（可用来侧写用户身份）、Wi-Fi 组件有一个 app 可能以内核权限执行任意代码。
 - 同日发给更旧设备的 17.7.11、16.7.16、15.8.8 各只补一个问题，就是下面 4 月 22 日那个通知保留问题。
 
@@ -75,6 +75,6 @@ Apple 同一天常常发好几条更新线，版本号差很多，内容也不�
 
 > 2026-04-22 · [26.4.2 公告](https://support.apple.com/en-us/127002){target="_blank"} · [18.7.8 公告](https://support.apple.com/en-us/127003){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>隐私意涵值得知道。整个更新只修一个问题。
+- <span class="urg-tag urg-tag--routine">一般</span>隐私意涵值得知道。整个更新只修一个问题。Apple 没有标注任何一项已被实际利用。
 - CVE-2026-28950：标记为删除的通知，可能仍然被保留在设备上。原因是日志记录的问题，Apple 用改进的数据脱敏修好。以为划掉就消失的通知内容，实际上还留在设备里，对拿走设备的人可见。
 - 同一个修补到 17.x、16.x、15.x 这三条旧线是 5 月 11 日，晚了 19 天。旧机不只收到的修补比较少，时间也比较慢。

--- a/docs/zh-CN/changelog/macos.md
+++ b/docs/zh-CN/changelog/macos.md
@@ -38,7 +38,7 @@ Apple 同时维护最新版与前两代，安全修补三条线都发，但只�
 
 > 2026-08-17 · [上游公告](https://support.apple.com/en-us/148281){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>28 个修补，其中 19 个在 WebKit，多数是处理恶意网页内容造成的内存损坏或崩溃。
+- <span class="urg-tag urg-tag--soon">尽快</span>28 个修补，其中 19 个在 WebKit，多数是处理恶意网页内容造成的内存损坏或崩溃。Apple 没有标注任何一项已被实际利用。
 - ImageIO 有一个「处理图像可能导致任意代码执行」，这一类常被用在传一张图过去就能触发的攻击。
 - Kernel 有 3 个、IOGPUFamily 有 1 个。这一波只发给 Tahoe，Sequoia 与 Sonoma 没有对应版本。
 
@@ -46,7 +46,7 @@ Apple 同时维护最新版与前两代，安全修补三条线都发，但只�
 
 > 2026-08-06 · [26.6.1 公告](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9 公告](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9 公告](https://support.apple.com/en-us/148172){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>三条线同时发，各自只修一个问题。单一修补动用三条线，代表 Apple 认为不能等到下次排程。
+- <span class="urg-tag urg-tag--soon">尽快</span>三条线同时发，各自只修一个问题。单一修补动用三条线，代表 Apple 认为不能等到下次排程。Apple 没有标注任何一项已被实际利用。
 - CVE-2026-65400：同一网络上的攻击者可以在没有有效凭证的情况下通过屏幕共享（Screen Sharing）的验证。成因是验证流程的状态管理问题。
 - 有开启屏幕共享的人优先处理。系统设置里的「通用」、「共享」可以确认自己有没有开，平常用不到就关掉，那是最直接的处理方式。
 
@@ -54,7 +54,7 @@ Apple 同时维护最新版与前两代，安全修补三条线都发，但只�
 
 > 2026-07-27 · [26.6 公告](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8 公告](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8 公告](https://support.apple.com/en-us/128072){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>年度最大的一波，Tahoe 补 153 个、Sequoia 138 个、Sonoma 127 个。三条线的数量落差就是旧线收到的修补比较少的具体证据。
+- <span class="urg-tag urg-tag--soon">尽快</span>年度最大的一波，Tahoe 补 153 个、Sequoia 138 个、Sonoma 127 个。三条线的数量落差就是旧线收到的修补比较少的具体证据。Apple 没有标注任何一项已被实际利用。
 - Kernel 是重点，Tahoe 占 27 个、Sequoia 21 个、Sonoma 20 个。
 - Accounts 有一个 app 可能取得 root 权限。Assets 有一个恶意应用程序可以绕过隐私偏好，也就是不必经过你同意就取得原本要授权的权限。
 - AppleDouble 处理恶意文件时可能导致应用程序异常退出。Model I/O 与 HFS 各有多个文件解析类的问题，这一类的触发方式通常是打开一个别人给的文件。
@@ -63,14 +63,14 @@ Apple 同时维护最新版与前两代，安全修补三条线都发，但只�
 
 > 2026-06-29 · [上游公告](https://support.apple.com/en-us/127595){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>38 个修补里有 24 个在 WebKit、4 个在 WebRTC，整包几乎都是浏览器引擎。
+- <span class="urg-tag urg-tag--soon">尽快</span>38 个修补里有 24 个在 WebKit、4 个在 WebRTC，整包几乎都是浏览器引擎。Apple 没有标注任何一项已被实际利用。
 - 影响范围不只 Safari。系统上任何用 WebView 显示网页内容的 app 都走同一套引擎，包含邮件预览与许多聊天软件的内置浏览器。
 
 ## macOS Tahoe 26.5
 
 > 2026-05-11 · [上游公告](https://support.apple.com/en-us/127115){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>87 个修补，WebKit 占 22 个、Kernel 占 9 个。
+- <span class="urg-tag urg-tag--soon">尽快</span>87 个修补，WebKit 占 22 个、Kernel 占 9 个。Apple 没有标注任何一项已被实际利用。
 - CUPS 有一个 app 可能取得 root 权限。CUPS 是打印系统，平常不会想到它，而它默认就在运行。
 - BOM 有一个恶意的 ZIP 压缩文件可以绕过 Gatekeeper 检查。解压别人寄来的文件是很日常的动作，这条值得知道。
 - Accounts 有一个绕过部分隐私偏好的问题，mDNSResponder 有 4 个。

--- a/docs/zh-CN/changelog/onionshare.md
+++ b/docs/zh-CN/changelog/onionshare.md
@@ -23,14 +23,14 @@ OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2026-07-28 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>依赖包更新，涵盖内置的 tor、Python 包与网页端依赖。这一级是给已经装了 2.6.4 的人看的。
+- <span class="urg-tag urg-tag--routine">一般</span>依赖包更新，涵盖内置的 tor、Python 包与网页端依赖。这一级是给已经装了 2.6.4 的人看的。安全公告没有提到已被实际利用。
 - 没有新功能与行为变更。还停在 2.6.3 或更早的人请视同「尽快」，因为升上来会一并带进 2.6.4 的两个安全修补，直接装 2.6.5 即可。
 
 ## OnionShare 2.6.4
 
 > 2026-06-09 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>修补两个安全问题，影响 2.6.3 与更早的版本，桌面版与 `onionshare-cli` 都受影响，两者共用同一份 web 模块。
+- <span class="urg-tag urg-tag--soon">尽快</span>修补两个安全问题，影响 2.6.3 与更早的版本，桌面版与 `onionshare-cli` 都受影响，两者共用同一份 web 模块。安全公告没有提到已被实际利用。
 - CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式与网站模式会跟着文件夹里的符号链接（symlink）走，把链接指向的文件一并提供出去。分享的文件夹里若有他人放进来或来源不明的符号链接，获得 onion 地址的对方就能读到 OnionShare 进程权限范围内的其他本地文件。严重度评为中等，利用前提是对方要先有办法把符号链接放进你分享的文件夹。
 - CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾选「停用文件上传」之后，限制没有落实到实际写文件那一段。发出特制的 multipart 请求仍会把文件写进磁盘，路由处理只是不把它计入上传记录。设置成纯文本消息端点的服务因此可能被写入非预期的文件。同一版顺手修掉空的 POST 请求会创建空文件夹的问题。
 - 依赖包更新，包含内置的 tor 与 flatpak runtime。
@@ -40,7 +40,7 @@ OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2025-02-25 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式与网站模式可以看到哪些网址被访问过。
+- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式与网站模式可以看到哪些网址被访问过。这一版没有安全修补。
 - 保存下来的持久 onion 标签页，可在 OnionShare 启动并连上 Tor 之后自动开始服务。
 - 修好无法获取网桥、无法使用 meek 传输的问题，以及网桥查询没有返回结果时的致命错误。
 - 修好 CLI 关闭时线程竞争造成的 segfault，以及分享模式在有人访问过之后自动停止计时器失效的问题。
@@ -52,7 +52,7 @@ OnionShare 的发版节奏比 Tor Browser 与 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2024-03-21 · [上游发布页](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>全部是安全修补，集中在接收模式与聊天模式的输入处理。
+- <span class="urg-tag urg-tag--soon">尽快</span>全部是安全修补，集中在接收模式与聊天模式的输入处理。安全公告没有提到已被实际利用。
 - 历史记录项目的路径移除换行字符。
 - 接收模式的文本消息长度上限设为 524288 字符。
 - 用户名只允许特定 ASCII 字符并移除控制字符，另补上名称验证的异常处理，避免无声加入聊天室。

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -24,7 +24,7 @@ Tails 官方只区分紧急发布与排程发布，中间那一层是社群志�
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，同时带入 Linux 内核的安全更新。
+- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，同时带入 Linux 内核的安全更新。上游没有提到这些漏洞有实际攻击案例。
 - Tor Browser 升至 15.0.20（基于 Firefox ESR 140.14）。
 - 内核升至 6.12.101，涵盖 Debian 安全公告 DSA-6415-1 的 24 个漏洞，影响包含提权、拒绝服务与信息泄露。
 - 修正部分电脑上 Persistent Storage 无法解锁的问题。启用流程原本会等待 `udevadm settle`，无关的硬件问题会让这一步超时或失败，现已不再等待。
@@ -48,7 +48,7 @@ Tails 官方只区分紧急发布与排程发布，中间那一层是社群志�
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，带来新的关机流程与视频播放器。
+- <span class="urg-tag urg-tag--soon">尽快</span>例行排程版本，带来新的关机流程与视频播放器。上游没有提到这些漏洞有实际攻击案例。
 - 改用 GNOME 标准关机流程。关机前会提醒尚未保存的文档与开启中的应用程序，并在 60 秒后自动关机。速度略慢，换来更好的数据保护。紧急关机选项仍保留，供需要快速断电时使用。
 - 视频播放器改用 Celluloid，更现代也更可靠，且不具网络访问权限。要在线看视频请改用 Tor Browser，或额外安装 VLC。此播放器不支持 2011 年（含）以前制造的电脑。
 - Tor Browser 升至 15.0.19。
@@ -68,7 +68,7 @@ Tails 官方只区分紧急发布与排程发布，中间那一层是社群志�
 
 > 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非紧急安全发布。
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非紧急安全发布。上游没有提到这些漏洞有实际攻击案例。
 - Tor Browser 升至 15.0.16。
 - 更新部分 firmware 套件，改善较新硬件的支持，包含显卡、Wi-Fi 等。
 - 修正在 Secure Boot 证书已是最新的少数情境下，仍误跳「证书过期」通知的问题。
@@ -87,7 +87,7 @@ Tails 官方只区分紧急发布与排程发布，中间那一层是社群志�
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>Tor Browser 升至 15.0.14（基于 Firefox ESR 140.11）。
+- <span class="urg-tag urg-tag--soon">尽快</span>Tor Browser 升至 15.0.14（基于 Firefox ESR 140.11）。上游没有提到这些漏洞有实际攻击案例。
 - 修补 Linux 内核本地提权漏洞「Fragnesia」（同步缓解「Dirty Frag」）。此类漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。
 - 修补 Flatpak 通过 Yelp 逃逸沙箱的问题，yelp 升至 42.2-4tails1。
 - 修补 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
@@ -104,28 +104,28 @@ Tails 官方只区分紧急发布与排程发布，中间那一层是社群志�
 
 > 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻译文章](../blog/posts/2026-tails-7-6.md)
 
-- <span class="urg-tag urg-tag--routine">一般</span>自动 Tor 桥接（依用户区域获取）、GNOME Secrets 取代 KeePassXC 作为内置密码管理器、例行组件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
+- <span class="urg-tag urg-tag--routine">一般</span>自动 Tor 桥接（依用户区域获取）、GNOME Secrets 取代 KeePassXC 作为内置密码管理器、例行组件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。上游没有提到这些漏洞有实际攻击案例。
 
 ## Tails 7.1
 
 > 2025-10-15 · [上游公告](https://tails.net/news/version_7.1/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-1-released.md)
 
-- <span class="urg-tag urg-tag--routine">一般</span>Tor Browser 首页改为离线版本（移除启动时的 metadata 泄露）、Snowflake 桥接更新方式翻新、例行组件更新（Tor Browser 14.5.8、Tor 客户端 0.4.8.19、Thunderbird 140.3.0）。
+- <span class="urg-tag urg-tag--routine">一般</span>Tor Browser 首页改为离线版本（移除启动时的 metadata 泄露）、Snowflake 桥接更新方式翻新、例行组件更新（Tor Browser 14.5.8、Tor 客户端 0.4.8.19、Thunderbird 140.3.0）。上游没有提到这些漏洞有实际攻击案例。
 
 ## Tails 7.0
 
 > 2025-09-20 · [上游公告](https://tails.net/news/version_7.0/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-released.md)
 
-- <span class="urg-tag urg-tag--routine">一般</span>首个以 Debian 13（Trixie）与 GNOME 48（Bengaluru）为基底的大版本，桌面与系统组件全面升级。
+- <span class="urg-tag urg-tag--routine">一般</span>首个以 Debian 13（Trixie）与 GNOME 48（Bengaluru）为基底的大版本，桌面与系统组件全面升级。上游没有提到这些漏洞有实际攻击案例。
 
 ## Tails 7.0~rc2
 
 > 2025-08-29 · [上游公告](https://tails.net/news/test_7.0-rc2/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-rc.md)
 
-- <span class="chan-tag chan-tag--alpha">RC 测试版</span>Tails 7.0 第二个发行候选版（RC2），开放社群协助测试 Debian 13 与 GNOME 48 新基底、自动升级流程、持久存储迁移。
+- <span class="chan-tag chan-tag--alpha">RC 测试版</span>Tails 7.0 第二个发行候选版（RC2），开放社群协助测试 Debian 13 与 GNOME 48 新基底、自动升级流程、持久存储迁移。上游没有提到这些漏洞有实际攻击案例。
 
 ## Tails 6.18
 
 > 2025-07-31 · [上游公告](https://tails.net/news/version_6.18/){target="_blank"} · [完整翻译文章](../blog/posts/tails-6-18-webtunnel.md)
 
-- <span class="urg-tag urg-tag--routine">一般</span>新增 WebTunnel 桥接协议支持，把 Tor 流量伪装成 HTTPS，对无法直接连入 Tor 的网络环境多一条进入路径。
+- <span class="urg-tag urg-tag--routine">一般</span>新增 WebTunnel 桥接协议支持，把 Tor 流量伪装成 HTTPS，对无法直接连入 Tor 的网络环境多一条进入路径。上游没有提到这些漏洞有实际攻击案例。

--- a/docs/zh-CN/changelog/tor-daemon.md
+++ b/docs/zh-CN/changelog/tor-daemon.md
@@ -32,7 +32,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>距离上一版只隔两天的安全发布，官方说明是又发现高优先级的问题，其中一个影响 onion 服务。
+- <span class="urg-tag urg-tag--now">立刻</span>距离上一版只隔两天的安全发布，官方说明是又发现高优先级的问题，其中一个影响 onion 服务。上游没有提到已被实际利用。
 - 修掉一个竞态条件：在特定情况下，会合点（rendezvous point）可以冒充客户端想连的那个 onion 服务，形成中间人。架设 onion 服务的人这一版务必要升（bug 41297，问题从 0.3.5.3-alpha 就存在）。
 - 客户端遇到 onion 服务把某个引介点的公钥编成全零时，不再直接中止退出（bug 41295）。
 - 目录权威不再接受出口策略里把端口写成 0 的写法。原本的次要检查误把 `0` 解析成 `1-0` 这个端口范围，生成 networkstatus 投票时会触发 assert。
@@ -41,7 +41,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全发布，官方强烈建议尽快升级。
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，官方强烈建议尽快升级。上游没有提到已被实际利用。
 - TROVE-2026-025：拒绝在已经有附挂流的电路上收到的 `CONFLUX_LINK` 信元。恶意客户端可以先发 `RELAY_COMMAND_BEGIN` 再发 `CONFLUX_LINK`，挂上的出口流最后会变成孤儿，留下悬空的电路反向指针，电路被释放时形成 use-after-free，也就是内存还回去之后又被拿来用，结果是中继当掉（bug 41258）。
 - 未设置 `SafeSocks` 时，恢复对不安全 SOCKS 协议（socks4 或不带主机名的 socks5）的警告。这个警告消失了很久，而它防的是把要解析的域名直接泄漏给本机以外的地方（bug 41290）。
 - 客户端的入口守卫（entry guard）过期时间回到一致的 48 到 60 天。
@@ -50,7 +50,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全发布，一次修掉三个主要问题。
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，一次修掉三个主要问题。上游没有提到已被实际利用。
 - TROVE-2026-022：压缩炸弹检查可以被绕过。攻击者把多个 gzip 或 zlib 子流接在一起，每一段都刚好低于单流的检测门槛，整体就闪过了检查（bug 41275，问题从 0.3.1.1-alpha 就存在）。
 - TROVE-2026-021：解压被截断的 zlib/gzip 流时陷入无穷循环。截断的流永远到不了 `Z_STREAM_END`，zlib 返回的 `Z_BUF_ERROR` 被误判成输出缓冲区满了，于是无限重试（bug 41274）。
 - TROVE-2026-017：发出 `CONFLUX_SWITCH` 信元失败时的 NULL write after free。发送失败会关闭电路并移除该条腿，但返回值被忽略，调用端接着往已经释放的内存写入而崩溃（bug 41263）。
@@ -59,7 +59,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">尽快</span>前一版发出后的紧急补发，起因是 CI 构建过程的一个无声错误，把备援目录（fallback directory）清单整份清空了。
+- <span class="urg-tag urg-tag--soon">尽快</span>前一版发出后的紧急补发，起因是 CI 构建过程的一个无声错误，把备援目录（fallback directory）清单整份清空了。这一版没有安全问题，也就没有利用与否的问题。
 - 影响的是新安装的客户端：没有备援目录可用时，只能直接对目录权威做 bootstrap，那几台机器的负载与可观测性都因此变差。
 - 重新生成 2026 年 5 月 7 日版本的备援目录清单。
 
@@ -67,7 +67,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两条维护线同时发布。
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两条维护线同时发布。上游没有提到已被实际利用。
 - TROVE-2026-011：处理 END、TRUNCATE 与 TRUNCATED 信元时，若载荷里没有原因字段会发生越界读取，也就是读到不该读的内存，可能让中继当掉或泄漏内存内容。这个问题从 0.1.1.1-alpha 存在到现在（bug 41254）。
 - TROVE-2026-008：不再通过 conflux 的分腿尝试或接受 `BEGIN_DIR`（bug 41243）。
 - TROVE-2026-010：清空 conflux 的乱序队列时修正计数（bug 41251）。
@@ -76,7 +76,7 @@ tor daemon（社群惯称 c-tor）是 [Tor](../tools/what-is-tor.md) 网络的 C
 
 > 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两个问题都可能让中继被远程弄崩。
+- <span class="urg-tag urg-tag--now">立刻</span>安全发布，两个问题都可能让中继被远程弄崩。上游没有提到已被实际利用。
 - TROVE-2026-003：恶意的 `CREATED2` 造成 11 个字节的栈溢出，结果是远程崩溃（bug 41231）。
 - TROVE-2026-004：conflux 子系统的内存比对用错长度，同样可能导致远程崩溃（bug 41232）。
 - 另外修了一批纵深防御性质的问题，以及 big-endian 平台上的 polyval 实现。

--- a/docs/zh-TW/changelog/ios.md
+++ b/docs/zh-TW/changelog/ios.md
@@ -49,7 +49,7 @@ Apple 同一天常常發好幾條更新線，版本號差很多，內容也不�
 
 > 2026-07-27 · [上游公告](https://support.apple.com/en-us/128066){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>86 個修補，Kernel 佔 19 個、WebKit 佔 7 個、ImageIO 佔 6 個。
+- <span class="urg-tag urg-tag--soon">儘快</span>86 個修補，Kernel 佔 19 個、WebKit 佔 7 個、ImageIO 佔 6 個。Apple 沒有標注任何一項已被實際利用。
 - WebKit 修掉一個瀏覽紀錄外洩：網站有辦法知道你是否造訪過某個連結。同一組還修了惡意內容違反 iframe 沙箱政策（沙箱是把嵌入的網頁關在隔離環境裡，破得掉就能碰到不該碰的東西），以及網頁內嵌惡意內容造成的介面偽裝。
 - Kernel 有一個連到惡意 NFS 伺服器就可能造成核心記憶體損毀的問題，接不明網路儲存空間的人要留意。
 - Contacts 修了三個問題，包含 app 未經授權新增聯絡人，以及處理惡意聯絡人資料造成的資料外洩。
@@ -58,7 +58,7 @@ Apple 同一天常常發好幾條更新線，版本號差很多，內容也不�
 
 > 2026-06-29 · [上游公告](https://support.apple.com/en-us/127594){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>38 個修補裡有 24 個在 WebKit、4 個在 WebRTC，整包幾乎都是瀏覽器引擎。
+- <span class="urg-tag urg-tag--soon">儘快</span>38 個修補裡有 24 個在 WebKit、4 個在 WebRTC，整包幾乎都是瀏覽器引擎。Apple 沒有標注任何一項已被實際利用。
 - 多個「惡意網站跨來源竊取資料」與「處理惡意網頁內容洩漏敏感使用者資訊」，這一類直接影響在瀏覽器裡登入的服務。
 - 有一個惡意網站可以在沙箱外處理受限網頁內容，沙箱是瀏覽器隔離網頁的最後一道，破得掉就等於少一層防護。
 - 6 月 1 日另有 26.5.1，Apple 沒有發布 CVE 清單，本頁不另立條目。
@@ -67,7 +67,7 @@ Apple 同一天常常發好幾條更新線，版本號差很多，內容也不�
 
 > 2026-05-11 · [26.5 公告](https://support.apple.com/en-us/127110){target="_blank"} · [18.7.9 公告](https://support.apple.com/en-us/127111){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>26.x 線補 67 個，WebKit 佔 21 個、Kernel 佔 6 個。Kernel 那組有一個 app 可能取得 root 權限（系統的最高控制權，取得之後等同裝置的主人）。
+- <span class="urg-tag urg-tag--soon">儘快</span>26.x 線補 67 個，WebKit 佔 21 個、Kernel 佔 6 個。Kernel 那組有一個 app 可能取得 root 權限（系統的最高控制權，取得之後等同裝置的主人）。Apple 沒有標注任何一項已被實際利用。
 - 18.x 線補 49 個，另外修了三個值得注意的隱私問題：app 可能繞過 App 隱私報告的記錄（那份報告本來就是拿來稽核 app 在背後連了哪裡）、app 可能列舉裝置上已安裝的應用程式（可用來側寫使用者身分）、Wi-Fi 元件有一個 app 可能以核心權限執行任意程式碼。
 - 同日發給更舊裝置的 17.7.11、16.7.16、15.8.8 各只補一個問題，就是下面 4 月 22 日那個通知保留問題。
 
@@ -75,6 +75,6 @@ Apple 同一天常常發好幾條更新線，版本號差很多，內容也不�
 
 > 2026-04-22 · [26.4.2 公告](https://support.apple.com/en-us/127002){target="_blank"} · [18.7.8 公告](https://support.apple.com/en-us/127003){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>隱私意涵值得知道。整個更新只修一個問題。
+- <span class="urg-tag urg-tag--routine">一般</span>隱私意涵值得知道。整個更新只修一個問題。Apple 沒有標注這一項已被實際利用。
 - CVE-2026-28950：標記為刪除的通知，可能仍然被保留在裝置上。原因是日誌記錄的問題，Apple 用改進的資料遮蔽修好。以為滑掉就消失的通知內容，實際上還留在裝置裡，對取得裝置的人可見。
 - 同一個修補到 17.x、16.x、15.x 這三條舊線是 5 月 11 日，晚了 19 天。舊機不只收到的修補比較少，時間也比較慢。

--- a/docs/zh-TW/changelog/macos.md
+++ b/docs/zh-TW/changelog/macos.md
@@ -38,7 +38,7 @@ Apple 同時維護最新版與前兩代，安全修補三條線都發，但只�
 
 > 2026-08-17 · [上游公告](https://support.apple.com/en-us/148281){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>28 個修補，其中 19 個在 WebKit，多數是處理惡意網頁內容造成的記憶體損毀或崩潰。
+- <span class="urg-tag urg-tag--soon">儘快</span>28 個修補，其中 19 個在 WebKit，多數是處理惡意網頁內容造成的記憶體損毀或崩潰。Apple 沒有標注任何一項已被實際利用。
 - ImageIO 有一個「處理影像可能導致任意程式碼執行」，這一類常被用在傳一張圖過去就能觸發的攻擊。
 - Kernel 有 3 個、IOGPUFamily 有 1 個。這一波只發給 Tahoe，Sequoia 與 Sonoma 沒有對應版本。
 
@@ -46,7 +46,7 @@ Apple 同時維護最新版與前兩代，安全修補三條線都發，但只�
 
 > 2026-08-06 · [26.6.1 公告](https://support.apple.com/en-us/148170){target="_blank"} · [15.7.9 公告](https://support.apple.com/en-us/148171){target="_blank"} · [14.8.9 公告](https://support.apple.com/en-us/148172){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>三條線同時發，各自只修一個問題。單一修補動用三條線，代表 Apple 認為不能等到下次排程。
+- <span class="urg-tag urg-tag--soon">儘快</span>三條線同時發，各自只修一個問題。單一修補動用三條線，代表 Apple 認為不能等到下次排程。Apple 沒有標注這一項已被實際利用，不過驗證被繞過本身就等於門沒鎖。
 - CVE-2026-65400：同一網路上的攻擊者可以在沒有有效憑證的情況下通過螢幕共享（Screen Sharing）的驗證。成因是驗證流程的狀態管理問題。
 - 有開啟螢幕共享的人優先處理。系統設定裡的「一般」、「共享」可以確認自己有沒有開，平常用不到就關掉，那是最直接的處理方式。
 
@@ -54,7 +54,7 @@ Apple 同時維護最新版與前兩代，安全修補三條線都發，但只�
 
 > 2026-07-27 · [26.6 公告](https://support.apple.com/en-us/128067){target="_blank"} · [15.7.8 公告](https://support.apple.com/en-us/128071){target="_blank"} · [14.8.8 公告](https://support.apple.com/en-us/128072){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>年度最大的一波，Tahoe 補 153 個、Sequoia 138 個、Sonoma 127 個。三條線的數量落差就是舊線收到的修補比較少的具體證據。
+- <span class="urg-tag urg-tag--soon">儘快</span>年度最大的一波，Tahoe 補 153 個、Sequoia 138 個、Sonoma 127 個。三條線的數量落差就是舊線收到的修補比較少的具體證據。Apple 沒有標注任何一項已被實際利用。
 - Kernel 是重點，Tahoe 佔 27 個、Sequoia 21 個、Sonoma 20 個。
 - Accounts 有一個 app 可能取得 root 權限。Assets 有一個惡意應用程式可以繞過隱私偏好，也就是不必經過你同意就取得原本要授權的權限。
 - AppleDouble 處理惡意檔案時可能導致應用程式異常結束。Model I/O 與 HFS 各有多個檔案解析類的問題，這一類的觸發方式通常是打開一個別人給的檔案。
@@ -63,14 +63,14 @@ Apple 同時維護最新版與前兩代，安全修補三條線都發，但只�
 
 > 2026-06-29 · [上游公告](https://support.apple.com/en-us/127595){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>38 個修補裡有 24 個在 WebKit、4 個在 WebRTC，整包幾乎都是瀏覽器引擎。
+- <span class="urg-tag urg-tag--soon">儘快</span>38 個修補裡有 24 個在 WebKit、4 個在 WebRTC，整包幾乎都是瀏覽器引擎。Apple 沒有標注任何一項已被實際利用。
 - 影響範圍不只 Safari。系統上任何用 WebView 顯示網頁內容的 app 都走同一套引擎，包含郵件預覽與許多聊天軟體的內建瀏覽器。
 
 ## macOS Tahoe 26.5
 
 > 2026-05-11 · [上游公告](https://support.apple.com/en-us/127115){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>87 個修補，WebKit 佔 22 個、Kernel 佔 9 個。
+- <span class="urg-tag urg-tag--soon">儘快</span>87 個修補，WebKit 佔 22 個、Kernel 佔 9 個。Apple 沒有標注任何一項已被實際利用。
 - CUPS 有一個 app 可能取得 root 權限。CUPS 是列印系統，平常不會想到它，而它預設就在執行。
 - BOM 有一個惡意的 ZIP 壓縮檔可以繞過 Gatekeeper 檢查。解壓縮別人寄來的檔案是很日常的動作，這條值得知道。
 - Accounts 有一個繞過部分隱私偏好的問題，mDNSResponder 有 4 個。

--- a/docs/zh-TW/changelog/onionshare.md
+++ b/docs/zh-TW/changelog/onionshare.md
@@ -23,14 +23,14 @@ OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2026-07-28 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.5){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>相依套件更新，涵蓋內建的 tor、Python 套件與網頁端相依。這一級是給已經裝了 2.6.4 的人看的。
+- <span class="urg-tag urg-tag--routine">一般</span>相依套件更新，涵蓋內建的 tor、Python 套件與網頁端相依。這一級是給已經裝了 2.6.4 的人看的，這一版本身沒有安全修補。
 - 沒有新功能與行為變更。還停在 2.6.3 或更早的人請視同「儘快」，因為升上來會一併帶進 2.6.4 的兩個安全修補，直接裝 2.6.5 即可。
 
 ## OnionShare 2.6.4
 
 > 2026-06-09 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.4){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>修補兩個安全問題，影響 2.6.3 與更早的版本，桌面版與 `onionshare-cli` 都受影響，兩者共用同一份 web 模組。
+- <span class="urg-tag urg-tag--soon">儘快</span>修補兩個安全問題，影響 2.6.3 與更早的版本，桌面版與 `onionshare-cli` 都受影響，兩者共用同一份 web 模組。兩則安全公告都沒有提到已被實際利用。
 - CVE-2026-54706（[GHSA-22p9-r2f5-22mf](https://github.com/onionshare/onionshare/security/advisories/GHSA-22p9-r2f5-22mf){target="_blank"}）：分享模式與網站模式會跟著資料夾裡的符號連結（symlink）走，把連結指向的檔案一併提供出去。分享的資料夾裡若有他人放進來或來源不明的符號連結，取得 onion 網址的對方就能讀到 OnionShare 行程權限範圍內的其他本機檔案。嚴重度評為中等，利用前提是對方要先有辦法把符號連結放進你分享的資料夾。
 - CVE-2026-54707（[GHSA-v833-3823-cmhp](https://github.com/onionshare/onionshare/security/advisories/GHSA-v833-3823-cmhp){target="_blank"}）：接收模式勾選「停用檔案上傳」之後，限制沒有落實到實際寫檔那一段。送出特製的 multipart 請求仍會把檔案寫進磁碟，路由處理只是不把它計入上傳紀錄。設定成純文字訊息端點的服務因此可能被寫入非預期的檔案。同一版順手修掉空的 POST 請求會建立空資料夾的問題。
 - 相依套件更新，包含內建的 tor 與 flatpak runtime。
@@ -40,7 +40,7 @@ OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2025-02-25 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.3){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式與網站模式可以看到哪些網址被造訪過。
+- <span class="urg-tag urg-tag--routine">一般</span>CLI 新增 `--log-filenames`，分享模式與網站模式可以看到哪些網址被造訪過。這一版沒有安全修補。
 - 儲存下來的持續性 onion 分頁，可在 OnionShare 啟動並連上 Tor 之後自動開始服務。
 - 修好無法取得橋接、無法使用 meek 傳輸的問題，以及橋接查詢沒有回傳結果時的致命錯誤。
 - 修好 CLI 關閉時執行緒競爭造成的 segfault，以及分享模式在有人造訪過之後自動停止計時器失效的問題。
@@ -52,7 +52,7 @@ OnionShare 的發版節奏比 Tor Browser 與 Tails 慢很多，2.6.3 到 2.6.4 
 
 > 2024-03-21 · [上游發布頁](https://github.com/onionshare/onionshare/releases/tag/v2.6.2){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>全部是安全修補，集中在接收模式與聊天模式的輸入處理。
+- <span class="urg-tag urg-tag--soon">儘快</span>全部是安全修補，集中在接收模式與聊天模式的輸入處理。上游沒有提到這些問題已被實際利用。
 - 歷史紀錄項目的路徑移除換行字元。
 - 接收模式的文字訊息長度上限設為 524288 字元。
 - 使用者名稱只允許特定 ASCII 字元並移除控制字元，另補上名稱驗證的例外處理，避免無聲加入聊天室。

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -24,7 +24,7 @@ Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志�
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，同時帶入 Linux 核心的安全更新。
+- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，同時帶入 Linux 核心的安全更新。上游沒有提到這些漏洞有實際攻擊案例。
 - Tor Browser 升至 15.0.20（基於 Firefox ESR 140.14）。
 - 核心升至 6.12.101，涵蓋 Debian 安全公告 DSA-6415-1 的 24 個漏洞，影響包含提權、阻斷服務與資訊外洩。
 - 修正部分電腦上 Persistent Storage 無法解鎖的問題。啟用流程原本會等待 `udevadm settle`，無關的硬體問題會讓這一步逾時或失敗，現已不再等待。
@@ -48,7 +48,7 @@ Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志�
 
 > 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，帶來新的關機流程與影片播放器。
+- <span class="urg-tag urg-tag--soon">儘快</span>例行排程版本，帶來新的關機流程與影片播放器。上游沒有提到這些變更牽涉實際攻擊案例。
 - 改用 GNOME 標準關機流程。關機前會提醒尚未儲存的文件與開啟中的應用程式，並在 60 秒後自動關機。速度略慢，換來更好的資料保護。緊急關機選項仍保留，供需要快速斷電時使用。
 - 影片播放器改用 Celluloid，更現代也更可靠，且不具網路存取權限。要線上看影片請改用 Tor Browser，或額外安裝 VLC。此播放器不支援 2011 年（含）以前製造的電腦。
 - Tor Browser 升至 15.0.19。
@@ -69,7 +69,7 @@ Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志�
 
 > 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
 
-- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非緊急安全釋出。
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非緊急安全釋出。上游沒有提到有實際攻擊案例，這一版本身也不是安全釋出。
 - Tor Browser 升至 15.0.16。
 - 更新部分 firmware 套件，改善較新硬體的支援，包含顯示卡、Wi-Fi 等。
 - 修正在 Secure Boot 憑證已是最新的少數情境下，仍誤跳「憑證過期」通知的問題。
@@ -88,7 +88,7 @@ Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志�
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>Tor Browser 升至 15.0.14（基於 Firefox ESR 140.11）。
+- <span class="urg-tag urg-tag--soon">儘快</span>Tor Browser 升至 15.0.14（基於 Firefox ESR 140.11）。上游沒有提到這些漏洞有實際攻擊案例。
 - 修補 Linux 核心本機提權漏洞「Fragnesia」（同步緩解「Dirty Frag」）。此類漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。
 - 修補 Flatpak 透過 Yelp 逃逸沙箱的問題，yelp 升至 42.2-4tails1。
 - 修補 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
@@ -118,7 +118,7 @@ Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志�
 
 > 2026-04-30 · [上游公告](https://tails.net/news/version_7.7.1/){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Tor Browser 多個漏洞。
+- <span class="urg-tag urg-tag--now">立刻</span>緊急安全更新，修補 Tor Browser 多個漏洞。上游明說目前尚未發現這些漏洞被實際利用。
 - Tor Browser 升至 15.0.11，修補 Firefox 140.10.1 多個漏洞。
 - Thunderbird 升至 140.10.0。
 - 停止支援以 ISO 映像從 USB 隨身碟開機，ISO 映像僅供 DVD 與虛擬機使用，USB 隨身碟請改用 USB image（自 2019 年起為推薦做法）。

--- a/docs/zh-TW/changelog/tor-daemon.md
+++ b/docs/zh-TW/changelog/tor-daemon.md
@@ -32,7 +32,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-06-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.11/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>距離上一版只隔兩天的安全釋出，官方說明是又發現高優先級的問題，其中一個影響 onion 服務。
+- <span class="urg-tag urg-tag--now">立刻</span>距離上一版只隔兩天的安全釋出，官方說明是又發現高優先級的問題，其中一個影響 onion 服務。上游沒有提到已被實際利用，不過 onion 服務是長期在線的目標。
 - 修掉一個競態條件：在特定情況下，會合點（rendezvous point）可以冒充用戶端想連的那個 onion 服務，形成中間人。架設 onion 服務的人這一版務必要升（bug 41297，問題從 0.3.5.3-alpha 就存在）。
 - 用戶端遇到 onion 服務把某個引介點的公鑰編成全零時，不再直接中止結束（bug 41295）。
 - 目錄權威不再接受離開政策裡把埠寫成 0 的寫法。原本的次要檢查誤把 `0` 解析成 `1-0` 這個埠範圍，產生 networkstatus 投票時會觸發 assert。
@@ -41,7 +41,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-06-23 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.10/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，官方強烈建議盡快升級。
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，官方強烈建議盡快升級。上游沒有提到已被實際利用。
 - TROVE-2026-025：拒絕在已經有附掛串流的電路上收到的 `CONFLUX_LINK` 資料元。惡意用戶端可以先送 `RELAY_COMMAND_BEGIN` 再送 `CONFLUX_LINK`，掛上的離開串流最後會變成孤兒，留下懸空的電路反向指標，電路被釋放時形成 use-after-free，也就是記憶體還回去之後又被拿來用，結果是中繼當掉（bug 41258）。
 - 未設定 `SafeSocks` 時，恢復對不安全 SOCKS 協定（socks4 或不帶主機名的 socks5）的警告。這個警告消失了很久，而它防的是把要解析的網域直接洩漏給本機以外的地方（bug 41290）。
 - 用戶端的入口守衛（entry guard）過期時間回到一致的 48 到 60 天。
@@ -50,7 +50,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-06-01 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，一次修掉三個主要問題。
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，一次修掉三個主要問題。上游沒有提到已被實際利用。
 - TROVE-2026-022：壓縮炸彈檢查可以被繞過。攻擊者把多個 gzip 或 zlib 子串流接在一起，每一段都剛好低於單串流的偵測門檻，整體就閃過了檢查（bug 41275，問題從 0.3.1.1-alpha 就存在）。
 - TROVE-2026-021：解壓被截斷的 zlib/gzip 串流時陷入無窮迴圈。截斷的串流永遠到不了 `Z_STREAM_END`，zlib 回傳的 `Z_BUF_ERROR` 被誤判成輸出緩衝區滿了，於是無限重試（bug 41274）。
 - TROVE-2026-017：送出 `CONFLUX_SWITCH` 資料元失敗時的 NULL write after free。送出失敗會關閉電路並移除該條腿，但回傳值被忽略，呼叫端接著往已經釋放的記憶體寫入而崩潰（bug 41263）。
@@ -59,7 +59,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-05-07 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.8/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--soon">儘快</span>前一版發出後的緊急補發，起因是 CI 建置過程的一個無聲錯誤，把備援目錄（fallback directory）清單整份清空了。
+- <span class="urg-tag urg-tag--soon">儘快</span>前一版發出後的緊急補發，起因是 CI 建置過程的一個無聲錯誤，把備援目錄（fallback directory）清單整份清空了。這一版沒有安全問題，也就沒有利用與否的問題。
 - 影響的是新安裝的用戶端：沒有備援目錄可用時，只能直接對目錄權威做 bootstrap，那幾台機器的負載與可觀測性都因此變差。
 - 重新產生 2026 年 5 月 7 日版本的備援目錄清單。
 
@@ -67,7 +67,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-05-06 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.7/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩條維護線同時發布。
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩條維護線同時發布。上游沒有提到已被實際利用。
 - TROVE-2026-011：處理 END、TRUNCATE 與 TRUNCATED 資料元時，若酬載裡沒有原因欄位會發生越界讀取，也就是讀到不該讀的記憶體，可能讓中繼當掉或洩漏記憶體內容。這個問題從 0.1.1.1-alpha 存在到現在（bug 41254）。
 - TROVE-2026-008：不再透過 conflux 的分腿嘗試或接受 `BEGIN_DIR`（bug 41243）。
 - TROVE-2026-010：清空 conflux 的亂序佇列時修正計數（bug 41251）。
@@ -76,7 +76,7 @@ tor daemon（社群慣稱 c-tor）是 [Tor](../tools/what-is-tor.md) 網路的 C
 
 > 2026-03-25 · [ChangeLog](https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.6/ChangeLog){target="_blank"}
 
-- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩個問題都可能讓中繼被遠端弄崩。
+- <span class="urg-tag urg-tag--now">立刻</span>安全釋出，兩個問題都可能讓中繼被遠端弄崩。上游沒有提到已被實際利用。
 - TROVE-2026-003：惡意的 `CREATED2` 造成 11 個位元組的堆疊溢位，結果是遠端崩潰（bug 41231）。
 - TROVE-2026-004：conflux 子系統的記憶體比對用錯長度，同樣可能導致遠端崩潰（bug 41232）。
 - 另外修了一批深度防禦性質的問題，以及 big-endian 平台上的 polyval 實作。


### PR DESCRIPTION
## 補完 #406 沒做完的那一半

#406 把「該多快處理」與「有沒有人已經在利用」拆成兩個維度講，但只有 Windows 那頁的條目真的每則都寫了。盤點六頁 36 則，**25 則沒寫**，讀者看到顏色卻不知道那是「後果嚴重但還沒人動手」還是「已經有人在打」。

| 頁面 | 條目數 | 原本已寫 | 這次補 |
|---|---|---|---|
| ios | 5 | 1 | 4 |
| macos | 5 | 0 | 5 |
| windows | 5 | 5 | 0 |
| tails | 10 | 5 | 5 |
| tor-daemon | 6 | 0 | 6 |
| onionshare | 4 | 0 | 4 |

## 措辭區分三種確定性

不同來源給的資訊強度不同，寫法就該不同，含糊帶過會誤導：

- **上游有標注機制、這次沒標**：「Apple 沒有標注任何一項已被實際利用」
- **上游明說沒有**：「上游明說目前尚未發現這些漏洞被實際利用」（Tails 7.7.1 的公告原文就是 "We are not aware of these vulnerabilities being exploited in practice until now"）
- **上游根本沒提**：「上游沒有提到已被實際利用」（tor daemon 六則都是這種，ChangeLog 從頭到尾沒有一處談利用狀態）

沒有安全修補的版本另外處理。tor 0.4.9.8 與 OnionShare 2.6.3、2.6.5 寫的是「這一版沒有安全問題，也就沒有利用與否的問題」，避免用否定句誤導成「查過沒有人在利用」。

## 依據

逐一查過，沒有一句是憑印象寫的：

- Apple：十四份 iOS 與 macOS 公告的 `actively exploited` 標注，全部無
- Tails：五份公告原文，7.11／7.10／7.9／7.8 沒有提到，7.7.1 明說尚未發現
- tor：各版 ChangeLog 的 exploit 字樣，0.4.9.6 到 0.4.9.11 全部無
- OnionShare：兩則 GHSA advisory，無

## 呈現位置

句子接在帶標籤那一行的句尾，顏色與利用狀態同一行，三十秒讀者掃過去就看得完，不必往下找。

過程中修掉一個自己造成的問題：Tails 的 7.10.1、7.9.1、7.8.1 原本在後面的 bullet 就寫了「目前尚未發現實際被利用案例」，第一次補的時候在開頭又加一句同義的，讀起來冗贅，已經移除。

## 驗證

- `docs_style_lint.py` 掃三語系 39 個檔案，0 error 0 warn
- 三語系建置皆通過
- 逐則複驗：zh-TW 35 則、zh-CN 37 則、en 33 則，全部涵蓋

🤖 Generated with [Claude Code](https://claude.com/claude-code)