### PR TITLE
feat(changelog): Arti 補上 2.6.0 與中繼端的官方進度清單

### DIFF
--- a/docs/en/changelog/arti.md
+++ b/docs/en/changelog/arti.md
@@ -21,15 +21,47 @@ Arti is the Tor Project's effort, started in 2021, to rewrite the original C imp
 | Hosting onion services (service side, incl. full vanguards, restricted discovery, client auth) | ✅ Done | since 1.2.0 (2024-03) |
 | RPC control interface (replaces c-tor's control port) | ✅ Done, now stable | 1.4.2 (2025-03) |
 | HTTP CONNECT proxy | ✅ Done, enabled by default | 2.2.0 (2026-03) |
-| Flow control and congestion control (`flowctl-cc`, paving the way for conflux) | ✅ Done, now stable | 2.4.0 (2026-06) |
+| Flow control and congestion control | ✅ Always on since 2.6.0; the `flowctl-cc` flag is gone | Stable in 2.4.0, on by default in 2.6.0 (2026-09) |
+| Counter Galois Onion cryptography (CGO) | ✅ Always on since 2.6.0 | 2.6.0 (2026-09) |
 | Embedding from non-Rust languages (C FFI) | 🟡 RPC client already has a C-friendly interface; full FFI planned | In progress |
-| Relay: circuit reactor, relay channels, handshake responses, TLS server side | 🟡 In development, not usable yet | since 2.0.0 (2026-02) |
-| Directory authority: certificate management, directory cache | 🟡 In development, not usable yet | since 2.0.0 (2026-02) |
+| Relay | 🟡 In development; upstream says explicitly not to point it at the public network | 2.0.0 (2026-02) through 2.6.0 |
+| Directory authority | 🟡 In development; document parsing and microdescriptor generation have early shape | 2.0.0 (2026-02) through 2.6.0 |
 | control-port protocol compatibility | ⬜ Not reimplemented; replaced by RPC | — |
 
 Legend: ✅ Done　🟡 In development　⬜ Not implemented
 
 On the client side, Arti's capabilities are now largely on par with c-tor: it works as a SOCKS proxy, connects to and hosts onion services, and runs over bridges and pluggable transports. The project's current focus is the relay side. Relay and directory authority support are still under development, so you cannot yet run a Tor relay with Arti, which still requires c-tor. Arti replaces c-tor's control port with the RPC interface, a different design approach.
+
+## How far the relay side has got
+
+2.6.0 ships a [`README_relay.md`](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/README_relay.md){target="_blank"} listing what relay and directory authority support still needs, with completion marked. It is the closest thing to an official roadmap right now, and its opening line is not to run `arti-relay` on the public Tor network.
+
+Per that list, as of August 2026:
+
+| Area | Done | To do |
+|---|---|---|
+| Basic operations (channels, circuits, CREATE2, EXTEND2, ORPort) | 9 | 8 |
+| Exit support (DNS, BEGIN, RESOLVE, exit policies) | 0 | 5 |
+| Directory cache | 0 | 13 |
+| Self-testing (ORPort reachability, bandwidth, DNS) | 0 | 3 |
+| Onion service support (HsDir, introduction, rendezvous) | 0 | 3 |
+| Security features (offline identity keys, memory and socket DoS defences) | 0 | 4 |
+| Performance features (buffer tuning, circuit scheduling, conflux) | 0 | 5 |
+| Directory authority | 0 | 28 |
+
+The nine finished items sit at the lowest layer: accepting incoming channels, bidirectional channel authentication, processing and delivering relay cells, CREATE2 and CREATE\_FAST, EXTEND2, and listening on ORPort. Circuits can be built, in other words, but almost everything else a relay needs to actually go live is untouched, including key generation and rotation, publishing router descriptors, and bandwidth caps.
+
+The list notes that the team had not revisited the checkboxes since 11 August 2026, so real progress may run ahead of it: 2.6.0 alone added `ntor-v3` CREATE2 handshakes and an initial design for the relay DNS resolver. For exact status, the [issue tracker](https://gitlab.torproject.org/tpo/core/arti/-/issues/){target="_blank"} is authoritative.
+
+## Arti 2.6.0
+
+> 2026-09-01 · [CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- Congestion control and Counter Galois Onion (CGO) cryptography are now always on, and the `flowctl-cc` and `counter-galois-onion` cargo features have been removed. Projects using `arti-client` or `tor-proto` need to drop those flags when upgrading.
+- Relay progress: CREATE2 with `ntor-v3` handshakes, unrecognised circuit IDs no longer treated as a channel protocol violation, no more DESTROY sent back on channels that received one, plus an initial design for the relay DNS resolver and cache.
+- Directory authority progress: microdescriptors can now be computed, Extra Info documents have initial support, and `DirMgr` can serve as a `DirServer` backend for now.
+- Ships `README_relay.md`, listing what relay and directory authority support still needs. See "How far the relay side has got" above.
+- Upstream does not mention active exploitation. This release lists no security fixes.
 
 ## Arti 2.5.1
 

--- a/docs/zh-CN/changelog/arti.md
+++ b/docs/zh-CN/changelog/arti.md
@@ -21,15 +21,47 @@ Arti 是 Tor Project 从 2021 年开始的计划，把原本用 C 写成的 Tor�
 | 架设 onion 服务（服务端，含 full vanguards、限制性发现、客户端授权） | ✅ 已完成 | 1.2.0（2024-03）起 |
 | RPC 控制接口（取代 c-tor 的 control port） | ✅ 已完成，转 stable | 1.4.2（2025-03） |
 | HTTP CONNECT 代理 | ✅ 已完成，默认启用 | 2.2.0（2026-03） |
-| 流量控制与拥塞控制（`flowctl-cc`，为 conflux 铺路） | ✅ 已完成，转 stable | 2.4.0（2026-06） |
+| 流量控制与拥塞控制 | ✅ 2.6.0 起永远启用，`flowctl-cc` 这个开关已移除 | 2.4.0 转 stable、2.6.0（2026-09）默认化 |
+| Counter Galois Onion 加密（CGO） | ✅ 2.6.0 起永远启用 | 2.6.0（2026-09） |
 | 嵌入非 Rust 语言（C FFI） | 🟡 RPC client 已有 C 友好接口，完整 FFI 规划中 | 进行中 |
-| 中继（relay）：circuit reactor、relay channel、握手响应、TLS server 端 | 🟡 开发中，尚不可用 | 2.0.0（2026-02）起 |
-| 目录权威（directory authority）：证书管理、目录缓存 | 🟡 开发中，尚不可用 | 2.0.0（2026-02）起 |
+| 中继（relay） | 🟡 开发中，官方明说不要拿去接公开网络 | 2.0.0（2026-02）到 2.6.0 持续推进 |
+| 目录权威（directory authority） | 🟡 开发中，文档解析与 microdescriptor 计算已有雏形 | 2.0.0（2026-02）到 2.6.0 持续推进 |
 | control-port 协议兼容 | ⬜ 不另行实现，改以 RPC 取代 | — |
 
 图例：✅ 已完成　🟡 开发中　⬜ 不实现
 
-客户端这一侧的能力已大致对齐 c-tor，能当 SOCKS 代理、连接与架设 onion 服务、走桥接与 pluggable transports。计划现在的主力放在中继端，relay 与 directory authority 仍在开发，还无法用 Arti 架设 Tor 中继，这部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 接口取代，设计取向不同。
+客户端这一侧的能力已大致对齐 c-tor，能当 SOCKS 代理、连接与架设 onion 服务、走桥接与 pluggable transports。计划现在的主力放在中继端，还无法用 Arti 架设 Tor 中继，这部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 接口取代，设计取向不同。
+
+## 中继端做到哪里
+
+2.6.0 随版附上一份 [`README_relay.md`](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/README_relay.md){target="_blank"}，把中继与目录权威要做的事列成清单并标出完成状态。这是目前最接近官方路线图的东西，开头第一句就是不要在公开 Tor 网络上运行 `arti-relay`。
+
+依 2026 年 8 月那份清单，中继端的完成度：
+
+| 区块 | 已完成 | 待办 |
+|---|---|---|
+| 基本运作（通道、电路、CREATE2、EXTEND2、ORPort） | 9 | 8 |
+| 出口支持（DNS、BEGIN、RESOLVE、出口策略） | 0 | 5 |
+| 目录缓存 | 0 | 13 |
+| 自我检测（ORPort 可达性、带宽、DNS） | 0 | 3 |
+| onion 服务支持（HsDir、引介、会合） | 0 | 3 |
+| 安全功能（离线身份密钥、内存与 socket 层 DoS 防御） | 0 | 4 |
+| 性能功能（缓冲区调校、电路调度、conflux） | 0 | 5 |
+| 目录权威 | 0 | 28 |
+
+已完成的九项集中在最底层：接受连入通道、双向通道认证、处理与递送 relay cell、CREATE2 与 CREATE\_FAST、EXTEND2、监听 ORPort。也就是说电路建得起来，但一个中继要能真的上线所需的其他东西几乎都还没开始，密钥生成与轮换、发布 router descriptor、带宽上限这些都还在待办。
+
+那份清单自己注明 2026 年 8 月 11 日之后团队还没回头勾选，所以实际进度可能比表上更前面，2.6.0 就补上了 `ntor-v3` 的 CREATE2 握手与中继 DNS 解析器的初步设计。要追精确状态得看 [issue tracker](https://gitlab.torproject.org/tpo/core/arti/-/issues/){target="_blank"}。
+
+## Arti 2.6.0
+
+> 2026-09-01 · [CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- 拥塞控制与 Counter Galois Onion 加密（CGO）改为永远启用，`flowctl-cc` 与 `counter-galois-onion` 两个 cargo feature 开关一并移除。用 `arti-client` 或 `tor-proto` 的项目升上来时要拿掉那两个开关。
+- 中继端进展：支持 `ntor-v3` 的 CREATE2 握手、不再把认不得的电路 ID 当成通道协议违规、收到 DESTROY 的通道不再回送 DESTROY，另有中继 DNS 解析器与缓存的初步设计。
+- 目录权威端进展：可以计算 microdescriptor、初步支持 Extra Info 文档、`DirMgr` 暂时可以当 `DirServer` 的后端。
+- 随版附上 `README_relay.md`，列出中继与目录权威还要做哪些事，见上面的「中继端做到哪里」。
+- 上游没有提到已被实际利用。这一版没有列出安全修补。
 
 ## Arti 2.5.1
 

--- a/docs/zh-TW/changelog/arti.md
+++ b/docs/zh-TW/changelog/arti.md
@@ -21,15 +21,47 @@ Arti 是 Tor Project 從 2021 年開始的計畫，把原本用 C 寫成的 Tor�
 | 架設 onion 服務（服務端，含 full vanguards、限制性探索、用戶端授權） | ✅ 已完成 | 1.2.0（2024-03）起 |
 | RPC 控制介面（取代 c-tor 的 control port） | ✅ 已完成，轉 stable | 1.4.2（2025-03） |
 | HTTP CONNECT 代理 | ✅ 已完成，預設啟用 | 2.2.0（2026-03） |
-| 流量控制與壅塞控制（`flowctl-cc`，為 conflux 鋪路） | ✅ 已完成，轉 stable | 2.4.0（2026-06） |
+| 流量控制與壅塞控制 | ✅ 2.6.0 起永遠啟用，`flowctl-cc` 這個開關已移除 | 2.4.0 轉 stable、2.6.0（2026-09）預設化 |
+| Counter Galois Onion 加密（CGO） | ✅ 2.6.0 起永遠啟用 | 2.6.0（2026-09） |
 | 嵌入非 Rust 語言（C FFI） | 🟡 RPC client 已有 C 友善介面，完整 FFI 規畫中 | 進行中 |
-| 中繼（relay）：circuit reactor、relay channel、握手回應、TLS server 端 | 🟡 開發中，尚不可用 | 2.0.0（2026-02）起 |
-| 目錄權威（directory authority）：憑證管理、目錄快取 | 🟡 開發中，尚不可用 | 2.0.0（2026-02）起 |
+| 中繼（relay） | 🟡 開發中，官方明說不要拿去接公開網路 | 2.0.0（2026-02）到 2.6.0 持續推進 |
+| 目錄權威（directory authority） | 🟡 開發中，文件解析與 microdescriptor 計算已有雛形 | 2.0.0（2026-02）到 2.6.0 持續推進 |
 | control-port 協定相容 | ⬜ 不另實作，改以 RPC 取代 | — |
 
 圖例：✅ 已完成　🟡 開發中　⬜ 不實作
 
-用戶端這一側的能力已大致對齊 c-tor，能當 SOCKS 代理、連線與架設 onion 服務、走橋接與 pluggable transports。計畫現在的主力放在中繼端，relay 與 directory authority 仍在開發，還無法用 Arti 架設 Tor 中繼，這部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 介面取代，設計取向不同。
+用戶端這一側的能力已大致對齊 c-tor，能當 SOCKS 代理、連線與架設 onion 服務、走橋接與 pluggable transports。計畫現在的主力放在中繼端，還無法用 Arti 架設 Tor 中繼，這部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 介面取代，設計取向不同。
+
+## 中繼端做到哪裡
+
+2.6.0 隨版附上一份 [`README_relay.md`](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/README_relay.md){target="_blank"}，把中繼與目錄權威要做的事列成清單並標出完成狀態。這是目前最接近官方路線圖的東西，開頭第一句就是不要在公開 Tor 網路上執行 `arti-relay`。
+
+依 2026 年 8 月那份清單，中繼端的完成度：
+
+| 區塊 | 已完成 | 待辦 |
+|---|---|---|
+| 基本運作（通道、電路、CREATE2、EXTEND2、ORPort） | 9 | 8 |
+| 出口支援（DNS、BEGIN、RESOLVE、離開政策） | 0 | 5 |
+| 目錄快取 | 0 | 13 |
+| 自我檢測（ORPort 可達性、頻寬、DNS） | 0 | 3 |
+| onion 服務支援（HsDir、引介、會合） | 0 | 3 |
+| 安全功能（離線身分金鑰、記憶體與 socket 層 DoS 防禦） | 0 | 4 |
+| 效能功能（緩衝區調校、電路排程、conflux） | 0 | 5 |
+| 目錄權威 | 0 | 28 |
+
+已完成的九項集中在最底層：接受連入通道、雙向通道認證、處理與遞送 relay cell、CREATE2 與 CREATE\_FAST、EXTEND2、監聽 ORPort。也就是說電路建得起來，但一個中繼要能真的上線所需的其他東西幾乎都還沒開始，金鑰產生與輪替、發布 router descriptor、頻寬上限這些都還在待辦。
+
+那份清單自己註明 2026 年 8 月 11 日之後團隊還沒回頭勾選，所以實際進度可能比表上更前面，2.6.0 就補上了 `ntor-v3` 的 CREATE2 握手與中繼 DNS 解析器的初步設計。要追精確狀態得看 [issue tracker](https://gitlab.torproject.org/tpo/core/arti/-/issues/){target="_blank"}。
+
+## Arti 2.6.0
+
+> 2026-09-01 · [CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- 壅塞控制與 Counter Galois Onion 加密（CGO）改為永遠啟用，`flowctl-cc` 與 `counter-galois-onion` 兩個 cargo feature 開關一併移除。用 `arti-client` 或 `tor-proto` 的專案升上來時要拿掉那兩個開關。
+- 中繼端進展：支援 `ntor-v3` 的 CREATE2 握手、不再把認不得的電路 ID 當成通道協定違規、收到 DESTROY 的通道不再回送 DESTROY，另有中繼 DNS 解析器與快取的初步設計。
+- 目錄權威端進展：可以計算 microdescriptor、初步支援 Extra Info 文件、`DirMgr` 暫時可以當 `DirServer` 的後端。
+- 隨版附上 `README_relay.md`，列出中繼與目錄權威還要做哪些事，見上面的「中繼端做到哪裡」。
+- 上游沒有提到已被實際利用。這一版沒有列出安全修補。
 
 ## Arti 2.5.1
 


### PR DESCRIPTION
## 有新版，而且對進度表有實質影響

Arti 2.6.0 在 2026-09-01 進了 CHANGELOG。tag 還沒建、官方部落格也還沒發文，所以條目連 CHANGELOG 本身。

這一版改了兩件影響進度表的事：壅塞控制與 Counter Galois Onion 加密改為**永遠啟用**，`flowctl-cc` 與 `counter-galois-onion` 兩個 cargo feature 開關移除。原本表格寫「流量控制與壅塞控制（`flowctl-cc`，為 conflux 鋪路）｜已完成，轉 stable｜2.4.0」，現在要改寫，CGO 也獨立成一列。

## 真正的收穫是 README_relay.md

2.6.0 隨版附上 [`README_relay.md`](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/README_relay.md)，把中繼與目錄權威要做的事列成清單並標出完成狀態。那是目前最接近官方路線圖的東西。

原本的表格只寫「開發中，尚不可用」，讀者看不出還差多遠。現在補上實際統計：

| 區塊 | 已完成 | 待辦 |
|---|---|---|
| 基本運作（通道、電路、CREATE2、EXTEND2、ORPort） | 9 | 8 |
| 出口支援 | 0 | 5 |
| 目錄快取 | 0 | 13 |
| 自我檢測 | 0 | 3 |
| onion 服務支援 | 0 | 3 |
| 安全功能 | 0 | 4 |
| 效能功能 | 0 | 5 |
| 目錄權威 | 0 | 28 |

完成的九項集中在最底層（接受連入通道、雙向認證、處理 relay cell、CREATE2、EXTEND2、監聽 ORPort），也就是電路建得起來，但金鑰產生與輪替、發布 router descriptor、頻寬上限這些真的要上線才用得到的東西都還沒開始。

兩個誠實標注：那份清單自己說 8 月 11 日之後團隊還沒回頭勾選，所以實際進度可能更前面（2.6.0 就補了 `ntor-v3` CREATE2 握手與中繼 DNS 解析器的初步設計），要追精確狀態得看 issue tracker。以及文件開頭那句「不要在公開 Tor 網路上執行 `arti-relay`」照樣寫進頁面。

## 驗證

- `docs_style_lint.py` 掃三語系 arti.md，0 error 0 warn
- 三語系建置皆通過，新表格與 2.6.0 條目都正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)