### PR TITLE
content(blog): 完整版 uBlock Origin 無法在 Chrome 使用，整理替代選擇與廣告隱私脈絡 [發布 2026-09-09]

### DIFF
--- a/docs/en/blog/posts/ublock-origin-mv3.md
+++ b/docs/en/blog/posts/ublock-origin-mv3.md
@@ -1,0 +1,193 @@
+---
+date: 2026-09-09
+authors:
+    - anoni-net
+categories:
+    - Technology
+    - Privacy
+slug: ublock-origin-mv3
+summary: "Chrome users can no longer install the full uBlock Origin. Firefox, LibreWolf and Brave each keep it alive a different way, while Google spent the same year shutting down the project meant to replace third-party cookies."
+description: "Why the full uBlock Origin no longer runs in Chrome, how Firefox, Brave and LibreWolf each keep it working, and what users give up when ad blocking moves from an extension into the browser core."
+---
+
+# :material-shield-off-outline: The full uBlock Origin no longer runs in Chrome
+
+Chrome users can no longer install the full uBlock Origin. On 31 August 2026 the Chrome Web Store removed the last remaining Manifest V2 extensions[^chrome-timeline], uBlock Origin among them. Copies already installed on older Chrome builds stay in place but receive no further updates, and removing one means it cannot be installed again.
+
+Manifest is the specification Google sets for Chrome extensions, and it decides what an extension is allowed to do. Version 2 let an extension inspect every connection request before the page loaded and decide on the spot whether to block it. Version 3 replaces that with a rule list declared in advance, leaving the matching and blocking to the browser. Ad blockers were built on the version 2 model.
+
+The transition ran for more than four years, from the Chrome Web Store closing to new MV2 submissions in early 2022, through the full shutdown in July 2025, to this August's removal. Every step came with public documentation and a published timeline.
+
+On 17 October 2025 Google retired ten Privacy Sandbox technologies[^ps-retire], ending the project meant to replace third-party cookies. Third-party cookies remain in Chrome.
+
+Rule limits and the API differences sit in the second half of this piece; readers who only want to know which tool to switch to can skip that section.
+
+<!-- more -->
+
+## Four years of winding down
+
+| Date | What happened |
+|------|---------------|
+| January and June 2022 | Chrome Web Store stops accepting new MV2 extensions |
+| 3 June 2024 | Warning banners appear on the Beta, Dev and Canary channels |
+| 9 October 2024 | Chrome stable begins disabling installed MV2 extensions in waves; enterprise policy exempt until June 2025 |
+| 31 March 2025 | Disabled by default on all channels, with users still able to turn them back on |
+| 24 July 2025 | Chrome 138 disables them everywhere with no way back; the enterprise policy is removed in Chrome 139 |
+| 31 August 2026 | Chrome Web Store removes all remaining MV2 extensions |
+
+## Browsers split three ways
+
+| Browser | Full uBlock Origin | How |
+|---------|-------------------|-----|
+| Chrome | Unavailable | MV2 code removed from Chromium; only uBlock Origin Lite remains |
+| Edge | Winding down | Consumer transition completes end of 2026, enterprise early 2027 |
+| Firefox | Available | The Gecko engine keeps blocking `webRequest`, in MV3 as well |
+| LibreWolf | Available | A Firefox fork that ships with uBlock Origin preinstalled |
+| Brave | Available | Four MV2 extensions hosted on Brave's own servers |
+| Safari | Unavailable | WebKit content blockers are declarative; uBlock Origin has not supported Safari since version 13 |
+
+Microsoft's announcement of 7 August 2026 states that the consumer transition away from MV2 begins "in August 2026", with the goal to "complete the consumer transition by the end of 2026" and enterprise deprecation following in early 2027[^edge]. The stated reasons are security and performance improvements over MV2, and the announcement never mentions uBlock Origin by name.
+
+Firefox runs its own engine and Mozilla implemented MV3 independently. The official post states that Firefox "will continue supporting both blockingWebRequest and declarativeNetRequest"[^mozilla]. Both APIs remain, and extension authors can choose.
+
+Vivaldi and Opera are Chromium-based. Vivaldi's built-in blocker hooks into an internal Chromium API and is unaffected by MV3; the 2022 post says only that the team would consider keeping `webRequest` alive a while longer if an easy path existed, stopping short of a commitment[^vivaldi]. With no MV2 code left upstream, any browser tracking Chromium releases has to carry its own patches to keep support.
+
+## What you can pick now
+
+### Browser level
+
+Firefox is the most direct choice. The full uBlock Origin installs on both desktop and Android, and the default filter lists are enough for most people.
+
+Brave's built-in Shields work as soon as the browser is installed. For finer control, the MV2 build of uBlock Origin can be added from `brave://settings/extensions/v2`. Note that the project's own documentation advises against running two content blockers at once, since they can interfere with each other.
+
+For anyone staying on Chrome, uBlock Origin Lite still blocks most ads, without the dynamic control or the live filter-list updates.
+
+### Who LibreWolf suits
+
+LibreWolf is a community fork of Firefox that ships with privacy settings already configured. The features page lists uBlock Origin preinstalled with its filter lists, Tracking Protection in strict mode, Total Cookie Protection, telemetry fully disabled, and RFP (Resist Fingerprinting) enabled, the anti-fingerprinting work that came out of the Tor Uplift project[^librewolf-features]. Install it and the whole set is already in place, with no trip through `about:config`.
+
+RFP does break some sites: canvas access has to be granted per site, the language is always reported as en-US, and window dimensions are quantised. LibreWolf also has no auto-update mechanism. The FAQ states that updating "relies on package managers or users to apply them", with releases usually following a Firefox stable build within three days and sometimes the same day[^librewolf-faq]. Security updates are on you, or on your package manager. There is no Android build either; the FAQ says nobody is working on one and points Android users to IronFox[^librewolf-faq].
+
+It suits desktop users who can live with the occasional broken site and who will keep up with updates. Anyone who would rather not manage the update cadence can stay on Firefox and install uBlock Origin themselves, for much the same protection in practice.
+
+Mullvad Browser is the other option here. Built by Mullvad together with the Tor Project, it amounts to Tor Browser without the Tor network, ships with uBlock Origin, and uses techniques such as letterboxing to make its users look alike. It runs on Linux, macOS and Windows. Because it commits harder to the uniformity approach, sites break slightly more often than on LibreWolf.
+
+Neither LibreWolf nor Mullvad Browser should be pointed at Tor. The LibreWolf FAQ answers that question with "Please don't", and directs anyone who wants anonymity to Tor Browser[^librewolf-faq].
+
+### DNS level
+
+NextDNS, AdGuard DNS and a self-hosted Pi-hole all sit at this layer. The advantage is coverage: one configuration applies to an entire device or an entire network, including ads inside mobile apps. The boundary is equally clear. DNS filtering only sees domain names, so it cannot touch content served from the same domain and cannot do cosmetic filtering. When the ads and the content share a domain, this layer cannot help.
+
+### System level
+
+The AdGuard desktop app and content-blocker apps on iOS sit here. The desktop version usually installs a local certificate to inspect encrypted traffic, which is the trade-off worth thinking through: it puts a component that can read all your HTTPS content inside your system.
+
+### Mobile
+
+Firefox on Android runs the full uBlock Origin, which is unusual among mobile browsers. iOS offers no equivalent because of platform restrictions, leaving Safari content-blocker apps or a DNS-level approach.
+
+## Do not add extensions to Tor Browser
+
+The Tor Project's support documentation is blunt about this. Installing new add-ons in Tor Browser, AdBlock Plus and uBlock Origin included, is strongly discouraged, because "installing new add-ons may affect Tor Browser in unforeseen ways and potentially make your Tor Browser fingerprint unique"[^tor-addons].
+
+Tor Browser's protection rests on every user looking identical. Each extension you add lifts you out of that crowd. The bundled NoScript is the one extension that has been tested for it.
+
+Blocking ads and resisting fingerprinting are two different jobs. Blocking ad requests does not make your fingerprint any less distinctive, and the more tools you install, the more distinctive it gets. On how the two relate, see [A browser fingerprint cannot be cleared the way a cookie can](../../basics/browser-fingerprinting.md).
+
+## Brave's two layers of protection
+
+Brave Shields is the blocker built into the browser, running the Rust `adblock-rust` engine patched directly into Chromium. The engine reads the same Adblock Plus syntax lists as everyone else, EasyList and EasyPrivacy among them, and supports cosmetic filtering and scriptlet injection[^adblock-rust]. Brave's post states that Shields "don't rely on MV2 _or_ MV3"[^brave-mv3], which leaves it untouched by changes to the extension platform.
+
+Extensions are the second layer. Since `v1.81` Brave has hosted four MV2 extensions on its own backend, AdGuard, uBlock Origin, uMatrix and NoScript, installed from the `brave://settings/extensions/v2` page and kept separate from the Chrome Web Store builds[^brave-mv3]. `v1.92` added automatic migration; issue `56654` describes the behaviour as detecting installed Web Store MV2 extensions, backing up their settings, and swapping in the Brave-hosted equivalent[^brave-issue]. The same milestone turned that settings page on by default. Brave stable reached `v1.96` by September 2026, so both changes are in the shipping build.
+
+Brave's stated commitment runs "for as long as we're able (and assuming the cooperation of the extension authors)". The same post adds that if an extension becomes outdated or unmaintained, Brave may drop support rather than ship an out-of-date and possibly unsafe build[^brave-mv3].
+
+In June 2026 a report described the MV2 settings page in Brave beta turning up empty, with the extensions gone, while the nightly build of the same version worked and stable was unaffected[^piunika]. Brave restated its commitment in a post that August.
+
+Updates used to come from the Chrome Web Store and now come from Brave's servers. The update source, the release cadence, and the decision to keep supporting any of it all sit with Brave. In 2020 Brave was caught appending its own referral codes to cryptocurrency exchange URLs typed by users; the CEO apologised publicly and the behaviour was removed. Brave Rewards, the BAT token and the built-in wallet are all opt-in, but the underlying business model, replacing Google's ad system with its own, has been argued over in privacy circles ever since.
+
+## Google's security case and Google's ad business
+
+The security argument holds up. An extension can read and rewrite every network request, so a compromised or malicious one has a great deal of room to work with. Incidents disclosed between 2025 and 2026 include a supply-chain attack that started with a phished OAuth authorisation and reached more than 30 extensions and roughly 2.6 million users, plus extensions that exfiltrated AI chat transcripts from around 900,000 people.
+
+Chrome held roughly 65% of the global browser market in 2026, and about 70% on desktop. The company writing the rules for the extension platform is also the largest advertising company in the world, and in April 2025 a US federal court found it had illegally monopolised the publisher ad server and ad exchange markets, with remedies still undecided. When one company both sets the rules and sells the ads, a restriction imposed in the name of security is hard to take at face value.
+
+The EFF's position is that the MV3 changes weaken the ability of extension developers to keep up with tracking techniques. Vivaldi called the rule limits artificial limitations set by Google, and closed that post by asking, "Perhaps, wise to move away from Chrome?"[^vivaldi].
+
+## The other project shut down the same year
+
+Privacy Sandbox began in 2019, presented as a set of technologies that would replace third-party cookies and let ad delivery and measurement work without tracking individuals. In July 2024 Google abandoned its plan to phase out third-party cookies. In April 2025 it dropped the fallback plan of prompting users to choose.
+
+On 17 October 2025 it ended. Google retired ten technologies, Topics, Protected Audience, Attribution Reporting, IP Protection and Related Website Sets among them, giving as the reason that this followed "evaluating ecosystem feedback about their expected value and in light of their low levels of adoption"[^ps-retire]. Three survive: CHIPS, FedCM and Private State Tokens, described officially as having seen broad adoption including support from other browsers. On third-party cookies the wording is direct, with Chrome maintaining its current approach.
+
+The same day, the UK Competition and Markets Authority released Google from its Privacy Sandbox commitments. AdExchanger reported that all 15 consultation responses the authority received opposed the release[^adexchanger].
+
+Six years on, the user side has had its ad blocking narrowed to a declarative rule list, the industry side has watched the promised replacement for third-party cookies fold, and third-party cookies are still where they started.
+
+## What a built-in blocker costs
+
+Brave Shields, Vivaldi's built-in blocker and Safari's content blockers all point the same way, moving the blocking into the browser core. Once it is built in, the problem of over-privileged extensions disappears, and performance is usually better too.
+
+The cost lands on control. Whether to block, how aggressively, and how often the lists update are all decided by the browser vendor. The per-site dynamic filtering in uBlock Origin, its point-and-click firewall, the freedom to swap in a different list at any time, rarely have equivalents in a built-in model. Users move from picking a tool and tuning it themselves to picking a vendor and accepting its defaults.
+
+The difference shows up at the edges: a tracking technique that has just appeared and is not in the built-in list yet, or something you want blocked that the vendor would rather not block. Auditability shifts too. An open-source extension lets anyone read the rules and change them, while how far a built-in feature can be inspected or replaced varies from vendor to vendor.
+
+## What actually changed, technically
+
+### How the two APIs differ
+
+MV2's `webRequest` is interceptive. The browser hands the full request details to the extension before sending it, and the extension's own logic decides whether to block. The extension can rewrite rules on the fly, read the surrounding context, and apply different rules depending on the state of the tab.
+
+MV3's `declarativeNetRequest` is declarative. The extension registers its rules in advance, the browser does the matching and blocking, and the extension never receives the individual requests. Google's stated reasons are security and performance, since an extension no longer needs the contents of every network request.
+
+The rule counts are capped. Constants in the official documentation include a maximum of 50 enabled static rulesets, a guaranteed minimum of 30,000 static rules, 30,000 dynamic rules (safe rules only), 5,000 unsafe dynamic rules, and 1,000 regular-expression rules[^dnr]. Google's May 2024 announcement notes that, after community feedback, the limits rose to "up to 330,000 static rules and 30,000 dynamically added rules"[^google-phaseout]. The figure of 30,000 rules that circulated in early coverage is out of date; the totals did go up.
+
+### What uBlock Origin Lite gives up
+
+Raymond Hill, the author of uBlock Origin, did not port the full extension to MV3 and built uBlock Origin Lite separately. The project FAQ lists what the MV3 architecture cannot support[^ubol-faq]:
+
+- No dynamic filtering. `declarativeNetRequest` cannot enforce rules based on the top-level domain in the address bar
+- No per-site no-remote-fonts or no-scripting switches
+- No generic cosmetic filtering in the default mode; that requires Complete mode
+- Many regex filters that work well in uBlock Origin are rejected by the API
+- `redirect-rule=`, the regex form of `removeparam=`, `replace=`, `ipaddress=` and CNAME uncloaking are all unsupported
+
+The way filter lists update changed as well. The FAQ states that "uBOL never makes network requests to any remote servers", so the rules only change when a new version of the extension ships. A list that used to update several times a day, tracking domain changes as advertisers made them, now moves at the pace of Chrome Web Store review. Google introduced an expedited review path for rule-only changes in 2024, and the announcement says those updates can clear in minutes[^google-phaseout].
+
+### The escape hatches removed one by one
+
+Four merged changes on Chromium's code review platform show the switches that could re-enable MV2 being taken out: the MV2 availability policy on 10 June 2025 (`6617410`), the `allow-legacy-mv2-extensions` developer flag on 4 November 2025 (`7113458`), the `kExtensionManifestV2Disabled` feature flag on 22 May 2026 (`7813942`), and the policy handling code on 4 June 2026 (`7890750`)[^gerrit]. The commit message on the third describes removing the feature "and the effectively-dead code".
+
+## Where this goes next
+
+How long Brave can keep hosting MV2 extensions comes down to maintenance cost. With no such code left upstream, every Chromium release Brave follows means a little more to patch back in.
+
+Remedies in the Google ad tech antitrust case are still undecided, and the gap between a structural divestiture and behavioural fixes is wide. With third-party cookies staying put, fingerprinting and server-side identification techniques have not gone anywhere either.
+
+The choice of tool will keep changing; the way to judge one is steadier. Work out who you are defending against, check what the tool in front of you actually blocks, and ask who holds that capability.
+
+## Further reading
+
+- [A browser fingerprint cannot be cleared the way a cookie can](../../basics/browser-fingerprinting.md) — why fingerprints persist, and where each browser stands by default
+- [Brave flattens GPU fingerprints two opposite ways](./brave-gpu-fingerprinting.md) — how built-in protection works, and what it leaves untouched
+- [How platforms collect your data, and the microphone question](../../basics/platform-tracking.md) — where ad tracking sits in the wider ecosystem
+- [Threat modeling](../../basics/threat-model.md) — establish who you are defending against before picking tools
+- [What your browser gives away](../../utils/leaks.md) — see for yourself what your browser reports
+
+[^chrome-timeline]: [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline){target="_blank"} — Chrome for Developers. Source for every date in the timeline table, the roles of Chrome 138 and 139, and the 31 August 2026 removal. Verified 2026-09-01.
+[^gerrit]: Chromium code review, the four changes being [`6617410`](https://chromium-review.googlesource.com/c/chromium/src/+/6617410){target="_blank"}, [`7113458`](https://chromium-review.googlesource.com/c/chromium/src/+/7113458){target="_blank"}, [`7813942`](https://chromium-review.googlesource.com/c/chromium/src/+/7813942){target="_blank"} and [`7890750`](https://chromium-review.googlesource.com/c/chromium/src/+/7890750){target="_blank"}. Merge dates and commit messages retrieved through the Gerrit API. Verified 2026-09-01.
+[^dnr]: [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest){target="_blank"} — Chrome for Developers. Source for the rule limit constants. Verified 2026-09-01.
+[^google-phaseout]: [Manifest V2 phase-out begins](https://blog.google/chromium/manifest-v2-phase-out-begins/){target="_blank"} — Chromium official blog, May 2024. Source for the 330,000 static rules, the 30,000 dynamic rules, and the expedited review path. Verified 2026-09-01.
+[^ubol-faq]: [uBlock Origin Lite FAQ](https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)){target="_blank"} — uBlock Origin Lite project wiki. Source for the unsupported capabilities and the filter list update model. The official home of uBlock Origin is [gorhill/uBlock](https://github.com/gorhill/uBlock){target="_blank"}. Verified 2026-09-01.
+[^edge]: [Moving the Microsoft Edge extensions ecosystem forward with Manifest Version 3](https://blogs.windows.com/msedgedev/2026/08/07/moving-the-microsoft-edge-extensions-ecosystem-forward-with-manifest-version-3/){target="_blank"} — Microsoft Edge blog, 7 August 2026. Source for the consumer and enterprise timelines. Verified 2026-09-01.
+[^mozilla]: [Mozilla's approach to Manifest V3](https://blog.mozilla.org/en/firefox/firefox-manifest-v3-adblockers/){target="_blank"} — The Mozilla Blog, 25 February 2025. Source for Firefox keeping both APIs. Verified 2026-09-01.
+[^vivaldi]: [Manifest V3, webRequest, and ad blockers](https://vivaldi.com/blog/manifest-v3-webrequest-and-ad-blockers/){target="_blank"} — Vivaldi blog, 23 September 2022, updated June 2024. Source for how the built-in blocker is implemented and for the criticism of the rule limits. Verified 2026-09-01.
+[^adblock-rust]: [Brave Improves Its Ad-Blocker Performance by 69x with New Engine Implementation in Rust](https://brave.com/blog/improved-ad-blocker-performance/){target="_blank"} and [brave/adblock-rust](https://github.com/brave/adblock-rust){target="_blank"}. Source for the engine implementation and the filter syntax it supports. Verified 2026-09-01.
+[^brave-mv3]: [What Manifest V3 means for Brave Shields and the use of extensions in the Brave browser](https://brave.com/blog/brave-shields-manifest-v3/){target="_blank"} — Brave official blog. Source for Shields being independent of the extension platform, the four hosted extensions, the `v1.81` starting point, and the wording of the support commitment. Verified 2026-09-01.
+[^brave-issue]: [Auto-replace known Web Store MV2 extensions with Brave-hosted equivalents](https://github.com/brave/brave-browser/issues/56654){target="_blank"} — brave-browser issue `56654`, milestone `1.92.x`. Source for the automatic migration behaviour; the settings page being enabled by default is covered in issue [`56799`](https://github.com/brave/brave-browser/issues/56799){target="_blank"}. Verified 2026-09-01.
+[^piunika]: [Latest Brave Beta hints at Manifest V2 support drop](https://piunikaweb.com/2026/06/26/latest-brave-beta-manifest-support-drop/){target="_blank"} — PiunikaWeb, 26 June 2026. Source for the empty settings page in the beta build. Brave issued no statement about that change. Verified 2026-09-01.
+[^ps-retire]: [Update on plans for Privacy Sandbox technologies](https://privacysandbox.google.com/blog/update-on-plans-for-privacy-sandbox-technologies){target="_blank"} — Privacy Sandbox official announcement, 17 October 2025. Source for the ten retired technologies, the three that remain, and the position on third-party cookies. Verified 2026-09-01.
+[^adexchanger]: [Google Pulls The Plug On Topics, PAAPI And Other Major Privacy Sandbox APIs (As The CMA Says 'Cheerio')](https://www.adexchanger.com/privacy/google-pulls-the-plug-on-topics-paapi-and-other-major-privacy-sandbox-apis-as-the-cma-says-cheerio/){target="_blank"} — AdExchanger, October 2025. Source for the CMA releasing Google from its commitments and for the 15 opposing consultation responses. Verified 2026-09-01.
+[^tor-addons]: [Should I install a new add-on or extension in Tor Browser, like AdBlock Plus or uBlock Origin?](https://support.torproject.org/tbb/tbb-14/){target="_blank"} — Tor Project support documentation. Source for the advice against installing extensions. Verified 2026-09-01.
+[^librewolf-features]: [LibreWolf Features](https://librewolf.net/docs/features/){target="_blank"} — LibreWolf documentation. Source for the preinstalled uBlock Origin and its filter lists, strict-mode Tracking Protection, Total Cookie Protection, disabled telemetry, and RFP being enabled. Verified 2026-09-02.
+[^librewolf-faq]: [LibreWolf FAQ](https://librewolf.net/docs/faq/){target="_blank"} — LibreWolf documentation. Source for the update cadence and lack of auto-update, the absence of an Android build and the IronFox recommendation, and the advice against pairing it with Tor. Verified 2026-09-02.

--- a/docs/zh-CN/blog/posts/ublock-origin-mv3.md
+++ b/docs/zh-CN/blog/posts/ublock-origin-mv3.md
@@ -1,0 +1,201 @@
+---
+date: 2026-09-09
+authors:
+    - anoni-net
+categories:
+    - 技术
+    - 隐私
+slug: ublock-origin-mv3
+summary: "Chrome 用户已经装不回完整版的 uBlock Origin。Firefox、LibreWolf 与 Brave 各用不同方式留住它，Google 则在同一年收掉了取代第三方 cookie 的整套计划"
+description: "完整版 uBlock Origin 为什么不能在 Chrome 使用，Firefox、Brave 与 LibreWolf 分别用什么方式留住它，以及拦截广告从扩展程序搬进浏览器内核之后，用户失去了什么。"
+---
+
+# :material-shield-off-outline: 完整版 uBlock Origin 已经无法在 Chrome 使用
+
+Chrome 用户现在装不回完整版的 uBlock Origin。2026 年 8 月 31 日，Chrome 应用商店移除最后一批 Manifest V2 扩展程序[^chrome-timeline]，uBlock Origin 是其中一个。已经装在旧版 Chrome 上的还留着，但无法再更新，移除之后也装不回来。
+
+Manifest 是 Google 替 Chrome 扩展程序制定的规格，决定扩展程序能做哪些事。第二版让扩展程序在网页加载前逐一检查每个连接请求，当场决定要不要拦。第三版改成事先申报一份规则列表，比对与拦截交给浏览器执行。广告拦截器原本靠第二版的做法运作。
+
+过程走了四年多，从 2022 年初停收新的 MV2 扩展程序开始，到 2025 年 7 月全面停用，再到今年 8 月的下架。每一步都有公开文件与时间表。
+
+2025 年 10 月 17 日，Google 退役十项 Privacy Sandbox 技术[^ps-retire]，原本要用来取代第三方 cookie 的整套计划收在那一天。第三方 cookie 继续留在 Chrome 里。
+
+规则上限与 API 差异整理在文章后半，只想知道该换什么工具的读者可以直接跳过。
+
+<!-- more -->
+
+## 四年的退场过程
+
+| 日期 | 发生什么 |
+|------|----------|
+| 2022 年 1 月与 6 月 | Chrome 应用商店停收新的 MV2 扩展程序 |
+| 2024 年 6 月 3 日 | Beta、Dev、Canary 开始显示警告横幅 |
+| 2024 年 10 月 9 日 | Chrome stable 分批停用已安装的 MV2 扩展程序，企业策略可豁免到 2025 年 6 月 |
+| 2025 年 3 月 31 日 | 全渠道默认停用，用户仍可手动开回 |
+| 2025 年 7 月 24 日 | Chrome 138 起一律停用且无法开回，企业策略在 Chrome 139 移除 |
+| 2026 年 8 月 31 日 | Chrome 应用商店移除所有剩余的 MV2 扩展程序 |
+
+## 各家浏览器分成三条路
+
+| 浏览器 | 完整版 uBlock Origin | 靠什么 |
+|--------|-----------|--------|
+| Chrome | 不能用 | MV2 代码已从 Chromium 移除，只剩 uBlock Origin Lite |
+| Edge | 退场中 | 消费者版 2026 年底完成，企业版 2027 年初 |
+| Firefox | 可以用 | Gecko 内核保留拦截式的 `webRequest`，MV3 也保留 |
+| LibreWolf | 可以用 | Firefox 分支，安装时就内置 uBlock Origin |
+| Brave | 可以用 | 自建服务器托管四个 MV2 扩展程序 |
+| Safari | 不能用 | WebKit 的 content blocker 是申报式，uBlock Origin 在 Safari 13 之后就没有支持 |
+
+Microsoft 在 2026 年 8 月 7 日的公告写，Edge 的消费者版 MV2 退场「Beginning in August 2026」开始，目标「complete the consumer transition by the end of 2026」，企业版接在 2027 年初[^edge]。公告写的理由是 MV3 在安全与性能上优于 MV2，全文没有提到 uBlock Origin。
+
+Firefox 有自己的内核，MV3 由 Mozilla 自行实现，官方文章写 Firefox「will continue supporting both blockingWebRequest and declarativeNetRequest」[^mozilla]。两个 API 都在，扩展程序作者可以选。
+
+Vivaldi 与 Opera 属于 Chromium 系。Vivaldi 的内置拦截器接的是 Chromium 内部 API，不受 MV3 影响，2022 年那篇说明文章的措辞是，如果有简单的方法让 `webRequest` 继续运作一段时间会考虑，没有做出承诺[^vivaldi]。上游已经没有 MV2 代码，任何跟随上游的分支要继续支持，都得自己维护修改。
+
+国内常见的 QQ 浏览器、360 浏览器、UC 浏览器同样基于 Chromium，跟随上游版本之后一样会失去 MV2 支持。这些浏览器多半不提供 Brave 那种自建托管，也很少公开说明扩展平台的时间表，判断依据只有实际测试。
+
+## 你现在可以怎么选
+
+### 浏览器层
+
+Firefox 是最直接的选择，完整版 uBlock Origin 在桌面与 Android 都能装，安装之后默认的过滤列表就够用。
+
+Brave 内置的 Shields 安装后就生效，需要进阶控制时再从 `brave://settings/extensions/v2` 装 MV2 版的 uBlock Origin。要注意该项目的说明文件明确写不要同时使用两个内容拦截器，两个一起开可能互相干扰。
+
+留在 Chrome 的人，uBlock Origin Lite 拦得掉大部分广告，动态控制与即时的列表更新没有了。
+
+### LibreWolf 适合什么样的人
+
+LibreWolf 是 Firefox 的社区分支，把隐私设置预先调好再打包发布。官方功能页写的默认值包含内置 uBlock Origin 并配好过滤列表、Tracking Protection 开在 strict 模式、Total Cookie Protection、完全停用遥测，以及启用 RFP（Resist Fingerprinting）这项来自 Tor Uplift 项目的指纹防护[^librewolf-features]。装完直接使用就有一整套设置，省去自行研究 `about:config` 的工夫。
+
+RFP 会让一部分网站显示异常，canvas 访问需要逐站允许，语言统一回报成 en-US，窗口尺寸也被对齐。LibreWolf 也没有自动更新功能，官方 FAQ 写更新「relies on package managers or users to apply them」，跟上 Firefox 稳定版通常在三天内，有时同一天[^librewolf-faq]。安全更新要自己记得装，或交给包管理器。Android 用户则没有这个选项，官方 FAQ 写目前没有人在开发，可改用 IronFox[^librewolf-faq]。
+
+适合的是愿意接受偶尔网站显示异常、也会固定更新的桌面用户。不想处理更新节奏的人留在 Firefox 自行安装，实际防护差距不大。
+
+Mullvad Browser 是另一个选项，由 Mullvad 与 Tor Project 合作开发，等于拿掉 Tor 网络的 Tor Browser，默认内置 uBlock Origin，用 letterboxing 之类的手法让所有用户的指纹看起来相近，支持 Linux、macOS 与 Windows。它走的是一致化路线，网站显示异常的概率比 LibreWolf 更高一些。
+
+LibreWolf 与 Mullvad Browser 都不要拿来连 Tor。LibreWolf 的官方 FAQ 在这一题底下写的是「Please don't」，要匿名就用 Tor Browser[^librewolf-faq]。
+
+### DNS 层
+
+NextDNS、AdGuard DNS、自建的 Pi-hole 都属于这一层。优点是整台设备或整个网络一次生效，手机 app 里的广告也拦得到。界线很清楚，DNS 层依据的只有域名，处理不了同一个域名下的内容，也做不到外观过滤。广告与内容来自同一个域名的情况拦不下来。
+
+在 DNS 查询本身受到干扰的网络环境里，这一层的可靠性还要再打折。加密 DNS 的服务器地址可能连不上，回落到本地 DNS 之后过滤就失效，浏览器层的拦截器不受这个影响，两层一起用比较稳。
+
+### 系统层
+
+AdGuard 桌面版与 iOS 上的 content blocker app 属于这一层。桌面版通常需要安装本地证书来检查加密流量，取舍在于，等于把一个能读取所有 HTTPS 内容的组件装进系统。
+
+### 移动设备
+
+Android 上的 Firefox 支持完整版 uBlock Origin，在手机浏览器里算少见。iOS 因为系统限制没有这个选项，只剩 Safari 的 content blocker app 或 DNS 层方案。
+
+## 用 Tor Browser 的人不要装
+
+Tor Project 的支持文件写得很直接，强烈不建议在 Tor Browser 里安装新的扩展程序，包含 AdBlock Plus 与 uBlock Origin，理由是「Installing new add-ons may affect Tor Browser in unforeseen ways and potentially make your Tor Browser fingerprint unique」[^tor-addons]。
+
+Tor Browser 的防护建立在所有用户长得一样，多装一个扩展程序就是把自己从人群里挑出来。内置的 NoScript 是唯一经过测试的那一个。
+
+在直连 Tor 受阻的地区，接入方式要靠网桥与可插拔传输，那是另一个话题，与要不要装扩展程序无关。无论用哪种方式接入，Tor Browser 的配置都不要改动。
+
+拦广告与抗指纹是两件不同的事。拦掉广告请求不会让你在指纹上变得不显眼，工具装得越多，指纹反而越独特。两者的关系见 [浏览器指纹是什么，为什么很难摆脱](../../basics/browser-fingerprinting.md)。
+
+## Brave 的两层防护
+
+Brave Shields 是浏览器内置的拦截器，用 Rust 写的 `adblock-rust` 引擎，直接修改在 Chromium 上。引擎读取的是 EasyList、EasyPrivacy 那一套 Adblock Plus 语法的列表，支持外观过滤与 scriptlet 注入[^adblock-rust]。Brave 的公告里写 Shields「don't rely on MV2 _or_ MV3」[^brave-mv3]，扩展平台怎么改都影响不到它。
+
+扩展程序是另外一层，Brave 从 `v1.81` 起在自家后端托管 AdGuard、uBlock Origin、uMatrix、NoScript 四个 MV2 扩展程序，用户从 `brave://settings/extensions/v2` 页面安装，这几份与 Chrome 应用商店上的版本各自独立[^brave-mv3]。`v1.92` 新增自动迁移，项目的 issue `56654` 描述的行为是检测已安装的应用商店 MV2 扩展程序、备份设置、换装 Brave 托管的对应版本[^brave-issue]。同一个里程碑把该设置页改成默认启用。Brave 的 stable 版在 2026 年 9 月已经到 `v1.96`，两项变更都在正式版里。
+
+Brave 的公告写的支持期限是「For as long as we're able (and assuming the cooperation of the extension authors)」，同一篇也写，如果扩展程序过时或停止维护，Brave 可能会移除支持，理由是不想提供过时、甚至不安全的版本[^brave-mv3]。
+
+2026 年 6 月有报道写，Brave beta 的 MV2 设置页变成空列表，扩展程序全部消失，同版本的 nightly 正常，stable 没有受影响[^piunika]。Brave 在 8 月的帖子里重申会继续支持。
+
+用户原本从 Chrome 应用商店取得更新，现在从 Brave 的服务器取得。更新来源、版本节奏、要不要继续支持，决定权都在 Brave 手上。Brave 在 2020 年被发现在用户输入的加密货币交易所网址后面自动加上自家的推荐码，首席执行官公开道歉并移除该行为。Brave Rewards、BAT 代币与内置钱包都是可选启用的功能，用自家广告系统取代 Google 广告系统这个商业模式本身，在隐私社区里一直有争论。
+
+## Google 的安全理由与广告生意
+
+Google 在安全上的论点成立，扩展程序能取得并改写每一个网络请求，一旦被入侵或本来就是恶意的，能做的事很多。2025 到 2026 年之间公开的事件包含一波从钓鱼取得 OAuth 授权开始的供应链攻击，波及超过 30 个扩展程序、约 260 万名用户，另有窃取 AI 对话内容的扩展程序影响约 90 万人。
+
+Chrome 在 2026 年握有全球约 65% 的浏览器市占，桌面约 70%。制定扩展平台规则的公司，同时是全球最大的广告公司，2025 年 4 月已经被美国联邦法院认定在发布商广告服务器与广告交易所市场违法垄断，救济措施到现在还没定案。同一家公司同时决定规则与销售广告，以安全为名的限缩就很难被单纯接受。
+
+EFF 的立场是 MV3 的改动会削弱扩展程序开发者因应跟踪技术变化的能力。Vivaldi 那篇文章把规则上限称为 Google 设下的人为限制，那篇文章的结尾写了一句「Perhaps, wise to move away from Chrome?」[^vivaldi]。
+
+## 同一年收掉的另一套计划
+
+Privacy Sandbox 从 2019 年开始，对外的说法是要用一批新技术取代第三方 cookie，让广告投放与效果衡量在不跟踪个人的前提下运作。2024 年 7 月，Google 放弃淘汰第三方 cookie 的原定计划。2025 年 4 月，弹出提示让用户自己选的方案也放弃了。
+
+2025 年 10 月 17 日，Google 退役十项技术，包含 Topics、Protected Audience、Attribution Reporting、IP Protection 与 Related Website Sets，公告写的理由是「After evaluating ecosystem feedback about their expected value and in light of their low levels of adoption」[^ps-retire]。留下来的只有 CHIPS、FedCM、Private State Tokens 三项，官方的说明是这几项获得了广泛采用，包含其他浏览器的支持。第三方 cookie 的部分写得很直接，Chrome 维持现行做法。
+
+同一天，英国竞争与市场管理局解除了 Google 的 Privacy Sandbox 承诺。AdExchanger 的报道写，该机关收到的 15 份咨询回复全部反对解除[^adexchanger]。
+
+六年下来，用户这一侧的拦广告工具被限缩到申报式的规则列表，产业那一侧承诺要取代第三方 cookie 的替代方案收摊，第三方 cookie 留在原地。
+
+## 内置拦截器的代价
+
+Brave Shields、Vivaldi 的内置拦截器、Safari 的 content blocker，走的都是同一个方向，把拦截能力收进浏览器内核。内置之后，扩展程序权限过大的问题就不存在，性能通常也更好。
+
+代价落在控制权上，拦不拦、拦到什么程度、列表多久更新一次，全部由浏览器厂商决定。uBlock Origin 那种逐站的动态过滤、点对点的防火墙式控制、随时换一份列表的自由，在内核内置的模型里通常没有对应物。用户从自行挑选工具、自行调整规则，变成挑一家厂商，接受它的默认值。
+
+差别在极端情况才显现，例如某个跟踪手法刚出现而内置列表还没跟上，或者你想拦的东西刚好是厂商不想拦的。可审计性也跟着变化，开源的扩展程序谁都能读规则、谁都能改，内置功能能不能检查、能不能替换，各家程度不同。
+
+对使用简体中文的用户来说还有一层。浏览器厂商所在的司法管辖区决定了它要听谁的，内置拦截器的过滤列表由厂商维护，要加什么、要拿掉什么，外部不一定看得到。开源的扩展程序加上公开维护的过滤列表，至少变更有记录可查。
+
+## 技术上到底改了什么
+
+### 两个 API 差在哪里
+
+MV2 的 `webRequest` 是拦截式的。浏览器在送出请求之前把完整的请求信息交给扩展程序，由扩展程序的逻辑决定要不要拦。扩展程序能即时改写规则，能取得上下文，能依照标签页当下的状态套用不同规则。
+
+MV3 的 `declarativeNetRequest` 是申报式的。扩展程序事先把规则交给浏览器，比对与拦截由浏览器执行，扩展程序取不到每一个请求的内容。Google 公告写的理由是安全与性能，因为扩展程序不再需要取得每一个网络请求的内容。
+
+规则数量有硬上限，官方文件里的常数包含启用中的静态规则集最多 50 组、保证至少 30,000 条静态规则、动态规则 30,000 条（限安全规则）、不安全的动态规则 5,000 条、正则表达式规则 1,000 条[^dnr]。Google 2024 年 5 月的公告写，回应社区意见后把上限提高到「多达 330,000 个静态规则，再加上动态新增 30,000 个」[^google-phaseout]。早年报道常写的 MV3 只剩 30,000 条规则已经过时，总量确实提高了。
+
+### uBlock Origin Lite 少掉的东西
+
+uBlock Origin 的作者 Raymond Hill 没有把完整版搬到 MV3，另外做了一个 uBlock Origin Lite。项目的 FAQ 里逐条写着 MV3 架构下做不到的能力[^ubol-faq]：
+
+- 动态过滤做不到。`declarativeNetRequest` 无法依照地址栏上的顶层域名强制套用规则
+- 没有逐站的 no remote fonts 与 no scripting 开关
+- 默认模式没有通用的外观过滤（cosmetic filtering），要切到 Complete 模式才有
+- 大量在 uBlock Origin 里很有用的 regex 过滤器不被 API 接受
+- `redirect-rule=`、regex 版本的 `removeparam=`、`replace=`、`ipaddress=`、CNAME 解除伪装全部无法支持
+
+列表更新的方式也跟着改变，FAQ 里写「uBOL never makes network requests to any remote servers」，过滤规则只在扩展程序改版时一并更新。原本一天可以更新好几次、追着广告商的域名变动调整的列表，现在要跟着版本走 Chrome 应用商店的审核流程。Google 在 2024 年推出过针对规则变更的加速审核，公告写这类更新可以在数分钟内通过[^google-phaseout]。
+
+### 绕道的开关逐一被移除
+
+Chromium 的 code review 平台上查得到四笔已合并的变更，移除的都是能让 MV2 重新生效的开关：2025 年 6 月 10 日的 MV2 可用性策略（`6617410`）、2025 年 11 月 4 日的 `allow-legacy-mv2-extensions` 开发者标志（`7113458`）、2026 年 5 月 22 日的 `kExtensionManifestV2Disabled` 功能开关（`7813942`）、2026 年 6 月 4 日的策略处理代码（`7890750`）[^gerrit]。第三笔的 commit message 写的是移除该功能「and the effectively-dead code」。
+
+## 接下来会怎么走
+
+Brave 的 MV2 托管能维持多久，取决于维护成本。Chromium 上游已经没有相关代码，每跟一次上游版本，要自己补的东西就多一点。
+
+Google 广告技术反垄断案的救济措施还没定案，分拆与行为面补救对广告生态的影响差距很大。第三方 cookie 留下来之后，指纹识别与服务器端的识别手法也还在原地。
+
+工具的选择会一直变，判断的方式比较稳定。先确认自己在防谁，再看手上的工具实际拦得到什么，以及这个能力握在谁手上。
+
+## 延伸阅读
+
+- [浏览器指纹是什么，为什么很难摆脱](../../basics/browser-fingerprinting.md)：cookie 删得掉，指纹删不掉，以及各家浏览器的默认状态
+- [Brave 用两种相反的手法抹平 GPU 指纹](./brave-gpu-fingerprinting.md)：内置防护怎么运作，以及它处理不了什么
+- [社群平台怎么收集你的数据](../../basics/platform-tracking.md)：广告跟踪在整套生态里的位置
+- [威胁模型如何建立](../../basics/threat-model.md)：先确认在防谁，再选工具
+- [你的浏览器透露了什么](../../utils/leaks.md)：当场看一次自己的浏览器回报了哪些信息
+
+[^chrome-timeline]: [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline){target="_blank"} - Chrome for Developers。本文时间线表格的所有日期、Chrome 138 与 139 的角色、2026 年 8 月 31 日的下架说明皆出自此页。查证日 2026-09-01。
+[^gerrit]: Chromium code review，四笔变更依序为 [`6617410`](https://chromium-review.googlesource.com/c/chromium/src/+/6617410){target="_blank"}、[`7113458`](https://chromium-review.googlesource.com/c/chromium/src/+/7113458){target="_blank"}、[`7813942`](https://chromium-review.googlesource.com/c/chromium/src/+/7813942){target="_blank"}、[`7890750`](https://chromium-review.googlesource.com/c/chromium/src/+/7890750){target="_blank"}。合并日期与 commit message 取自 Gerrit API。查证日 2026-09-01。
+[^dnr]: [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest){target="_blank"} - Chrome for Developers。规则数量上限的常数定义出自此页。查证日 2026-09-01。
+[^google-phaseout]: [Manifest V2 phase-out begins](https://blog.google/chromium/manifest-v2-phase-out-begins/){target="_blank"} - Chromium 官方博客，2024 年 5 月。330,000 静态规则、30,000 动态规则与加速审核的说明出自此文。查证日 2026-09-01。
+[^ubol-faq]: [uBlock Origin Lite FAQ](https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)){target="_blank"} - uBlock Origin Lite 项目 wiki。MV3 底下无法支持的能力清单与列表更新方式出自此页。uBlock Origin 的官方入口是 [gorhill/uBlock](https://github.com/gorhill/uBlock){target="_blank"}。查证日 2026-09-01。
+[^edge]: [Moving the Microsoft Edge extensions ecosystem forward with Manifest Version 3](https://blogs.windows.com/msedgedev/2026/08/07/moving-the-microsoft-edge-extensions-ecosystem-forward-with-manifest-version-3/){target="_blank"} - Microsoft Edge 博客，2026 年 8 月 7 日。消费者版与企业版的时间表出自此文。查证日 2026-09-01。
+[^mozilla]: [Mozilla's approach to Manifest V3](https://blog.mozilla.org/en/firefox/firefox-manifest-v3-adblockers/){target="_blank"} - The Mozilla Blog，2025 年 2 月 25 日。Firefox 同时保留两个 API 的说明出自此文。查证日 2026-09-01。
+[^vivaldi]: [Manifest V3, webRequest, and ad blockers](https://vivaldi.com/blog/manifest-v3-webrequest-and-ad-blockers/){target="_blank"} - Vivaldi 博客，2022 年 9 月 23 日，2024 年 6 月更新。内置拦截器的实现方式与对规则上限的批评出自此文。查证日 2026-09-01。
+[^adblock-rust]: [Brave Improves Its Ad-Blocker Performance by 69x with New Engine Implementation in Rust](https://brave.com/blog/improved-ad-blocker-performance/){target="_blank"} 与 [brave/adblock-rust](https://github.com/brave/adblock-rust){target="_blank"}。引擎的实现与支持的过滤语法出自这两处。查证日 2026-09-01。
+[^brave-mv3]: [What Manifest V3 means for Brave Shields and the use of extensions in the Brave browser](https://brave.com/blog/brave-shields-manifest-v3/){target="_blank"} - Brave 官方博客。Shields 与扩展平台无关的说明、四个托管的扩展程序、`v1.81` 的时点与支持期限的措辞皆出自此文。查证日 2026-09-01。
+[^brave-issue]: [Auto-replace known Web Store MV2 extensions with Brave-hosted equivalents](https://github.com/brave/brave-browser/issues/56654){target="_blank"} - brave-browser issue `56654`，里程碑 `1.92.x`。自动迁移的行为描述出自此 issue，设置页默认启用另见 issue [`56799`](https://github.com/brave/brave-browser/issues/56799){target="_blank"}。查证日 2026-09-01。
+[^piunika]: [Latest Brave Beta hints at Manifest V2 support drop](https://piunikaweb.com/2026/06/26/latest-brave-beta-manifest-support-drop/){target="_blank"} - PiunikaWeb，2026 年 6 月 26 日。beta 版设置页变空的描述出自此篇报道，Brave 官方未就该次变动发表说明。查证日 2026-09-01。
+[^ps-retire]: [Update on plans for Privacy Sandbox technologies](https://privacysandbox.google.com/blog/update-on-plans-for-privacy-sandbox-technologies){target="_blank"} - Privacy Sandbox 官方公告，2025 年 10 月 17 日。退役的十项技术、保留的三项与第三方 cookie 的处置出自此文。查证日 2026-09-01。
+[^adexchanger]: [Google Pulls The Plug On Topics, PAAPI And Other Major Privacy Sandbox APIs (As The CMA Says 'Cheerio')](https://www.adexchanger.com/privacy/google-pulls-the-plug-on-topics-paapi-and-other-major-privacy-sandbox-apis-as-the-cma-says-cheerio/){target="_blank"} - AdExchanger，2025 年 10 月。英国 CMA 解除承诺与 15 份反对回复的数字出自此篇报道。查证日 2026-09-01。
+[^tor-addons]: [Should I install a new add-on or extension in Tor Browser, like AdBlock Plus or uBlock Origin?](https://support.torproject.org/tbb/tbb-14/){target="_blank"} - Tor Project 支持文件。不建议安装扩展程序的理由出自此页。查证日 2026-09-01。
+[^librewolf-features]: [LibreWolf Features](https://librewolf.net/docs/features/){target="_blank"} - LibreWolf 官方文件。内置 uBlock Origin 与过滤列表、Tracking Protection strict 模式、Total Cookie Protection、停用遥测、启用 RFP 的说明皆出自此页。查证日 2026-09-02。
+[^librewolf-faq]: [LibreWolf FAQ](https://librewolf.net/docs/faq/){target="_blank"} - LibreWolf 官方文件。更新节奏与无自动更新、无 Android 版与 IronFox 的建议、不建议搭配 Tor 使用的说明皆出自此页。查证日 2026-09-02。

--- a/docs/zh-TW/blog/posts/ublock-origin-mv3.md
+++ b/docs/zh-TW/blog/posts/ublock-origin-mv3.md
@@ -1,0 +1,193 @@
+---
+date: 2026-09-01
+authors:
+    - anoni-net
+categories:
+    - 技術
+    - 隱私
+slug: ublock-origin-mv3
+summary: "Chrome 使用者已經裝不回完整版的 uBlock Origin。Firefox、LibreWolf 與 Brave 各用不同方式留住它，Google 則在同一年收掉了取代第三方 cookie 的整套計畫"
+description: "完整版 uBlock Origin 為什麼不能在 Chrome 使用，Firefox、Brave 與 LibreWolf 分別用什麼方式留住它，以及擋廣告從擴充功能搬進瀏覽器核心之後，使用者失去了什麼。"
+---
+
+# :material-shield-off-outline: 完整版 uBlock Origin 已經無法在 Chrome 使用
+
+Chrome 使用者現在裝不回完整版的 uBlock Origin。2026 年 8 月 31 日，Chrome Web Store 移除最後一批 Manifest V2 擴充功能[^chrome-timeline]，uBlock Origin 是其中一個。已經裝在舊版 Chrome 上的還留著，但無法再更新，移除之後也裝不回來。
+
+Manifest 是 Google 替 Chrome 擴充功能訂的規格，決定擴充功能能做哪些事。第二版讓擴充功能在網頁載入前逐一檢查每個連線請求，當場決定要不要擋。第三版改成事先申報一份規則清單，比對與攔截交給瀏覽器執行。廣告攔截器原本靠第二版的做法運作。
+
+過程走了四年多，從 2022 年初停收新的 MV2 擴充功能開始，到 2025 年 7 月全面停用，再到今年 8 月的下架。每一步都有公開文件與時程表。
+
+2025 年 10 月 17 日，Google 退役十項 Privacy Sandbox 技術[^ps-retire]，原本要用來取代第三方 cookie 的整套計畫收在那一天。第三方 cookie 繼續留在 Chrome 裡。
+
+規則上限與 API 差異整理在文章後半，只想知道該換什麼工具的讀者可以直接跳過。
+
+<!-- more -->
+
+## 四年的退場過程
+
+| 日期 | 發生什麼 |
+|------|----------|
+| 2022 年 1 月與 6 月 | Chrome Web Store 停收新的 MV2 擴充功能 |
+| 2024 年 6 月 3 日 | Beta、Dev、Canary 開始顯示警告橫幅 |
+| 2024 年 10 月 9 日 | Chrome stable 分批停用已安裝的 MV2 擴充功能，企業政策可豁免到 2025 年 6 月 |
+| 2025 年 3 月 31 日 | 全頻道預設停用，使用者仍可手動開回 |
+| 2025 年 7 月 24 日 | Chrome 138 起一律停用且無法開回，企業政策在 Chrome 139 移除 |
+| 2026 年 8 月 31 日 | Chrome Web Store 移除所有剩餘的 MV2 擴充功能 |
+
+## 各家瀏覽器分成三條路
+
+| 瀏覽器 | 完整版 uBlock Origin | 靠什麼 |
+|--------|-----------|--------|
+| Chrome | 不能用 | MV2 程式碼已從 Chromium 移除，只剩 uBlock Origin Lite |
+| Edge | 退場中 | 消費者版 2026 年底完成，企業版 2027 年初 |
+| Firefox | 可以用 | Gecko 引擎保留攔截式的 `webRequest`，MV3 也保留 |
+| LibreWolf | 可以用 | Firefox 分支，安裝時就內建 uBlock Origin |
+| Brave | 可以用 | 自架伺服器託管四個 MV2 擴充功能 |
+| Safari | 不能用 | WebKit 的 content blocker 是申報式，uBlock Origin 在 Safari 13 之後就沒有支援 |
+
+Microsoft 在 2026 年 8 月 7 日的公告寫，Edge 的消費者版 MV2 退場「Beginning in August 2026」開始，目標「complete the consumer transition by the end of 2026」，企業版接在 2027 年初[^edge]。公告寫的理由是 MV3 在安全與效能上優於 MV2，全文沒有提到 uBlock Origin。
+
+Firefox 有自己的引擎，MV3 由 Mozilla 自行實作，官方文章寫 Firefox「will continue supporting both blockingWebRequest and declarativeNetRequest」[^mozilla]。兩個 API 都在，擴充功能作者可以選。
+
+Vivaldi 與 Opera 屬於 Chromium 系。Vivaldi 的內建攔截器接的是 Chromium 內部 API，不受 MV3 影響，2022 年那篇說明文章的措辭是，如果有簡單的方法讓 `webRequest` 繼續運作一段時間會考慮，沒有做出承諾[^vivaldi]。上游已經沒有 MV2 程式碼，任何跟隨上游的分支要繼續支援，都得自己維護修改。
+
+## 你現在可以怎麼選
+
+### 瀏覽器層
+
+Firefox 是最直接的選擇，完整版 uBlock Origin 在桌面與 Android 都能裝，安裝之後預設的過濾清單就夠用。
+
+Brave 內建的 Shields 安裝後就生效，需要進階控制時再從 `brave://settings/extensions/v2` 裝 MV2 版的 uBlock Origin。要注意該專案的說明文件明確寫不要同時使用兩個內容攔截器，兩個一起開可能互相干擾。
+
+留在 Chrome 的人，uBlock Origin Lite 擋得掉大部分廣告，動態控制與即時的清單更新沒有了。
+
+### LibreWolf 適合什麼樣的人
+
+LibreWolf 是 Firefox 的社群分支，把隱私設定預先調好再打包出貨。官方功能頁寫的預設值包含內建 uBlock Origin 並配好過濾清單、Tracking Protection 開在 strict 模式、Total Cookie Protection、完全停用遙測，以及啟用 RFP（Resist Fingerprinting）這項來自 Tor Uplift 專案的指紋防護[^librewolf-features]。裝完直接使用就有一整套設定，省去自行研究 `about:config` 的工夫。
+
+RFP 會讓一部分網站顯示異常，canvas 存取需要逐站允許，語言統一回報成 en-US，視窗尺寸也被對齊。LibreWolf 也沒有自動更新功能，官方 FAQ 寫更新「relies on package managers or users to apply them」，跟上 Firefox 穩定版通常在三天內，有時同一天[^librewolf-faq]。安全性更新要自己記得裝，或交給套件管理員。Android 使用者則沒有這個選項，官方 FAQ 寫目前沒有人在開發，可改用 IronFox[^librewolf-faq]。
+
+適合的是願意接受偶爾網站顯示異常、也會固定更新的桌面使用者。不想處理更新節奏的人留在 Firefox 自行安裝，實際防護差距不大。
+
+Mullvad Browser 是另一個選項，由 Mullvad 與 Tor Project 合作開發，等於拿掉 Tor 網路的 Tor Browser，預設內建 uBlock Origin，用 letterboxing 之類的手法讓所有使用者的指紋看起來相近，支援 Linux、macOS 與 Windows。它走的是一致化路線，網站顯示異常的機率比 LibreWolf 更高一些。
+
+LibreWolf 與 Mullvad Browser 都不要拿來連 Tor。LibreWolf 的官方 FAQ 在這一題底下寫的是「Please don't」，要匿名就用 Tor Browser[^librewolf-faq]。
+
+### DNS 層
+
+NextDNS、AdGuard DNS、自架的 Pi-hole 都屬於這一層。優點是整台裝置或整個網路一次生效，手機 app 裡的廣告也擋得到。界線很清楚，DNS 層依據的只有網域，處理不了同一個網域下的內容，也做不到外觀過濾。廣告與內容來自同一個網域的情況擋不下來。
+
+### 系統層
+
+AdGuard 桌面版與 iOS 上的 content blocker app 屬於這一層。桌面版通常需要安裝本機憑證來檢查加密流量，取捨在於，等於把一個能讀取所有 HTTPS 內容的元件裝進系統。
+
+### 行動裝置
+
+Android 上的 Firefox 支援完整版 uBlock Origin，在手機瀏覽器裡算少見。iOS 因為系統限制沒有這個選項，只剩 Safari 的 content blocker app 或 DNS 層方案。
+
+## 用 Tor Browser 的人不要裝
+
+Tor Project 的支援文件寫得很直接，強烈不建議在 Tor Browser 裡安裝新的擴充功能，包含 AdBlock Plus 與 uBlock Origin，理由是「Installing new add-ons may affect Tor Browser in unforeseen ways and potentially make your Tor Browser fingerprint unique」[^tor-addons]。
+
+Tor Browser 的防護建立在所有使用者長得一樣，多裝一個擴充功能就是把自己從人群裡挑出來。內建的 NoScript 是唯一經過測試的那一個。
+
+擋掉廣告請求不會讓你在指紋上變得不顯眼，擋廣告與抗指紋是兩件不同的事，工具裝得越多，指紋反而越獨特。兩者的關係見 [瀏覽器指紋是什麼，為什麼很難擺脫](../../basics/browser-fingerprinting.md)。
+
+## Brave 的兩層防護
+
+Brave Shields 是瀏覽器內建的攔截器，用 Rust 寫的 `adblock-rust` 引擎，直接修改在 Chromium 上。引擎讀取的是 EasyList、EasyPrivacy 那一套 Adblock Plus 語法的清單，支援外觀過濾與 scriptlet 注入[^adblock-rust]。Brave 的公告裡寫 Shields「don't rely on MV2 _or_ MV3」[^brave-mv3]，擴充功能平台怎麼改都影響不到它。
+
+擴充功能是另外一層，Brave 從 `v1.81` 起在自家後端託管 AdGuard、uBlock Origin、uMatrix、NoScript 四個 MV2 擴充功能，使用者從 `brave://settings/extensions/v2` 頁面安裝，這幾份與 Chrome Web Store 上的版本各自獨立[^brave-mv3]。`v1.92` 新增自動遷移，專案的 issue `56654` 描述的行為是偵測已安裝的 Web Store MV2 擴充功能、備份設定、換裝 Brave 託管的對應版本[^brave-issue]。同一個里程碑把該設定頁改成預設啟用。Brave 的 stable 版在 2026 年 9 月已經到 `v1.96`，兩項變更都在正式版裡。
+
+Brave 的公告寫的支援期限是「For as long as we're able (and assuming the cooperation of the extension authors)」，同一篇也寫，如果擴充功能過時或停止維護，Brave 可能會移除支援，理由是不想提供過時、甚至不安全的版本[^brave-mv3]。
+
+2026 年 6 月有報導寫，Brave beta 的 MV2 設定頁變成空清單，擴充功能全部消失，同版本的 nightly 正常，stable 沒有受影響[^piunika]。Brave 在 8 月的貼文裡重申會繼續支援。
+
+使用者原本從 Chrome Web Store 取得更新，現在從 Brave 的伺服器取得。更新來源、版本節奏、要不要繼續支援，決定權都在 Brave 手上。Brave 在 2020 年被發現在使用者輸入的加密貨幣交易所網址後面自動加上自家的推薦碼，執行長公開道歉並移除該行為。Brave Rewards、BAT 代幣與內建錢包都是選擇性啟用的功能，用自家廣告系統取代 Google 廣告系統這個商業模式本身，在隱私社群裡一直有爭論。
+
+## Google 的安全理由與廣告生意
+
+Google 在安全上的論點成立，擴充功能能取得並改寫每一個網路請求，一旦被入侵或本來就是惡意的，能做的事很多。2025 到 2026 年之間公開的事件包含一波從釣魚取得 OAuth 授權開始的供應鏈攻擊，波及超過 30 個擴充功能、約 260 萬名使用者，另有竊取 AI 對話內容的擴充功能影響約 90 萬人。
+
+Chrome 在 2026 年握有全球約 65% 的瀏覽器市佔，桌面約 70%。制定擴充功能平台規則的公司，同時是全球最大的廣告公司，2025 年 4 月已經被美國聯邦法院認定在發布商廣告伺服器與廣告交易所市場違法壟斷，救濟措施到現在還沒定案。同一家公司同時決定規則與販售廣告，以安全為名的限縮就很難被單純接受。
+
+EFF 的立場是 MV3 的改動會削弱擴充功能開發者因應追蹤技術變化的能力。Vivaldi 那篇文章把規則上限稱為 Google 設下的人為限制，那篇文章的結尾寫了一句「Perhaps, wise to move away from Chrome?」[^vivaldi]。
+
+## 同一年收掉的另一套計畫
+
+Privacy Sandbox 從 2019 年開始，對外的說法是要用一批新技術取代第三方 cookie，讓廣告投放與成效衡量在不追蹤個人的前提下運作。2024 年 7 月，Google 放棄淘汰第三方 cookie 的原定計畫。2025 年 4 月，跳出提示讓使用者自己選的方案也放棄了。
+
+2025 年 10 月 17 日，Google 退役十項技術，包含 Topics、Protected Audience、Attribution Reporting、IP Protection 與 Related Website Sets，公告寫的理由是「After evaluating ecosystem feedback about their expected value and in light of their low levels of adoption」[^ps-retire]。留下來的只有 CHIPS、FedCM、Private State Tokens 三項，官方的說明是這幾項獲得了廣泛採用，包含其他瀏覽器的支援。第三方 cookie 的部分寫得很直接，Chrome 維持現行做法。
+
+同一天，英國競爭與市場管理局解除了 Google 的 Privacy Sandbox 承諾。AdExchanger 的報導寫，該機關收到的 15 份諮詢回覆全部反對解除[^adexchanger]。
+
+六年下來，使用者這一側的擋廣告工具被限縮到申報式的規則清單，產業那一側承諾要取代第三方 cookie 的替代方案收攤，第三方 cookie 留在原地。
+
+## 內建攔截器的代價
+
+Brave Shields、Vivaldi 的內建攔截器、Safari 的 content blocker，走的都是同一個方向，把攔截能力收進瀏覽器核心。內建之後，擴充功能權限過大的問題就不存在，效能通常也更好。
+
+代價落在控制權上，擋不擋、擋到什麼程度、清單多久更新一次，全部由瀏覽器廠商決定。uBlock Origin 那種逐站的動態過濾、點對點的防火牆式控制、隨時換一份清單的自由，在核心內建的模型裡通常沒有對應物。使用者從自行挑選工具、自行調整規則，變成挑一家廠商，接受它的預設值。
+
+差別在極端情況才顯現，例如某個追蹤手法剛出現而內建清單還沒跟上，或者你想擋的東西剛好是廠商不想擋的。可稽核性也跟著變化，開源的擴充功能誰都能讀規則、誰都能改，內建功能能不能檢查、能不能替換，各家程度不同。
+
+## 技術上到底改了什麼
+
+### 兩個 API 差在哪裡
+
+MV2 的 `webRequest` 是攔截式的。瀏覽器在送出請求之前把完整的請求資訊交給擴充功能，由擴充功能的邏輯決定要不要擋。擴充功能能即時改寫規則，能取得上下文，能依照分頁當下的狀態套用不同規則。
+
+MV3 的 `declarativeNetRequest` 是申報式的。擴充功能事先把規則交給瀏覽器，比對與攔截由瀏覽器執行，擴充功能取不到每一個請求的內容。Google 公告寫的理由是安全與效能，因為擴充功能不再需要取得每一個網路請求的內容。
+
+規則數量有硬上限，官方文件裡的常數包含啟用中的靜態規則集最多 50 組、保證至少 30,000 條靜態規則、動態規則 30,000 條（限安全規則）、不安全的動態規則 5,000 條、正規表達式規則 1,000 條[^dnr]。Google 2024 年 5 月的公告寫，回應社群意見後把上限提高到「多達 330,000 個靜態規則，再加上動態新增 30,000 個」[^google-phaseout]。早年報導常寫的 MV3 只剩 30,000 條規則已經過時，總量確實提高了。
+
+### uBlock Origin Lite 少掉的東西
+
+uBlock Origin 的作者 Raymond Hill 沒有把完整版搬到 MV3，另外做了一個 uBlock Origin Lite。專案的 FAQ 裡逐條寫著 MV3 架構下做不到的能力[^ubol-faq]：
+
+- 動態過濾做不到。`declarativeNetRequest` 無法依照網址列上的頂層網域強制套用規則
+- 沒有逐站的 no remote fonts 與 no scripting 開關
+- 預設模式沒有通用的外觀過濾（cosmetic filtering），要切到 Complete 模式才有
+- 大量在 uBlock Origin 裡很有用的 regex 過濾器不被 API 接受
+- `redirect-rule=`、regex 版本的 `removeparam=`、`replace=`、`ipaddress=`、CNAME 解除偽裝全部無法支援
+
+清單更新的方式也跟著改變，FAQ 裡寫「uBOL never makes network requests to any remote servers」，過濾規則只在擴充功能改版時一併更新。原本一天可以更新好幾次、追著廣告商的網域變動調整的清單，現在要跟著版本走 Chrome Web Store 的審查流程。Google 在 2024 年推出過針對規則變更的加速審查，公告寫這類更新可以在數分鐘內通過[^google-phaseout]。
+
+### 繞道的開關逐一被移除
+
+Chromium 的 code review 平台上查得到四筆已合併的變更，移除的都是能讓 MV2 重新生效的開關：2025 年 6 月 10 日的 MV2 可用性政策（`6617410`）、2025 年 11 月 4 日的 `allow-legacy-mv2-extensions` 開發者旗標（`7113458`）、2026 年 5 月 22 日的 `kExtensionManifestV2Disabled` 功能開關（`7813942`）、2026 年 6 月 4 日的政策處理程式碼（`7890750`）[^gerrit]。第三筆的 commit message 寫的是移除該功能「and the effectively-dead code」。
+
+## 接下來會怎麼走
+
+Brave 的 MV2 託管能維持多久，取決於維護成本。Chromium 上游已經沒有相關程式碼，每跟一次上游版本，要自己補的東西就多一點。
+
+Google 廣告技術反壟斷案的救濟措施還沒定案，分拆與行為面補救對廣告生態的影響差距很大。第三方 cookie 留下來之後，指紋識別與伺服器端的識別手法也還在原地。
+
+工具的選擇會一直變，判斷的方式比較穩定。先確認自己在防誰，再看手上的工具實際擋得到什麼，以及這個能力握在誰手上。
+
+## 延伸閱讀
+
+- [瀏覽器指紋是什麼，為什麼很難擺脫](../../basics/browser-fingerprinting.md)：cookie 刪得掉，指紋刪不掉，以及各家瀏覽器的預設狀態
+- [Brave 用兩種相反的手法抹平 GPU 指紋](./brave-gpu-fingerprinting.md)：內建防護怎麼運作，以及它處理不了什麼
+- [社群平台怎麼收集你的資料](../../basics/platform-tracking.md)：廣告追蹤在整套生態裡的位置
+- [威脅模型如何建立](../../basics/threat-model.md)：先確認在防誰，再選工具
+- [你的瀏覽器透露了什麼](../../utils/leaks.md)：當場看一次自己的瀏覽器回報了哪些資訊
+
+[^chrome-timeline]: [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline){target="_blank"} - Chrome for Developers。本文時間線表格的所有日期、Chrome 138 與 139 的角色、2026 年 8 月 31 日的下架說明皆出自此頁。查證日 2026-09-01。
+[^gerrit]: Chromium code review，四筆變更依序為 [`6617410`](https://chromium-review.googlesource.com/c/chromium/src/+/6617410){target="_blank"}、[`7113458`](https://chromium-review.googlesource.com/c/chromium/src/+/7113458){target="_blank"}、[`7813942`](https://chromium-review.googlesource.com/c/chromium/src/+/7813942){target="_blank"}、[`7890750`](https://chromium-review.googlesource.com/c/chromium/src/+/7890750){target="_blank"}。合併日期與 commit message 取自 Gerrit API。查證日 2026-09-01。
+[^dnr]: [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest){target="_blank"} - Chrome for Developers。規則數量上限的常數定義出自此頁。查證日 2026-09-01。
+[^google-phaseout]: [Manifest V2 phase-out begins](https://blog.google/chromium/manifest-v2-phase-out-begins/){target="_blank"} - Chromium 官方部落格，2024 年 5 月。330,000 靜態規則、30,000 動態規則與加速審查的說明出自此文。查證日 2026-09-01。
+[^ubol-faq]: [uBlock Origin Lite FAQ](https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)){target="_blank"} - uBlock Origin Lite 專案 wiki。MV3 底下無法支援的能力清單與清單更新方式出自此頁。uBlock Origin 的官方入口是 [gorhill/uBlock](https://github.com/gorhill/uBlock){target="_blank"}。查證日 2026-09-01。
+[^edge]: [Moving the Microsoft Edge extensions ecosystem forward with Manifest Version 3](https://blogs.windows.com/msedgedev/2026/08/07/moving-the-microsoft-edge-extensions-ecosystem-forward-with-manifest-version-3/){target="_blank"} - Microsoft Edge 部落格，2026 年 8 月 7 日。消費者版與企業版的時程出自此文。查證日 2026-09-01。
+[^mozilla]: [Mozilla's approach to Manifest V3](https://blog.mozilla.org/en/firefox/firefox-manifest-v3-adblockers/){target="_blank"} - The Mozilla Blog，2025 年 2 月 25 日。Firefox 同時保留兩個 API 的說明出自此文。查證日 2026-09-01。
+[^vivaldi]: [Manifest V3, webRequest, and ad blockers](https://vivaldi.com/blog/manifest-v3-webrequest-and-ad-blockers/){target="_blank"} - Vivaldi 部落格，2022 年 9 月 23 日，2024 年 6 月更新。內建攔截器的實作方式與對規則上限的批評出自此文。查證日 2026-09-01。
+[^adblock-rust]: [Brave Improves Its Ad-Blocker Performance by 69x with New Engine Implementation in Rust](https://brave.com/blog/improved-ad-blocker-performance/){target="_blank"} 與 [brave/adblock-rust](https://github.com/brave/adblock-rust){target="_blank"}。引擎的實作與支援的過濾語法出自這兩處。查證日 2026-09-01。
+[^brave-mv3]: [What Manifest V3 means for Brave Shields and the use of extensions in the Brave browser](https://brave.com/blog/brave-shields-manifest-v3/){target="_blank"} - Brave 官方部落格。Shields 與擴充功能平台無關的說明、四個託管的擴充功能、`v1.81` 的時點與支援期限的措辭皆出自此文。查證日 2026-09-01。
+[^brave-issue]: [Auto-replace known Web Store MV2 extensions with Brave-hosted equivalents](https://github.com/brave/brave-browser/issues/56654){target="_blank"} - brave-browser issue `56654`，里程碑 `1.92.x`。自動遷移的行為描述出自此 issue，設定頁預設啟用另見 issue [`56799`](https://github.com/brave/brave-browser/issues/56799){target="_blank"}。查證日 2026-09-01。
+[^piunika]: [Latest Brave Beta hints at Manifest V2 support drop](https://piunikaweb.com/2026/06/26/latest-brave-beta-manifest-support-drop/){target="_blank"} - PiunikaWeb，2026 年 6 月 26 日。beta 版設定頁變空的描述出自此篇報導，Brave 官方未就該次變動發表說明。查證日 2026-09-01。
+[^ps-retire]: [Update on plans for Privacy Sandbox technologies](https://privacysandbox.google.com/blog/update-on-plans-for-privacy-sandbox-technologies){target="_blank"} - Privacy Sandbox 官方公告，2025 年 10 月 17 日。退役的十項技術、保留的三項與第三方 cookie 的處置出自此文。查證日 2026-09-01。
+[^adexchanger]: [Google Pulls The Plug On Topics, PAAPI And Other Major Privacy Sandbox APIs (As The CMA Says 'Cheerio')](https://www.adexchanger.com/privacy/google-pulls-the-plug-on-topics-paapi-and-other-major-privacy-sandbox-apis-as-the-cma-says-cheerio/){target="_blank"} - AdExchanger，2025 年 10 月。英國 CMA 解除承諾與 15 份反對回覆的數字出自此篇報導。查證日 2026-09-01。
+[^tor-addons]: [Should I install a new add-on or extension in Tor Browser, like AdBlock Plus or uBlock Origin?](https://support.torproject.org/tbb/tbb-14/){target="_blank"} - Tor Project 支援文件。不建議安裝擴充功能的理由出自此頁。查證日 2026-09-01。
+[^librewolf-features]: [LibreWolf Features](https://librewolf.net/docs/features/){target="_blank"} - LibreWolf 官方文件。內建 uBlock Origin 與過濾清單、Tracking Protection strict 模式、Total Cookie Protection、停用遙測、啟用 RFP 的說明皆出自此頁。查證日 2026-09-02。
+[^librewolf-faq]: [LibreWolf FAQ](https://librewolf.net/docs/faq/){target="_blank"} - LibreWolf 官方文件。更新節奏與無自動更新、無 Android 版與 IronFox 的建議、不建議搭配 Tor 使用的說明皆出自此頁。查證日 2026-09-02。

--- a/docs/zh-TW/blog/posts/ublock-origin-mv3.md
+++ b/docs/zh-TW/blog/posts/ublock-origin-mv3.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-09-01
+date: 2026-09-09
 authors:
     - anoni-net
 categories:


### PR DESCRIPTION
## 這篇在寫什麼

Chrome Web Store 在 2026-08-31 移除最後一批 Manifest V2 擴充功能，完整版 uBlock Origin 在 Chrome 到此為止。文章合併報導與評論兩種取向，讀者設定為非技術背景。

網址會是 `https://anoni.net/docs/blog/2026/09/ublock-origin-mv3/`。

## 結構

實用內容排在前面，技術細節收在文末，只想知道該換什麼工具的讀者可以跳過後半。

- 四年的退場時間線
- 各家瀏覽器現況，Chrome、Edge、Firefox、LibreWolf、Brave、Safari
- 分層的替代選擇，瀏覽器層、DNS 層、系統層、行動裝置各自擋得到什麼
- LibreWolf 單獨一節，預設值、三項代價、適合什麼樣的人
- 用 Tor Browser 的人不要裝擴充功能
- Brave 的兩層防護，Shields 與自架 MV2 託管的機制與風險
- Google 的安全理由與廣告生意
- 同一年 Google 退役十項 Privacy Sandbox 技術，第三方 cookie 留在 Chrome
- 內建攔截器的代價
- 技術細節，兩個 API 的差別、uBlock Origin Lite 少掉的能力、繞道的開關逐一被移除

## 查證

14 條註腳全部指向一手來源，包含 Chrome 的 MV2 時間線與 declarativeNetRequest 文件、Microsoft Edge 與 Mozilla 的官方公告、Brave 的部落格與兩個 GitHub issue、uBlock Origin Lite 專案 FAQ、LibreWolf 的 features 與 FAQ、Privacy Sandbox 退役公告、Tor Project 支援文件。

Chromium 移除 MV2 開關的四筆變更用 Gerrit API 查過編號、合併日期與 commit message，沒有引用媒體推算的版本對應。

兩處二手來源在文中標明出處：AdExchanger 對 CMA 解除承諾的報導、PiunikaWeb 對 Brave beta 中斷的報導。

## 檢查

- `python3 tools/docs_style_lint.py`：0 error、0 warn
- `mkdocs build -s`：exit 0，五條站內連結解析正確
- 「這」3.2、「那」2.4（每千漢字），無同句堆疊
- 標題無冒號句構、無逗號，段落開頭無短句斷句，擬人用法逐條改過

## 後續

三語系翻譯與 SNS 草稿還沒做。合併進 `main` 之後要另外推 `docs` 分支才會發布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)