### PR TITLE
feat(changelog): 補上 Tor Browser 15.0.21

### DIFF
--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -28,6 +28,16 @@ Since 16.0a6 (May 2026) the alpha channel has been based on Firefox betas, rebas
 - Updated NoScript to 13.6.31.90301984 and OpenSSL to 3.5.8.
 - `about:torconnect` now reports an error when the tor daemon crashes (tor-browser#43570), and bridge settings update when a connection fails (tor-browser#43939).
 
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes.
+- Rebased the Firefox base onto 140.15.0esr (tor-browser#45253), with Android GeckoView following, and backported security fixes from Firefox 155 (tor-browser#45259).
+- Fixed `about:torconnect` not appearing when the browser starts outside private browsing mode (tor-browser#45223). TorConnect redirections now go through the parent process (tor-browser#45264).
+- NoScript updated to 13.6.32.1984, OpenSSL to 3.5.8, and Go to 1.25.14 in the build toolchain.
+- Upstream switched the 32-bit Linux notice to the expired-version message, and the tracking item states this is the final 15.0 release (tor-browser#44996). Per the plan announced with 16.0a9, the 16.0 stable series takes over in September, so anyone on 15.x can start preparing to move.
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -28,6 +28,16 @@ Alpha 从 16.0a6（2026 年 5 月）起改以 Firefox beta 为基底，逐版小
 - NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
 - tor daemon 崩溃时，`about:torconnect` 会显示错误信息（tor-browser#43570）。网桥连接失败时也会更新网桥设置的显示（tor-browser#43939）。
 
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本。
+- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，并从 Firefox 155 backport 安全修补（tor-browser#45259）。
+- 修好在非隐私浏览模式启动浏览器时 `about:torconnect` 不显示的问题（tor-browser#45223）。TorConnect 的重定向改由父进程处理（tor-browser#45264）。
+- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，构建工具链的 Go 升至 1.25.14。
+- 上游把 32 位 Linux 的提示改成版本过期消息，跟踪项目写明这是 15.0 系列的最后一版（tor-browser#44996）。16.0 稳定版依 16.0a9 公告的规划在 9 月接手，还在 15.x 的人可以准备换过去。
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -28,6 +28,16 @@ Alpha 從 16.0a6（2026 年 5 月）起改以 Firefox beta 為基底，逐版小
 - NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
 - tor daemon 崩潰時，`about:torconnect` 會顯示錯誤訊息（tor-browser#43570）。橋接連線失敗時也會更新橋接設定的顯示（tor-browser#43939）。
 
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本。
+- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，並從 Firefox 155 backport 安全修補（tor-browser#45259）。
+- 修好在非隱私瀏覽模式啟動瀏覽器時 `about:torconnect` 不顯示的問題（tor-browser#45223）。TorConnect 的重導改由父行程處理（tor-browser#45264）。
+- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，建置工具鏈的 Go 升至 1.25.14。
+- 上游把 32 位元 Linux 的提示改成版本過期訊息，追蹤項目寫明這是 15.0 系列的最後一版（tor-browser#44996）。16.0 穩定版依 16.0a9 公告的規劃在 9 月接手，還在 15.x 的人可以準備換過去。
+
 ## Tor Browser 15.0.20
 
 > 2026-08-18 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15020/){target="_blank"}


### PR DESCRIPTION
## 全面查過，只有這一則要補

檢查十二頁對應的上游，只有 Tor Browser 有新版：

| 上游 | 站上最新 | 上游最新 | 狀態 |
|---|---|---|---|
| Tor Browser | 15.0.20 | **15.0.21（09-01）** | 補上 |
| tor daemon | 0.4.9.11 | 0.4.9.11 | 一致 |
| Snowflake / lyrebird / WebTunnel | 2.14.1 / 0.8.1 / 0.0.6 | 同左 | 一致 |
| Arti | 2.6.0 | 2.6.0 | 一致 |
| OONI Probe / CLI | 6.2.0 / v3.30.0 | 同左 | 一致 |
| OnionShare | 2.6.5 | 2.6.5 | 一致 |
| Tails | 7.11 | 7.11 | 一致 |
| Apple iOS / macOS | 08-17 那批 | 同左 | 一致 |
| GrapheneOS | 2026081300 | 2026081300 | 一致 |
| Android | 2026-08 | 9 月公告未發（404） | 等 |
| Windows | 2026-08 | 9 月 Patch Tuesday 在 9/8 | 等 |

## 15.0.21 值得寫的地方

內容本身是例行的 Firefox 安全修補（基底到 140.15.0esr，另從 Firefox 155 backport），但 changelog 裡有一條 `tor-browser#44996`：把 32 位元 Linux 的提示改成版本過期訊息，標題明寫 **for the final 15.0 release**。

也就是說 15.0.21 是 15.0 系列的最後一版。對照 16.0a9 公告裡「目標讓 16.0 穩定版於 9 月提前發布」的規劃，時間點吻合。條目直接告訴還在 15.x 的人可以準備換過去。

這種換代訊息藏在 bug 標題裡，公告正文只寫「This version includes important security updates to Firefox」，不逐條看 changelog 會漏掉。

## 驗證

- `docs_style_lint.py` 掃三語系 `tor.md`，0 error 0 warn
- 三語系建置皆通過，通道標籤渲染正常（穩定版 12 個、Alpha 6 個，含頁首說明）

🤖 Generated with [Claude Code](https://claude.com/claude-code)