### PR TITLE
fix(utils): 本機檔案加密的 scrypt 搬進 worker，關 JIT 的瀏覽器先估時間再問

### DIFF
--- a/docs/en/js/agecrypt-worker.js
+++ b/docs/en/js/agecrypt-worker.js
@@ -1,0 +1,1 @@
+../../zh-TW/js/agecrypt-worker.js

--- a/docs/en/utils/age.md
+++ b/docs/en/utils/age.md
@@ -8,6 +8,7 @@ offline_assets:
   # they are listed here one by one for offline copies. tools/test_agecrypt.mjs checks the
   # list against the vendor directory.
   - utils/asian-diceware-7776.txt
+  - js/agecrypt-worker.js
   - utils/vendor/age/age-encryption/dist/armor.js
   - utils/vendor/age/age-encryption/dist/cbor.js
   - utils/vendor/age/age-encryption/dist/format.js
@@ -86,7 +87,7 @@ offline_assets:
 
 1. Drop a file in, or click to choose one. The tool reads the start of the file to decide: an age file gets decrypted, anything else gets encrypted.
 2. Type a passphrase. When encrypting, "Draw a passphrase" picks six words from the Asian Diceware list. Write it down. It is gone when you close the page.
-3. Press "Encrypt and download". The page decrypts the output again with the same passphrase and checks it against the original before offering the download. The file name is the original with `.age` added. Decrypting removes the `.age`.
+3. Press "Encrypt and download". The page decrypts the output again with the same passphrase and checks it against the original before offering the download. The file name is the original with `.age` added. Decrypting removes the `.age`. In a slow environment the page shows an estimate first and lets you decide. If you go on, the check pass is skipped.
 
 The output is a standard age file. Any computer with the command-line tool opens it, without this site:
 
@@ -106,6 +107,7 @@ This page does passphrase mode only, so there are no keys to manage, at the cost
 - The file name is not inside the ciphertext. The output name is the original plus `.age`, visible to anyone. Give backups a name that gives nothing away.
 - Files encrypted to a key (a public key starting with `age1`) cannot be opened here. That needs the private key and the command-line tool.
 - The first use needs a connection to fetch the code. After that it stays on the device.
+- Browsers with the JavaScript JIT off compute scrypt fifty times slower or more. One pass took 50 seconds on a desktop in testing. IronFox turns the JIT off by default (Settings, Security), and Tor Browser's Safer level does too. The tool measures first and shows an estimate. The page stays usable while it works.
 
 ## Works offline
 

--- a/docs/zh-CN/js/agecrypt-worker.js
+++ b/docs/zh-CN/js/agecrypt-worker.js
@@ -1,0 +1,1 @@
+../../zh-TW/js/agecrypt-worker.js

--- a/docs/zh-CN/utils/age.md
+++ b/docs/zh-CN/utils/age.md
@@ -7,6 +7,7 @@ offline_assets:
   # 接到 vendor/age/ 底下，hooks/offline_index.py 只认 <script src>，所以逐一列在下面，
   # 读者把这一页存下来时才会一起存。清单由 tools/test_agecrypt.mjs 对照 vendor 目录。
   - utils/asian-diceware-7776.txt
+  - js/agecrypt-worker.js
   - utils/vendor/age/age-encryption/dist/armor.js
   - utils/vendor/age/age-encryption/dist/cbor.js
   - utils/vendor/age/age-encryption/dist/format.js
@@ -85,7 +86,7 @@ offline_assets:
 
 1. 把文件拖进来，或点一下选。工具看文件开头决定要做什么：age 文件就解密，其余一律加密。
 2. 输入密语。加密时可以按「抽一组密语」，会从 Asian Diceware 词表抽六个词，抄下来，关掉页面就没了。
-3. 按「加密并下载」。页面会用同一组密语把输出解回来比对，一致才给下载，文件名是原文件名加 `.age`。解密时文件名去掉 `.age`。
+3. 按「加密并下载」。页面会用同一组密语把输出解回来比对，一致才给下载，文件名是原文件名加 `.age`。解密时文件名去掉 `.age`。环境太慢时会先告诉你预估时间，由你决定要不要等，等的话省略比对那一趟。
 
 输出是标准的 age 格式，任何装了命令行工具的电脑都能解开，不需要这个网站：
 
@@ -105,6 +106,7 @@ age 是什么、格式长什么样、跟 PGP 差在哪，见[什么是 age](../t
 - 文件名不在密文里，输出文件名是原文件名加 `.age`，别人会看到。备份取一个不透露内容的文件名。
 - 用密钥（`age1` 开头的公钥）加密的文件需要对应的私钥，工具无法处理，用命令行工具解。
 - 第一次使用需要联网把程序抓回来，之后会留在设备上。
+- 关掉 JavaScript JIT 的浏览器算 scrypt 慢五十倍以上，桌机实测一次要 50 秒。IronFox 默认关闭，可在设置的 Security 开启。Tor Browser 的「较安全」等级也会关。工具会先量一次再告诉你预估时间，期间页面照常能操作。
 
 ## 离线可用
 

--- a/docs/zh-TW/js/agecrypt-worker.js
+++ b/docs/zh-TW/js/agecrypt-worker.js
@@ -1,0 +1,33 @@
+/*
+ * 本機檔案加密（utils/age.md）的 scrypt 算在這個 worker 裡，主程式是 agecrypt.js。
+ *
+ * 2026-09-03 在 GrapheneOS 的 IronFox 上發現工具像當掉。IronFox 預設關閉 JavaScript 的 JIT，
+ * Tor Browser 的「較安全」等級也關，純 JS 的 scrypt 一次 2^18 要 50 秒。在主執行緒上算的話
+ * 轉圈畫不動、點什麼都沒反應。noble 的 scryptAsync 只用 microtask 讓步，畫面照樣進不來，
+ * 所以搬到 worker，主執行緒只等訊息。
+ *
+ * 這是 module worker，直接用相對路徑載入 vendor 裡原封不動的 noble scrypt，它內部的 import
+ * 全是相對路徑，不需要頁面的 import map。三個語系共用，en 與 zh-CN 底下是 symlink，
+ * 那兩邊的 vendor/age 也是 symlink，所以同一個相對路徑都解得到。
+ * 進度只在百分比變了才回報，一趟最多一百則訊息。
+ */
+import { scrypt } from "../utils/vendor/age/noble-hashes/scrypt.js";
+
+self.onmessage = (event) => {
+  const job = event.data;
+  let shown = -1;
+  try {
+    const key = scrypt(job.passphrase, job.salt, {
+      N: job.N, r: job.r, p: job.p, dkLen: job.dkLen,
+      onProgress: (ratio) => {
+        const percent = Math.floor(ratio * 100);
+        if (percent === shown) return;
+        shown = percent;
+        self.postMessage({ id: job.id, progress: ratio });
+      },
+    });
+    self.postMessage({ id: job.id, key: key });
+  } catch (err) {
+    self.postMessage({ id: job.id, error: String((err && err.message) || err) });
+  }
+};

--- a/docs/zh-TW/js/agecrypt.js
+++ b/docs/zh-TW/js/agecrypt.js
@@ -25,6 +25,18 @@
  * scrypt 的工作因數用 age 命令列的預設值 2^18。手機上要幾秒，按鈕會轉圈。
  * 不偷降：降了檔案照樣能被別的實作解開，但猜密語也變快。
  *
+ * scrypt 不在主執行緒上算。2026-09-03 在 GrapheneOS 的 IronFox 上發現工具像當掉：
+ * IronFox 預設關閉 JavaScript 的 JIT（Tor Browser 的「較安全」等級也關），純 JS 的 scrypt
+ * 慢五十倍以上，桌機實測一次 2^18 從 0.9 秒變 50 秒，而 typage 內建的同步 scrypt 把主執行緒
+ * 整段占住，轉圈不會動、點什麼都沒反應。noble 的 scryptAsync 也救不了，它只用 microtask
+ * 讓步，畫面一樣進不來，headless Firefox 關 JIT 實測往返 48 秒。所以這裡照 typage 的
+ * ScryptRecipient 與 ScryptIdentity 重做一份收件人與身分物件，格式一個位元組都不差，
+ * 只把 scrypt 換成送進 agecrypt-worker.js 算，主執行緒只等訊息與進度。typage 允許自訂
+ * 這兩種物件，vendor 不用動。worker 起不來就退回主執行緒的 scryptAsync，慢但能用。
+ *
+ * 第一次按下時先量一次 2^12 推算整趟要多久，超過二十秒就先把預估時間與原因顯示出來，
+ * 讓讀者決定要不要等。決定要等的話省略解回比對那一趟，時間減半。快的環境維持比對。
+ *
  * 密語不存、不送、不記。重新整理就沒了。「抽一組密語」用的是 Asian Diceware 的詞表，
  * 跟密語產生器同一份，取樣方式也相同（拒絕重抽，理由見 passphrase.js）。
  *
@@ -34,6 +46,9 @@
  */
 (function () {
   "use strict";
+
+  // worker 的網址從這一支自己的網址推，三個語系的 js/ 都是 symlink 指向同一份
+  const scriptUrl = (document.currentScript && document.currentScript.src) || new URL("../../js/agecrypt.js", location.href).href;
 
   // --- 純邏輯（tools/test_agecrypt.mjs 從這裡原地抽出來測）---
 
@@ -49,6 +64,16 @@
 
   // 密語的詞數建議。六個詞是 77 bits，理由寫在 asian-diceware.md。
   const WORDS_SUGGESTED = 6;
+
+  // scrypt 段落的規格，跟 typage 的 ScryptRecipient 與 ScryptIdentity 逐項對齊
+  const SCRYPT_LABEL = "age-encryption.org/v1/scrypt";
+  const SCRYPT_MAX_LOG2_N = 20;
+
+  // 校準用的工作因數，成本是 2^18 的 1/64。有 JIT 十幾毫秒，沒有 JIT 接近一秒。
+  const CALIBRATE_LOG2_N = 12;
+
+  // 整趟預估超過這個毫秒數就先問過讀者。有 JIT 的手機兩趟加起來十秒內，碰不到。
+  const SLOW_MS = 20000;
 
   function asciiPrefix(bytes, length) {
     let text = "";
@@ -88,6 +113,71 @@
       out.push(words[randomBelow(words.length, randomUint32)]);
     }
     return out;
+  }
+
+  // scrypt 的鹽是固定標籤接上段落裡那 16 位元組
+  function scryptSalt(salt) {
+    const label = new TextEncoder().encode(SCRYPT_LABEL);
+    const out = new Uint8Array(label.length + salt.length);
+    out.set(label);
+    out.set(salt, label.length);
+    return out;
+  }
+
+  // 量過一個小的工作因數，推算大的。scrypt 的時間跟 N 成正比。
+  function estimateMs(sampleMs, sampleLog2N, targetLog2N) {
+    return sampleMs * Math.pow(2, targetLog2N - sampleLog2N);
+  }
+
+  // 整趟要幾次 scrypt：加密一次，解回比對再一次，解密一次
+  function plannedMs(perScryptMs, mode, verify) {
+    return perScryptMs * (mode === "encrypt" && verify ? 2 : 1);
+  }
+
+  function scryptParams(logN, onProgress) {
+    const params = { N: Math.pow(2, logN), r: 8, p: 1, dkLen: 32 };
+    if (onProgress) params.onProgress = onProgress;
+    return params;
+  }
+
+  // typage 的 Encrypter.addRecipient 接受自訂物件，這裡照它的 ScryptRecipient 重做一份，
+  // 輸出的段落逐位元組相同，差別只在 scrypt 用非同步版本。deps 由介面從 vendor 載入後傳進來。
+  function scryptRecipient(deps, passphrase, logN, onProgress) {
+    return {
+      async wrapFileKey(fileKey) {
+        const salt = crypto.getRandomValues(new Uint8Array(16));
+        const key = await deps.scryptAsync(passphrase, scryptSalt(salt), scryptParams(logN, onProgress));
+        const body = deps.chacha20poly1305(key, new Uint8Array(12)).encrypt(fileKey);
+        return [new deps.Stanza(["scrypt", deps.base64nopad.encode(salt), String(logN)], body)];
+      },
+    };
+  }
+
+  // 對應 Decrypter.addIdentity。檢查條件跟 typage 的 ScryptIdentity 一樣：scrypt 段落
+  // 必須是唯一的段落，鹽 16 位元組，工作因數不超過上限，密語不對就回 null。
+  function scryptIdentity(deps, passphrase, onProgress) {
+    return {
+      async unwrapFileKey(stanzas) {
+        for (let i = 0; i < stanzas.length; i += 1) {
+          const s = stanzas[i];
+          if (s.args.length < 1 || s.args[0] !== "scrypt") continue;
+          if (stanzas.length !== 1) throw new Error("scrypt recipient is not the only one in the header");
+          if (s.args.length !== 3 || !/^[1-9][0-9]*$/.test(s.args[2])) throw new Error("invalid scrypt stanza");
+          const salt = deps.base64nopad.decode(s.args[1]);
+          if (salt.length !== 16) throw new Error("invalid scrypt stanza");
+          const logN = Number(s.args[2]);
+          if (logN > SCRYPT_MAX_LOG2_N) throw new Error("scrypt work factor is too high");
+          if (s.body.length !== 32) throw new Error("invalid stanza");
+          const key = await deps.scryptAsync(passphrase, scryptSalt(salt), scryptParams(logN, onProgress));
+          try {
+            return deps.chacha20poly1305(key, new Uint8Array(12)).decrypt(s.body);
+          } catch (err) {
+            return null;
+          }
+        }
+        return null;
+      },
+    };
   }
 
   // --- 介面 ---
@@ -145,6 +235,11 @@
       border-left: .15rem solid #c62828; padding: .1rem 0 .1rem .6rem;
       margin: .8rem 0; font-size: .74rem; line-height: 1.7;
     }
+    #age-tool .ag-slow {
+      border-left: .15rem solid #ef6c00; padding: .1rem 0 .1rem .6rem;
+      margin: .8rem 0; font-size: .74rem; line-height: 1.7;
+    }
+    #age-tool .ag-progress { font-variant-numeric: tabular-nums; }
     #age-tool .ag-hint { font-size: .7rem; opacity: .75; line-height: 1.7; margin: .3rem 0 0; }
     #age-tool .ag-note { font-size: .7rem; opacity: .75; line-height: 1.7; margin: .8rem 0 0; }
     @media (pointer: coarse) { #age-tool button, #age-tool a.ag-dl { min-height: 2.2rem; } }
@@ -170,7 +265,13 @@
       decrypt: "解密並下載",
       working: "處理中，密語要先經過 scrypt 拉長運算，手機上要幾秒",
       encrypted: "加密完成，已用同一組密語解回來比對，跟原檔一致。",
+      encryptedNoVerify: "加密完成。這個環境慢，省略了解回比對那一趟。",
       decrypted: "解開了。",
+      slow: "這個瀏覽器算 scrypt 很慢，預估要 {time}。多半是關掉了 JavaScript 的 JIT：IronFox 預設關閉，可在設定的 Security 開啟。Tor Browser 的「較安全」等級也會關。繼續的話加密會省略解回比對那一趟，期間頁面照常能操作。",
+      slowGo: "還是繼續，約 {time}",
+      progress: "scrypt 第 {pass}/{passes} 趟，{percent}%",
+      seconds: "{n} 秒",
+      minutes: "{n} 分鐘",
       download: "下載 {name}",
       sizeLine: "原始 {a}，輸出 {b}",
       another: "換一個檔案",
@@ -201,7 +302,13 @@
       decrypt: "解密并下载",
       working: "处理中，密语要先经过 scrypt 拉长运算，手机上要几秒",
       encrypted: "加密完成，已用同一组密语解回来比对，跟原文件一致。",
+      encryptedNoVerify: "加密完成。这个环境慢，省略了解回比对那一趟。",
       decrypted: "解开了。",
+      slow: "这个浏览器算 scrypt 很慢，预估要 {time}。多半是关掉了 JavaScript 的 JIT：IronFox 默认关闭，可在设置的 Security 开启。Tor Browser 的「较安全」等级也会关。继续的话加密会省略解回比对那一趟，期间页面照常能操作。",
+      slowGo: "还是继续，约 {time}",
+      progress: "scrypt 第 {pass}/{passes} 趟，{percent}%",
+      seconds: "{n} 秒",
+      minutes: "{n} 分钟",
       download: "下载 {name}",
       sizeLine: "原始 {a}，输出 {b}",
       another: "换一个文件",
@@ -232,7 +339,13 @@
       decrypt: "Decrypt and download",
       working: "Working. The passphrase goes through scrypt first, which takes a few seconds on a phone",
       encrypted: "Encrypted, and decrypted again with the same passphrase to check: it matches the original.",
+      encryptedNoVerify: "Encrypted. This environment is slow, so the decrypt-and-compare pass was skipped.",
       decrypted: "Decrypted.",
+      slow: "scrypt is slow in this browser: about {time} expected. Usually the JavaScript JIT is off. IronFox turns it off by default (Settings, Security), and Tor Browser's Safer level does too. If you go on, encryption skips the decrypt-and-compare pass. The page stays usable meanwhile.",
+      slowGo: "Go on anyway, about {time}",
+      progress: "scrypt pass {pass}/{passes}, {percent}%",
+      seconds: "{n} s",
+      minutes: "{n} min",
       download: "Download {name}",
       sizeLine: "Original {a}, output {b}",
       another: "Another file",
@@ -275,23 +388,123 @@
     drawn: null,
     words: null,     // null 還沒抓、false 抓失敗、陣列抓到了
     drawing: false,
+    perScryptMs: null,   // 校準結果：一次 2^18 預估幾毫秒，整頁只量一次
+    slow: null,          // 等讀者決定時放預估毫秒數，其餘時候 null
+    slowAccepted: false, // 讀者答應等過一次，之後不再問，也不再解回比對
   };
+
+  function humanTime(ms) {
+    const seconds = Math.ceil(ms / 1000);
+    if (seconds < 90) return fill(t.seconds, { n: seconds });
+    return fill(t.minutes, { n: Math.ceil(seconds / 60) });
+  }
 
   function releaseResult() {
     if (state.result && state.result.url) URL.revokeObjectURL(state.result.url);
     state.result = null;
   }
 
-  // typage 經由頁面的 import map 載入，路徑在 vendor/age/ 底下
+  // typage 與它相依的 noble、scure 經由頁面的 import map 載入，路徑在 vendor/age/ 底下。
+  // scrypt 收件人自己組，所以除了入口還要拿非同步 scrypt、ChaCha20-Poly1305 與 base64。
   let libPromise = null;
   function lib() {
     if (!libPromise) {
-      libPromise = import("age-encryption").catch((err) => {
+      libPromise = Promise.all([
+        import("age-encryption"),
+        import("@noble/hashes/scrypt.js"),
+        import("@noble/ciphers/chacha.js"),
+        import("@scure/base"),
+      ]).then(([age, scryptMod, chachaMod, baseMod]) => ({
+        age: age,
+        deps: {
+          Stanza: age.Stanza,
+          scryptAsync: makeScrypt(scryptMod.scryptAsync),
+          chacha20poly1305: chachaMod.chacha20poly1305,
+          base64nopad: baseMod.base64nopad,
+        },
+      })).catch((err) => {
         libPromise = null;
         throw err;
       });
     }
     return libPromise;
+  }
+
+  // scrypt 送進 worker 算，主執行緒只等訊息，轉圈與進度才畫得出來。worker 起不來
+  // （舊瀏覽器、被擋）就退回主執行緒的 scryptAsync，慢但至少能用。
+  let worker = null;
+  let workerBroken = false;
+  let workerSeq = 0;
+  const workerJobs = new Map();
+
+  function failWorkerJobs() {
+    workerJobs.forEach((job) => job.reject(new Error("worker")));
+    workerJobs.clear();
+    worker = null;
+    workerBroken = true;
+  }
+
+  function workerScrypt(passphrase, salt, params) {
+    return new Promise((resolve, reject) => {
+      if (!worker) {
+        try {
+          worker = new Worker(new URL("agecrypt-worker.js", scriptUrl), { type: "module" });
+        } catch (err) {
+          workerBroken = true;
+          reject(new Error("worker"));
+          return;
+        }
+        worker.addEventListener("message", (event) => {
+          const job = workerJobs.get(event.data.id);
+          if (!job) return;
+          if (event.data.progress !== undefined) {
+            if (job.onProgress) job.onProgress(event.data.progress);
+            return;
+          }
+          workerJobs.delete(event.data.id);
+          if (event.data.error) job.reject(new Error(event.data.error));
+          else job.resolve(event.data.key);
+        });
+        worker.addEventListener("error", failWorkerJobs);
+      }
+      const id = ++workerSeq;
+      workerJobs.set(id, { resolve: resolve, reject: reject, onProgress: params.onProgress });
+      worker.postMessage({ id: id, passphrase: passphrase, salt: salt, N: params.N, r: params.r, p: params.p, dkLen: params.dkLen });
+    });
+  }
+
+  // 收件人與身分物件拿到的 scryptAsync 就是這一個：先試 worker，不行才在主執行緒算
+  function makeScrypt(scryptAsync) {
+    return (passphrase, salt, params) => {
+      if (workerBroken || typeof Worker === "undefined") return scryptAsync(passphrase, salt, params);
+      return workerScrypt(passphrase, salt, params).catch((err) => {
+        if (err && err.message === "worker") return scryptAsync(passphrase, salt, params);
+        throw err;
+      });
+    };
+  }
+
+  // 第一次按下時量一次 2^12 推算 2^18。JIT 關掉的瀏覽器在這一步就看得出來，
+  // 不必讓讀者卡五十秒才知道。
+  async function calibrate(deps) {
+    if (state.perScryptMs === null) {
+      const t0 = performance.now();
+      await deps.scryptAsync("calibrate", scryptSalt(new Uint8Array(16)), scryptParams(CALIBRATE_LOG2_N, null));
+      state.perScryptMs = estimateMs(performance.now() - t0, CALIBRATE_LOG2_N, SCRYPT_LOG2_N);
+    }
+    return state.perScryptMs;
+  }
+
+  // noble 每千分之一就回報一次，只在百分比變了才動 DOM
+  function reportProgress(pass, passes) {
+    let shown = -1;
+    return (ratio) => {
+      const percent = Math.floor(ratio * 100);
+      if (percent === shown) return;
+      shown = percent;
+      const node = root.querySelector(".ag-progress");
+      if (node) node.textContent = fill(t.progress, { pass: pass, passes: passes, percent: percent });
+    };
   }
 
   const randomUint32 = () => {
@@ -361,33 +574,47 @@
     state.working = true;
     render();
     await new Promise((next) => setTimeout(next, 0));
-    let age;
+    let loaded;
     try {
-      age = await lib();
+      loaded = await lib();
     } catch (err) {
       state.working = false;
       state.error = "libMissing";
       render();
       return;
     }
+    const age = loaded.age;
+    const deps = loaded.deps;
     const passphrase = state.passphrase;
+    const mode = state.file.mode;
+    const perScrypt = await calibrate(deps);
+    // 慢的環境先問過再開始。答應過一次就不再問，並省略解回比對那一趟。
+    if (!state.slowAccepted && plannedMs(perScrypt, mode, true) > SLOW_MS) {
+      state.working = false;
+      state.slow = plannedMs(perScrypt, mode, false);
+      render();
+      return;
+    }
+    const verify = mode === "encrypt" && !state.slowAccepted;
+    const passes = verify ? 2 : 1;
     try {
       let output;
-      if (state.file.mode === "encrypt") {
+      if (mode === "encrypt") {
         const encrypter = new age.Encrypter();
-        encrypter.setPassphrase(passphrase);
-        encrypter.setScryptWorkFactor(SCRYPT_LOG2_N);
+        encrypter.addRecipient(scryptRecipient(deps, passphrase, SCRYPT_LOG2_N, reportProgress(1, passes)));
         output = await encrypter.encrypt(state.file.bytes);
-        // 交出去之前自己解回來比對。比對的是雜湊，兩份一起留在記憶體裡太占。
-        const decrypter = new age.Decrypter();
-        decrypter.addPassphrase(passphrase);
-        const back = await decrypter.decrypt(output, "uint8array");
-        if (!sameBytes(await sha256(back), await sha256(state.file.bytes))) {
-          throw new Error("verify");
+        if (verify) {
+          // 交出去之前自己解回來比對。比對的是雜湊，兩份一起留在記憶體裡太占。
+          const decrypter = new age.Decrypter();
+          decrypter.addIdentity(scryptIdentity(deps, passphrase, reportProgress(2, passes)));
+          const back = await decrypter.decrypt(output, "uint8array");
+          if (!sameBytes(await sha256(back), await sha256(state.file.bytes))) {
+            throw new Error("verify");
+          }
         }
       } else {
         const decrypter = new age.Decrypter();
-        decrypter.addPassphrase(passphrase);
+        decrypter.addIdentity(scryptIdentity(deps, passphrase, reportProgress(1, 1)));
         try {
           output = await decrypter.decrypt(state.file.bytes, "uint8array");
         } catch (err) {
@@ -397,8 +624,9 @@
       const blob = new Blob([output], { type: "application/octet-stream" });
       state.result = {
         url: URL.createObjectURL(blob),
-        name: outputName(state.file.name, state.file.mode),
+        name: outputName(state.file.name, mode),
         size: blob.size,
+        verified: verify,
       };
     } catch (err) {
       const reason = err && err.message;
@@ -473,7 +701,7 @@
       if (hint) hint.hidden = !isShort(state.passphrase);
     });
     input.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") run();
+      if (event.key === "Enter" && state.slow === null) run();
     });
     row.appendChild(input);
     row.appendChild(button(state.show ? t.hide : t.show, null, () => {
@@ -510,8 +738,20 @@
       box.appendChild(short);
     }
 
+    if (state.slow !== null) {
+      box.appendChild(el("p", "ag-slow", fill(t.slow, { time: humanTime(state.slow) })));
+    }
+
     const actions = el("div", "ag-actions ag-row");
-    const primary = button(state.working ? "" : (file.mode === "decrypt" ? t.decrypt : t.encrypt), "ag-primary", run);
+    let primaryLabel = file.mode === "decrypt" ? t.decrypt : t.encrypt;
+    if (state.slow !== null) primaryLabel = fill(t.slowGo, { time: humanTime(state.slow) });
+    const primary = button(state.working ? "" : primaryLabel, "ag-primary", () => {
+      if (state.slow !== null) {
+        state.slowAccepted = true;
+        state.slow = null;
+      }
+      run();
+    });
     if (state.working) {
       // 轉圈用全站共用的那顆，樣式定義在 overrides/base.html。scrypt 在手機上要幾秒，
       // 按鈕沒有變化的話讀者會以為沒按到而重複按。
@@ -529,18 +769,22 @@
       state.passphrase = "";
       state.drawn = null;
       state.error = null;
+      state.slow = null;
       render();
     });
     another.disabled = state.working;
     actions.appendChild(another);
     box.appendChild(actions);
+    if (state.working) {
+      box.appendChild(el("p", "ag-progress ag-hint", ""));
+    }
 
     if (state.error) {
       box.appendChild(el("p", "ag-error", fill(t.errors[state.error] || t.errors.broken, { limit: humanSize(MAX_BYTES) })));
     }
     if (state.result) {
       const result = el("div", "ag-result");
-      result.appendChild(el("p", null, file.mode === "decrypt" ? t.decrypted : t.encrypted));
+      result.appendChild(el("p", null, file.mode === "decrypt" ? t.decrypted : (state.result.verified ? t.encrypted : t.encryptedNoVerify)));
       result.appendChild(el("p", null, fill(t.sizeLine, { a: humanSize(file.size), b: humanSize(state.result.size) })));
       const link = el("a", "ag-dl", fill(t.download, { name: state.result.name }));
       link.href = state.result.url;

--- a/docs/zh-TW/utils/age.md
+++ b/docs/zh-TW/utils/age.md
@@ -7,6 +7,7 @@ offline_assets:
   # 接到 vendor/age/ 底下，hooks/offline_index.py 只認 <script src>，所以逐一列在下面，
   # 讀者把這一頁存下來時才會一起存。清單由 tools/test_agecrypt.mjs 對照 vendor 目錄。
   - utils/asian-diceware-7776.txt
+  - js/agecrypt-worker.js
   - utils/vendor/age/age-encryption/dist/armor.js
   - utils/vendor/age/age-encryption/dist/cbor.js
   - utils/vendor/age/age-encryption/dist/format.js
@@ -85,7 +86,7 @@ offline_assets:
 
 1. 把檔案拖進來，或點一下選。工具看檔案開頭決定要做什麼：age 檔就解密，其餘一律加密。
 2. 輸入密語。加密時可以按「抽一組密語」，會從 Asian Diceware 詞表抽六個詞，抄下來，關掉頁面就沒了。
-3. 按「加密並下載」。頁面會用同一組密語把輸出解回來比對，一致才給下載，檔名是原檔名加 `.age`。解密時檔名去掉 `.age`。
+3. 按「加密並下載」。頁面會用同一組密語把輸出解回來比對，一致才給下載，檔名是原檔名加 `.age`。解密時檔名去掉 `.age`。環境太慢時會先告訴你預估時間，由你決定要不要等，等的話省略比對那一趟。
 
 輸出是標準的 age 格式，任何裝了命令列工具的電腦都能解開，不需要這個網站：
 
@@ -105,6 +106,7 @@ age 是什麼、格式長什麼樣、跟 PGP 差在哪，見[什麼是 age](../t
 - 檔名不在密文裡，輸出檔名是原檔名加 `.age`，別人會看到。備份取一個不透露內容的檔名。
 - 用金鑰（`age1` 開頭的公鑰）加密的檔案需要對應的私鑰，工具無法處理，用命令列工具解。
 - 第一次使用需要連上網把程式抓回來，之後會留在裝置上。
+- 關掉 JavaScript JIT 的瀏覽器算 scrypt 慢五十倍以上，桌機實測一次要 50 秒。IronFox 預設關閉，可在設定的 Security 開啟。Tor Browser 的「較安全」等級也會關。工具會先量一次再告訴你預估時間，期間頁面照常能操作。
 
 ## 離線可用
 

--- a/tools/test_agecrypt.mjs
+++ b/tools/test_agecrypt.mjs
@@ -37,7 +37,7 @@ const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 const start = src.indexOf('// --- 純邏輯');
 const end = src.indexOf('// --- 介面');
 assert.ok(start > 0 && end > start, 'agecrypt.js 裡找不到純邏輯與介面的分界註解');
-const tool = new Function(`${src.slice(start, end)}\n return { AGE_HEADER, MAX_BYTES, SCRYPT_LOG2_N, WORDS_SUGGESTED, isAgeFile, outputName, randomBelow, pickWords };`)();
+const tool = new Function(`${src.slice(start, end)}\n return { AGE_HEADER, MAX_BYTES, SCRYPT_LOG2_N, WORDS_SUGGESTED, SCRYPT_LABEL, SCRYPT_MAX_LOG2_N, CALIBRATE_LOG2_N, SLOW_MS, isAgeFile, outputName, randomBelow, pickWords, scryptSalt, estimateMs, plannedMs, scryptRecipient, scryptIdentity };`)();
 const STRINGS = new Function(`${src.match(/^  const STRINGS = \{[\s\S]*?\n  \};/m)[0]}\n return STRINGS;`)();
 
 // ---------------------------------------------------------------------------
@@ -167,8 +167,14 @@ async function loadTypage() {
   for (const [name, dir] of Object.entries(PKG_DIRS)) {
     copyTree(path.join(VENDOR, dir), path.join(tmp, 'node_modules', name));
   }
-  const mod = await import(pathToFileURL(path.join(tmp, 'node_modules', 'age-encryption', 'dist', 'index.js')).href);
-  return { age: mod, tmp };
+  const nm = (p) => pathToFileURL(path.join(tmp, 'node_modules', p)).href;
+  const mod = await import(nm('age-encryption/dist/index.js'));
+  // 介面自組 scrypt 段落時要用的三樣，跟 agecrypt.js 的 lib() 拿的是同一批檔案
+  const scryptMod = await import(nm('@noble/hashes/scrypt.js'));
+  const chachaMod = await import(nm('@noble/ciphers/chacha.js'));
+  const baseMod = await import(nm('@scure/base/index.js'));
+  const deps = { Stanza: mod.Stanza, scryptAsync: scryptMod.scryptAsync, chacha20poly1305: chachaMod.chacha20poly1305, base64nopad: baseMod.base64nopad };
+  return { age: mod, deps, tmp };
 }
 
 // ---------------------------------------------------------------------------
@@ -285,8 +291,60 @@ test('取樣沒有取模偏差，抽出來的都是詞表裡的字', () => {
 
 test('scrypt 工作因數用 age 命令列的預設值，不偷降', () => {
   assert.equal(tool.SCRYPT_LOG2_N, 18);
-  assert.ok(/setScryptWorkFactor\(SCRYPT_LOG2_N\)/.test(code), '介面沒有把工作因數傳給 typage');
+  assert.ok(/addRecipient\(scryptRecipient\(deps, passphrase, SCRYPT_LOG2_N/.test(code), '介面沒有把工作因數交給自組的收件人');
+  assert.ok(/addIdentity\(scryptIdentity\(deps, passphrase/.test(code), '解密沒有走自組的身分');
   assert.ok(/import\("age-encryption"\)/.test(code), '介面要用 import map 裡的入口名稱載入');
+});
+
+test('scrypt 走非同步版本，介面不再碰 typage 內建的同步密語模式', () => {
+  // 2026-09-03 IronFox（預設關 JIT）上同步 scrypt 一次 50 秒，主執行緒整段卡住。
+  // 之後的規則：scrypt 只能經由 scryptAsync，setPassphrase 與 addPassphrase 都不准出現。
+  assert.ok(/scryptAsync/.test(code), '沒有用 scryptAsync');
+  assert.ok(!/setPassphrase\(|addPassphrase\(|setScryptWorkFactor\(/.test(code), '介面又走回 typage 的同步 scrypt');
+  assert.ok(/onProgress/.test(src.slice(start, end)), '收件人與身分要把進度回報接出去');
+});
+
+test('scrypt 在 module worker 裡算，worker 用相對路徑載入 vendor 的 noble scrypt，三語系與離線清單都有', () => {
+  // noble 的 scryptAsync 只用 microtask 讓步，關 JIT 的 Firefox 實測主執行緒照樣卡 48 秒。
+  // 只有 worker 才讓轉圈與進度畫得出來。
+  const workerPath = path.join(DOCS, 'zh-TW', 'js', 'agecrypt-worker.js');
+  const w = fs.readFileSync(workerPath, 'utf8');
+  const m = w.match(/import \{ scrypt \} from "([^"]+)"/);
+  assert.ok(m, 'worker 沒有載入 scrypt');
+  assert.equal(fs.realpathSync(path.resolve(path.dirname(workerPath), m[1])), fs.realpathSync(path.join(VENDOR, 'noble-hashes', 'scrypt.js')), 'worker 載入的不是 vendor 那一份');
+  assert.ok(/onProgress/.test(w) && /postMessage\(\{ id: job\.id, progress/.test(w), 'worker 沒有回報進度');
+  assert.ok(/postMessage\(\{ id: job\.id, error/.test(w), 'worker 出錯沒有回報');
+  assert.ok(/new Worker\(new URL\("agecrypt-worker\.js", scriptUrl\), \{ type: "module" \}\)/.test(code), '主程式沒有用 module worker');
+  assert.ok(/scryptAsync: makeScrypt\(scryptMod\.scryptAsync\)/.test(code), '收件人與身分拿到的要是先試 worker 的那一個');
+  assert.ok(/return scryptAsync\(passphrase, salt, params\)/.test(code), 'worker 起不來沒有退路');
+  for (const lang of ['en', 'zh-CN']) {
+    const link = path.join(DOCS, lang, 'js', 'agecrypt-worker.js');
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), `${lang} 的 worker 不是 symlink`);
+    assert.equal(fs.realpathSync(link), fs.realpathSync(workerPath));
+    assert.ok(fs.existsSync(path.resolve(path.join(DOCS, lang, 'js'), m[1])), `${lang} 底下 worker 的相對路徑解不到 vendor`);
+  }
+  for (const lang of ['zh-TW', 'zh-CN', 'en']) {
+    const fm = frontmatter(fs.readFileSync(path.join(DOCS, lang, 'utils', 'age.md'), 'utf8'));
+    assert.ok(/^\s*- js\/agecrypt-worker\.js$/m.test(fm), `${lang} 的 offline_assets 少了 worker`);
+  }
+});
+
+test('校準與估時的算術：小工作因數量一次，推到 2^18，加密含比對算兩趟', () => {
+  assert.equal(tool.CALIBRATE_LOG2_N, 12);
+  assert.equal(tool.SCRYPT_MAX_LOG2_N, 20);
+  assert.equal(tool.SLOW_MS, 20000);
+  // 桌機關 JIT 實測：2^12 約 800 ms，推到 2^18 是 51.2 秒
+  assert.equal(tool.estimateMs(800, 12, 18), 51200);
+  assert.equal(tool.estimateMs(14, 12, 18), 896);
+  assert.equal(tool.plannedMs(51200, 'encrypt', true), 102400);
+  assert.equal(tool.plannedMs(51200, 'encrypt', false), 51200);
+  assert.equal(tool.plannedMs(51200, 'decrypt', true), 51200);
+  // 有 JIT 的手機：一次約 3 秒，兩趟 6 秒，不會被問
+  assert.ok(tool.plannedMs(3000, 'encrypt', true) < tool.SLOW_MS);
+  // 關 JIT 的桌機會被問，答應之後只做一趟
+  assert.ok(tool.plannedMs(51200, 'encrypt', true) > tool.SLOW_MS);
+  assert.ok(/plannedMs\(perScrypt, mode, true\) > SLOW_MS/.test(code), '介面的門檻沒有照 plannedMs 判斷');
+  assert.ok(/const verify = mode === "encrypt" && !state\.slowAccepted/.test(code), '答應等的慢環境才省略比對，其他情況都要比對');
 });
 
 // ---------------------------------------------------------------------------
@@ -335,6 +393,59 @@ test('密語錯了兩邊都拒絕，改一個位元組也拒絕', async () => {
   await assert.rejects(d2.decrypt(new Uint8Array(tampered), 'uint8array'));
 });
 
+test('自組的非同步 scrypt 收件人：typage 的密語模式與獨立實作都解得開，進度回報到 100%', async () => {
+  const { age, deps } = typage;
+  for (const size of [0, 1000, 65537]) {
+    const plain = crypto.randomBytes(size);
+    const seen = [];
+    const e = new age.Encrypter();
+    e.addRecipient(tool.scryptRecipient(deps, 'six words of passphrase here', 12, (r) => seen.push(r)));
+    const out = Buffer.from(await e.encrypt(new Uint8Array(plain)));
+    assert.ok(nodeAgeDecrypt(out, 'six words of passphrase here').equals(plain), `${size} 位元組獨立實作解回來不一樣`);
+    const d = new age.Decrypter();
+    d.addPassphrase('six words of passphrase here');
+    assert.ok(Buffer.from(await d.decrypt(new Uint8Array(out), 'uint8array')).equals(plain), `${size} 位元組 typage 解回來不一樣`);
+    assert.ok(seen.length > 10 && seen[seen.length - 1] === 1, '進度沒有回報到 1');
+    assert.ok(seen.every((v, i) => i === 0 || v >= seen[i - 1]), '進度倒退');
+  }
+});
+
+test('自組的非同步 scrypt 身分：解得開 typage 與獨立實作的輸出，密語錯了回 null', async () => {
+  const { age, deps } = typage;
+  const plain = crypto.randomBytes(5000);
+  const fromTypage = (() => { const e = new age.Encrypter(); e.setPassphrase('pw one'); e.setScryptWorkFactor(12); return e.encrypt(new Uint8Array(plain)); })();
+  const fromNode = nodeAgeEncrypt(plain, 'pw two', 12);
+  for (const [file, pw] of [[Buffer.from(await fromTypage), 'pw one'], [fromNode, 'pw two']]) {
+    const d = new age.Decrypter();
+    d.addIdentity(tool.scryptIdentity(deps, pw));
+    assert.ok(Buffer.from(await d.decrypt(new Uint8Array(file), 'uint8array')).equals(plain));
+    const wrong = new age.Decrypter();
+    wrong.addIdentity(tool.scryptIdentity(deps, 'nope'));
+    await assert.rejects(wrong.decrypt(new Uint8Array(file), 'uint8array'), /no identity matched/);
+  }
+});
+
+test('自組身分的檢查跟 typage 一致：多一個段落、鹽長度不對、工作因數太高、格式不對都拒絕', async () => {
+  const { deps } = typage;
+  const body = new Uint8Array(32);
+  const salt = deps.base64nopad.encode(new Uint8Array(16));
+  const ok = new deps.Stanza(['scrypt', salt, '12'], body);
+  const id = tool.scryptIdentity(deps, 'pw');
+  await assert.rejects(id.unwrapFileKey([ok, new deps.Stanza(['X25519', 'abc'], body)]), /not the only one/);
+  await assert.rejects(id.unwrapFileKey([new deps.Stanza(['scrypt', salt], body)]), /invalid scrypt stanza/);
+  await assert.rejects(id.unwrapFileKey([new deps.Stanza(['scrypt', salt, '012'], body)]), /invalid scrypt stanza/);
+  await assert.rejects(id.unwrapFileKey([new deps.Stanza(['scrypt', deps.base64nopad.encode(new Uint8Array(10)), '12'], body)]), /invalid scrypt stanza/);
+  await assert.rejects(id.unwrapFileKey([new deps.Stanza(['scrypt', salt, '21'], body)]), /too high/);
+  await assert.rejects(id.unwrapFileKey([new deps.Stanza(['scrypt', salt, '12'], new Uint8Array(31))]), /invalid stanza/);
+  // 不是 scrypt 的段落一律跳過，回 null 讓 typage 去報「沒有身分對上」
+  assert.equal(await id.unwrapFileKey([new deps.Stanza(['X25519', 'abc'], body)]), null);
+  // 鹽的組法：固定標籤接 16 位元組
+  const s = tool.scryptSalt(new Uint8Array(16).fill(7));
+  assert.equal(Buffer.from(s.subarray(0, 28)).toString(), 'age-encryption.org/v1/scrypt');
+  assert.equal(s.length, 28 + 16);
+  assert.equal(tool.SCRYPT_LABEL, 'age-encryption.org/v1/scrypt');
+});
+
 test('typage 的輸出符合規格的形狀：版本行、單一 scrypt 段落、工作因數、MAC 行', async () => {
   const e = new typage.age.Encrypter();
   e.setPassphrase('pw');
@@ -345,6 +456,14 @@ test('typage 的輸出符合規格的形狀：版本行、單一 scrypt 段落�
   assert.ok(/^-> scrypt [A-Za-z0-9+/]{22} 12$/.test(head[1]), head[1]);
   assert.ok(/^[A-Za-z0-9+/]{43}$/.test(head[2]), head[2]);
   assert.ok(/^--- [A-Za-z0-9+/]{43}$/.test(head[3]), head[3]);
+  // 自組收件人的輸出形狀一模一樣
+  const e2 = new typage.age.Encrypter();
+  e2.addRecipient(tool.scryptRecipient(typage.deps, 'pw', 12));
+  const head2 = Buffer.from(await e2.encrypt(new Uint8Array([1, 2, 3]))).toString('latin1').split('\n');
+  assert.equal(head2[0], 'age-encryption.org/v1');
+  assert.ok(/^-> scrypt [A-Za-z0-9+/]{22} 12$/.test(head2[1]), head2[1]);
+  assert.ok(/^[A-Za-z0-9+/]{43}$/.test(head2[2]), head2[2]);
+  assert.ok(/^--- [A-Za-z0-9+/]{43}$/.test(head2[3]), head2[3]);
 });
 
 // ---------------------------------------------------------------------------
@@ -369,6 +488,8 @@ test('頁面的 import map 涵蓋每一個 bare specifier，指到的檔案都�
       assert.equal(fs.realpathSync(target), fs.realpathSync(full), `${lang} 的 ${spec} 指錯檔案`);
     }
     for (const spec of Object.keys(map)) assert.ok(bare.has(spec), `${lang} 的 import map 多了沒人用的 ${spec}`);
+    // agecrypt.js 自己 import 的名稱也要在 map 裡，少一條是頁面上才炸
+    for (const m2 of code.matchAll(/import\("([^"]+)"\)/g)) assert.ok(map[m2[1]], `${lang} 的 import map 少了介面用到的 ${m2[1]}`);
   }
 });
 
@@ -423,10 +544,13 @@ test('原始碼裡除了抓詞表之外沒有網路請求，也沒有任何留�
   assert.ok(!/passphrase\s*[,)]?\s*\}?\)?\s*=>?\s*location|location\.(hash|search)\s*=/.test(code));
 });
 
-test('加密完先解回來比對，不一致就不給下載', () => {
+test('加密完先解回來比對，不一致就不給下載。只有讀者答應等的慢環境才省略', () => {
   assert.ok(/decrypter\.decrypt\(output/.test(code), '沒有把輸出解回來');
   assert.ok(/throw new Error\("verify"\)/.test(code), '比對不一致沒有攔下');
+  assert.ok(/if \(verify\) \{/.test(code), '比對要由 verify 決定');
+  assert.ok(/verified: verify/.test(code), '結果要記得有沒有比對過，文案才分得出來');
   assert.ok(code.includes('anoni-spinner') && code.includes('aria-busy'));
+  assert.ok(code.includes('ag-progress'), '等待期間要有進度');
 });
 
 test('三個語系的字串表結構一致', () => {


### PR DESCRIPTION
## 問題

上線當天在 GrapheneOS 的 IronFox 上，本機檔案加密按下去像當掉。查證結果：IronFox 預設關閉 JavaScript 的 JIT，Tor Browser 的「較安全」等級也關，純 JS 的 scrypt 慢五十倍以上。用本機 Firefox 156 headless 套上 IronFox 實際關掉的五個 pref 重現，數字如下（桌機 CPU）：

| 量測 | 有 JIT | 關 JIT |
|---|---|---|
| scrypt 2^18 一次 | 0.9 秒 | 50 秒 |
| 按下「加密並下載」到出現連結 | 3.5 秒 | 99 秒 |
| 加密期間頁面 script 呼叫的往返 | 正常 | 48 到 50 秒 |

最後一行是關鍵：typage 內建的 scrypt 是同步的，主執行緒整段被占住，轉圈畫不動、點什麼都沒反應。手機 CPU 再慢幾倍，Firefox Android 的「網頁沒有回應」或系統的記憶體回收很可能中途介入。

## 修法

三件事一起做，vendor 裡的 typage 與 noble 一個位元組都沒動：

- **scrypt 搬進 Web Worker**。照 typage 的 `ScryptRecipient` 與 `ScryptIdentity` 用它公開的自訂收件人與身分介面重做一份，輸出的段落逐位元組相同，只把 scrypt 換成送進 `js/agecrypt-worker.js` 算。worker 用相對路徑直接載入 vendor 的 noble `scrypt.js`，它內部全是相對 import，不需要 import map。worker 起不來就退回主執行緒的 `scryptAsync`。
- **先量再做**。第一次按下時先算一次 2^12（成本是 2^18 的 1/64）推算整趟時間，超過二十秒就把預估時間與原因顯示出來，由讀者決定要不要等。有 JIT 的手機兩趟加起來十秒內，碰不到這道門。
- **答應等的慢環境省略解回比對**。時間減半，結果文案會說明省略了那一趟。快的環境維持比對。

順帶發現 noble 的 `scryptAsync` 只用 microtask 讓步，主執行緒照樣卡住，所以非同步版本不是解法，worker 才是。

## 驗證

- `test_agecrypt.mjs` 從 21 個案例加到 22 個。自組收件人與身分跟 typage 的密語模式雙向互通，Node 獨立實作也解得開。身分的檢查條件（單一段落、鹽長度、工作因數上限、格式）跟 typage 一致。校準算術。worker 檔案、三語系 symlink、`offline_assets` 與相對路徑都對得上。原始碼掃描不准再出現 typage 的同步密語 API。
- headless Firefox 端對端，全新 profile，關 JIT 與開 JIT 各一輪，另外執行 en 頁面：
  - 關 JIT：1.6 秒內出現「預估要 50 秒」的提示，按下繼續後往返 5 毫秒、進度一百筆、51 秒完成，輸出由 Node 獨立實作解回一致。解密與錯密語兩條路同樣。
  - 開 JIT：不出提示、維持解回比對，2.4 秒完成，往返 5 毫秒。
- `check_precache.mjs` 過，`offline-index.json` 的 age 頁資產含 worker。三語系建置零警告，lint 零警告。

## 沒辦法在這裡驗的

真機上的秒數、Firefox Android 會不會在 worker 算的時候把分頁殺掉、256 MiB 的配置在低記憶體手機上會不會失敗。合併部署後請在那台 GrapheneOS 上再按一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
