### PR TITLE
fix(blog): Global Gathering 2026 那篇補上 more 標記，三語系一致

### DIFF
--- a/docs/en/blog/posts/2026-anoni-net-global-gathering.md
+++ b/docs/en/blog/posts/2026-anoni-net-global-gathering.md
@@ -20,6 +20,8 @@ Global Gathering 2026, hosted by Team CommUNITY, runs from 4 to 6 September in E
 
 Event details are at [Global Gathering 2026](https://wiki.digitalrights.community/index.php?title=2026_Global_Gathering_Programming){target="_blank"}.
 
+<!-- more -->
+
 ## What the Global Gathering is
 
 The Global Gathering is an annual event hosted by Team CommUNITY. It draws people from around the world whose work covers digital rights, internet freedom, and protecting civil society from digital attacks.

--- a/docs/zh-CN/blog/posts/2026-anoni-net-global-gathering.md
+++ b/docs/zh-CN/blog/posts/2026-anoni-net-global-gathering.md
@@ -20,6 +20,8 @@ Team CommUNITY 主办的 Global Gathering 2026 于 9 月 4 日到 6 日在葡萄
 
 活动信息见 [Global Gathering 2026](https://wiki.digitalrights.community/index.php?title=2026_Global_Gathering_Programming){target="_blank"}。
 
+<!-- more -->
+
 ## Global Gathering 是什么
 
 Global Gathering 是 Team CommUNITY 主办的年度聚会，参加者来自世界各地，工作范围涵盖数字权利、网络自由，以及协助民间社会抵御数字攻击。

--- a/docs/zh-TW/blog/posts/2026-anoni-net-global-gathering.md
+++ b/docs/zh-TW/blog/posts/2026-anoni-net-global-gathering.md
@@ -20,6 +20,8 @@ Team CommUNITY 主辦的 Global Gathering 2026 於 9 月 4 日到 6 日在葡萄
 
 活動資訊見 [Global Gathering 2026](https://wiki.digitalrights.community/index.php?title=2026_Global_Gathering_Programming){target="_blank"}。
 
+<!-- more -->
+
 ## Global Gathering 是什麼
 
 Global Gathering 是 Team CommUNITY 主辦的年度聚會，參加者來自世界各地，工作範圍涵蓋數位人權、網路自由，以及協助公民社會抵禦數位攻擊。


### PR DESCRIPTION
## 問題

`2026-anoni-net-global-gathering.md` 三個語系都沒有 `<!-- more -->`，部落格列表頁把整篇內文當成摘要展開，跟其他文章的長度落差很大。

## 改動

在「活動資訊見 Global Gathering 2026」那一段之後、第一個 `##` 小標之前插入標記，zh-TW、zh-CN、en 各 +2 行。列表頁留下的摘要是時間地點、攤位位置與攤位名稱三項，後面接「（請繼續閱讀→）」。

位置與 `2026-onionoo-mcp-public.md`、`2026-discord-matrix-statement.md` 的做法一致。

## 驗證

- `python3 tools/docs_style_lint.py` 掃三個檔案：0 error、0 warn
- `sh run.sh`（zh-TW，帶 `-s` strict）建置通過
- 產物 `output/blog/index.html` 確認該篇已切在標記處，並產生「（請繼續閱讀→）」連結

🤖 Generated with [Claude Code](https://claude.com/claude-code)