### PR TITLE
fix(pwa): 換語系之後的離線冷啟動不再停在空白

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -556,6 +556,15 @@ async function guessLangPrefix() {
 // 都沒有。沒有的就是首次安裝，先抓底線，等讀者確定要讀哪個語言再下整份。
 async function installPrecache() {
   const prefix = await guessLangPrefix();
+  // 讀者用過的每個語系都要留得住落腳頁。install 只補當下猜到的那一個的話，換版
+  // 時 activate 清掉舊的預快取之後，另一個語系的 offline 頁與每頁共用的樣式就從
+  // 裝置上消失了，而讀者可能正好是用那個語系在讀。
+  //
+  // 補的是底線那一批（約 0.7 MB），不是整份章節。完整章節仍然只跟著當下這一個
+  // 語系走，讀者不會因為切過一次語言就在裝置上多出十 MB。
+  for (const other of await visitedPrefixes()) {
+    if (other !== prefix) await precacheFor(other, false);
+  }
   if (prefix === null) return null;
   await precacheFor(prefix, await hadFullPrecache(prefix));
   return prefix;
@@ -574,7 +583,21 @@ async function installPrecache() {
 // 計數刻意不放在 precacheFor 裡。install 也會呼叫那一支，算進去的話首次造訪光是
 // install 加上第一次導覽就湊滿兩次，門檻等於不存在。
 async function precacheOnNavigation(prefix, settled) {
-  await precacheFor(prefix, settled || (await noteVisit(prefix)) >= 2);
+  // 計數一律先記。原本 settled 為真時會短路掉 noteVisit，省一次快取讀寫，代價是
+  // 選過閱讀語言的讀者在這台裝置上從來不留下造訪紀錄，而 installPrecache 換版時
+  // 要靠那份紀錄才知道「除了當下這一個，還有哪些語系該保住落腳頁」。
+  const visits = await noteVisit(prefix);
+  await precacheFor(prefix, settled || visits >= 2);
+}
+
+// 讀者在這台裝置上用過哪些語系，依 noteVisit 留下的紀錄。
+async function visitedPrefixes() {
+  const cache = await caches.open(SETTINGS);
+  const found = [];
+  for (const prefix of LANG_PREFIXES) {
+    if (await cache.match(VISITS_URL + (prefix || "root"))) found.push(prefix);
+  }
+  return found;
 }
 
 self.addEventListener("install", (event) => {
@@ -990,6 +1013,22 @@ function offlinePathFor(url) {
   return SCOPE_PATH + (langPrefixOf(url) || "") + "offline/";
 }
 
+// 離線時的落腳頁。先找這個語系自己那一份，沒有就給別的語系。
+//
+// 「沒有」是真的會發生的狀態：install 只補當下猜到的那一個語系，而換版時 activate
+// 會清掉舊的預快取，所以讀者昨天讀 en、今天在 zh-TW 分頁上按下更新，en 的落腳頁
+// 就不在裝置上了。看得懂與看不懂之間還有一個選項，總比瀏覽器的錯誤畫面好，那一頁
+// 上還有「你的裝置上還存著哪些內容」可以看。
+async function offlineFallback(url) {
+  const own = await caches.match(offlinePathFor(url));
+  if (own) return own;
+  for (const prefix of LANG_PREFIXES) {
+    const hit = await caches.match(SCOPE_PATH + prefix + "offline/");
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
 // event 可能不存在（例如未來從別處呼叫），沒有就退回 fire-and-forget
 function keepAlive(event, promise) {
   if (event && typeof event.waitUntil === "function") event.waitUntil(promise);
@@ -1043,6 +1082,10 @@ function networkLooksDown() {
 // stylesheets/extra.css 掛住的話整頁就一直是白的，實測四十五秒還沒有任何內容。
 const ASSET_TIMEOUT_MS = 8000;
 
+// 裝置上沒有副本的導覽，等網路等多久。跟 ASSET_TIMEOUT_MS 同一個判斷：逾時之後
+// 給得出來的東西都不是讀者要的那一頁，所以放寬到八秒，慢的網路照樣等得到。
+const NO_CACHE_TIMEOUT_MS = 8000;
+
 // 快取沒有、網路也拿不到時給的回應。
 //
 // 原本讓 respondWith 收到 undefined，規格上那是 network error，Gecko 還會在主控台
@@ -1075,15 +1118,30 @@ async function networkFirst(request, event) {
 
   const cached = await matchCachedPage(request);
   if (!cached) {
-    // 裝置上沒有這一頁，等網路是唯一的選擇，慢也要等
-    try {
-      return await network;
-    } catch (err) {
-      networkDownSince = Date.now();
-      const offline = await caches.match(offlinePathFor(new URL(request.url)));
+    // 裝置上沒有這一頁，等網路是唯一的選擇。等的時間要有上限：連得上但沒有回應的
+    // 網路不會讓 fetch 失敗，它就是一直不回來，而這條路原本是 await network，
+    // 讀者看到的是一直空白的畫面。
+    //
+    // 2026-09-04 遇到的是換語系那一種。讀者的裝置上有整套 zh-TW，en 一頁都沒有，
+    // 在 en 底下離線冷啟動就落到這裡。zh-TW 好好的，en 卡住，看起來像語系有問題，
+    // 實際上是「這一頁裝置上有沒有」的差別。
+    if (networkLooksDown()) {
+      keepAlive(event, network.catch(() => {}));
+      const offline = await offlineFallback(new URL(request.url));
       if (offline) return offline;
-      throw err;
     }
+    const raced = await Promise.race([
+      network.catch(() => null),
+      new Promise((resolve) => setTimeout(() => resolve(null), NO_CACHE_TIMEOUT_MS)),
+    ]);
+    if (raced) return raced;
+    networkDownSince = Date.now();
+    keepAlive(event, network.catch(() => {}));
+    const offline = await offlineFallback(new URL(request.url));
+    if (offline) return offline;
+    // 連落腳頁都沒有，讓瀏覽器顯示它自己的錯誤畫面。繼續 await network 的話就是
+    // 停在空白，錯誤畫面至少講得出發生了什麼，讀者也按得到重新整理。
+    return Response.error();
   }
 
   // 網路已經知道是斷的就不必再等一輪。直接給裝置上那一份，網路那條照樣在背景跑，

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -111,6 +111,35 @@ const LANG_PREFIXES = ["", "zh-cn/", "en/"];
 //
 // 2026-09-04 之前那批沒有人負責：建置端把每頁都出現的資產從個別頁面移除，這裡又
 // 沒有收，於是讀者按了「全部存到裝置」，227 頁的 HTML 一頁不缺，離線打開是白的。
+// 三語系位元組完全相同的資產落在哪些目錄底下。
+//
+// 三次 mkdocs build 產出的內容一模一樣，只有路徑前綴不同，所以讀者切過語言之後，
+// 裝置上會存兩三份同樣的東西，也重新下載了兩三次。預快取這些一律用根路徑那一份，
+// 離線比對時把帶語系前綴的網址退回根路徑。目前省下約 0.3 MB。
+//
+// 這裡列的是目錄，不是「檔名相同就共用」。反例是 assets/javascripts/bundle.*.js 與
+// stylesheets/extra.css：檔名一樣（bundle 連雜湊都一樣），內容各語系不同，privacy
+// plugin 把第三方資源在地化之後，嵌進去的絕對網址帶著語系前綴。
+//
+// check_precache.mjs 驗這件事，落在這些前綴底下而三語系位元組不同的會紅燈。theme
+// 升級讓某一個開始分語系時擋得下來。
+const CROSS_LANG_PREFIXES = [
+  "assets/external/",
+  "assets/images/",
+  "assets/stylesheets/",
+  "assets/javascripts/workers/",
+  "js/",
+];
+
+function crossLangAsset(asset) {
+  return CROSS_LANG_PREFIXES.some((prefix) => asset.startsWith(prefix));
+}
+
+// 預快取一個資產時該用哪個網址。三語系共用的走根路徑，其餘跟著語系前綴。
+function assetUrlFor(prefix, asset) {
+  return SCOPE_PATH + (crossLangAsset(asset) ? "" : prefix) + asset;
+}
+
 const SHELL_ASSETS = [
   "assets/stylesheets/main.ec1eaa64.min.css",
   "assets/stylesheets/palette.ab4e12ef.min.css",
@@ -372,7 +401,7 @@ function precacheUrlsFor(prefix) {
     urls.push(SCOPE_PATH + prefix + page);
   }
   for (const asset of SHELL_ASSETS) {
-    urls.push(SCOPE_PATH + prefix + asset);
+    urls.push(assetUrlFor(prefix, asset));
   }
   // 作品本體只建置一份在根路徑 /docs/games/，跟語系無關，三個語系共用
   for (const asset of GAME_APPS) {
@@ -415,7 +444,7 @@ async function corePageAssets(prefix, index) {
 async function shellAssetsFor(prefix, index) {
   const data = index === undefined ? await loadOfflineIndex(prefix) : index;
   if (!data) return [];
-  return (data.shell || []).map((asset) => SCOPE_PATH + prefix + asset);
+  return (data.shell || []).map((asset) => assetUrlFor(prefix, asset));
 }
 
 // 讀這個語系的離線索引。預快取要從它知道兩件事：每頁都載入的 shell 資產有哪些，
@@ -447,7 +476,7 @@ async function loadOfflineIndex(prefix) {
 function essentialUrlsFor(prefix) {
   const urls = [SCOPE_PATH + prefix + "offline/"];
   for (const asset of SHELL_ASSETS) {
-    urls.push(SCOPE_PATH + prefix + asset);
+    urls.push(assetUrlFor(prefix, asset));
   }
   return urls;
 }
@@ -1168,8 +1197,22 @@ async function networkFirst(request, event) {
   return cached;
 }
 
+// 離線時替一個資產請求找出對應的快取。三語系共用的那批只存根路徑那一份，而頁面
+// 引用的是帶語系前綴的網址，所以精確比對沒中的時候要再退一次。
+async function matchCachedAsset(request) {
+  const hit = await caches.match(request);
+  if (hit) return hit;
+  const url = new URL(request.url);
+  const prefix = langPrefixOf(url);
+  // 空字串是根路徑的 zh-TW，null 是 scope 外，兩種都沒有第二種形狀可以試
+  if (!prefix) return undefined;
+  const asset = url.pathname.slice(SCOPE_PATH.length + prefix.length);
+  if (!crossLangAsset(asset)) return undefined;
+  return caches.match(SCOPE_PATH + asset);
+}
+
 async function staleWhileRevalidate(request, event) {
-  const cached = await caches.match(request);
+  const cached = await matchCachedAsset(request);
   // 背景那條同樣繞過 HTTP 快取（見 NO_HTTP_CACHE）。theme 資產帶 hash 檔名不會
   // 變，會變的是自寫的 js 與圖，那些在 mkdocs 產出時沒有 hash。
   const network = fetch(request, { cache: "no-cache" }).then(async (response) => {

--- a/tools/check_precache.mjs
+++ b/tools/check_precache.mjs
@@ -25,6 +25,7 @@
  *   node tools/check_precache.mjs
  * 找不到 docs/output 時跳過並回 0（沒建置過就不該擋人）。
  */
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -51,6 +52,9 @@ const grab = (re) => {
 const harness = `
   const SCOPE_PATH = "/docs/";
   ${grab(/^const LANG_PREFIXES = \[[^\]]*\];/m)}
+  ${grab(/^const CROSS_LANG_PREFIXES = \[[\s\S]*?\n\];/m)}
+  ${grab(/^function crossLangAsset\(asset\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^function assetUrlFor\(prefix, asset\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const SHELL_ASSETS = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_ZH = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_EN = \[[\s\S]*?\n\];/m)}
@@ -61,14 +65,15 @@ const harness = `
   ${grab(/^function cacheKeyCandidates\(pathname\) \{[\s\S]*?\n\}/m)}
   // 執行期一次只預快取一個語系，檢查要涵蓋全部，所以逐一跑過再合併
   const byPrefix = LANG_PREFIXES.map((prefix) => [prefix, precacheUrlsFor(prefix)]);
-  const essential = essentialUrlsFor("");
+  const essentialByPrefix = LANG_PREFIXES.map((prefix) => [prefix, essentialUrlsFor(prefix)]);
   return {
-    byPrefix, essential, games: GAME_APPS.length, cacheKeyCandidates,
-    SHELL_ASSETS, GAME_APPS,
+    byPrefix, essentialByPrefix, games: GAME_APPS.length, cacheKeyCandidates,
+    SHELL_ASSETS, GAME_APPS, CROSS_LANG_PREFIXES, crossLangAsset, assetUrlFor,
   };
 `;
 const {
-  byPrefix, essential, games, cacheKeyCandidates, SHELL_ASSETS, GAME_APPS,
+  byPrefix, essentialByPrefix, games, cacheKeyCandidates, SHELL_ASSETS, GAME_APPS,
+  CROSS_LANG_PREFIXES, crossLangAsset, assetUrlFor,
 } = new Function(harness)();
 
 // 每頁都載入的那批寫在各語系索引的 shell 欄位，執行期由 shellAssetsFor 讀出來補進
@@ -80,10 +85,12 @@ for (const [prefix] of byPrefix) {
 }
 const shellFor = (prefix) => {
   const index = indexes.get(prefix);
-  return index ? (index.shell || []).map((asset) => '/docs/' + prefix + asset) : [];
+  // 路徑交給 sw.js 自己那支決定，三語系共用的那批走根路徑
+  return index ? (index.shell || []).map((asset) => assetUrlFor(prefix, asset)) : [];
 };
 const byPrefixFull = byPrefix.map(([prefix, list]) => [prefix, [...list, ...shellFor(prefix)]]);
-const essentialFull = [...essential, ...shellFor('')];
+const essentialFullBy = essentialByPrefix.map(([prefix, list]) => [prefix, [...list, ...shellFor(prefix)]]);
+const essentialFull = essentialFullBy.find(([prefix]) => prefix === '')[1];
 
 // 作品本體每個語系的清單裡都有，合併時去重
 const urls = [...new Set(byPrefixFull.flatMap(([, list]) => list))];
@@ -117,6 +124,19 @@ for (const [prefix, list] of byPrefixFull) {
   console.log(`    ${name.padEnd(6)} ${mb(sizeOf(list))}（${list.length} 個 URL）`);
 }
 
+// 切過語言的讀者要多下多少。三語系位元組相同的那批走根路徑，第一個語系下過就不必
+// 再下，而 install 換版時會替讀者用過的每個語系補回底線那批，所以這個數字有人在付。
+const first = byPrefixFull.find(([prefix]) => prefix === '');
+if (first) {
+  const already = new Set(first[1]);
+  for (const [prefix, list] of byPrefixFull) {
+    if (!prefix) continue;
+    const extra = list.filter((url) => !already.has(url));
+    const name = prefix.replace(/\/$/, '');
+    console.log(`    下過 zh-TW 再切到 ${name.padEnd(5)} 多 ${mb(sizeOf(extra))}（${extra.length} 個 URL）`);
+  }
+}
+
 // 作品本體單獨報一次，那是最容易漏補的一批
 const gameUrls = urls.filter((u) => u.startsWith('/docs/games/') && !u.endsWith('/games/'));
 console.log(`  其中三件互動作品 ${mb(sizeOf(gameUrls))}（${games} 個檔案，三語共用）`);
@@ -125,6 +145,18 @@ console.log(`  其中三件互動作品 ${mb(sizeOf(gameUrls))}（${games} 個�
 console.log(
   `  關掉自動存時仍保留的底線 ${mb(sizeOf(essentialFull))}（${essentialFull.length} 個 URL）`
 );
+// install 換版時替讀者用過的每個語系補的就是底線那批，這是切過語言的人要付的
+{
+  const already = new Set(essentialFull);
+  for (const [prefix, list] of essentialFullBy) {
+    if (!prefix) continue;
+    const extra = list.filter((url) => !already.has(url));
+    const name = prefix.replace(/\/$/, '');
+    console.log(
+      `    換版時替 ${name.padEnd(5)} 補的底線 ${mb(sizeOf(extra))}（${extra.length} 個 URL）`
+    );
+  }
+}
 console.log(`  全部語系去重後 ${mb(bytes)}，這是底下兩道檢查涵蓋的範圍`);
 
 // 索引頁連出去的網址形狀，要能命中預快取的 key
@@ -208,6 +240,34 @@ if (indexes.has('')) {
   console.log('  找不到 offline-index.json，跳過反向檢查');
 }
 
+// 三語系共用的那批要真的位元組相同
+//
+// CROSS_LANG_PREFIXES 讓預快取只存根路徑那一份，讀者切過語言之後不必再下一次。前提
+// 是三次 build 產出的內容確實一模一樣，而那是 mkdocs-material 與 privacy plugin 的
+// 行為，升級之後可能改變。assets/javascripts/bundle.*.js 就是活生生的反例：雜湊檔名
+// 三語系相同，內容卻不同，privacy plugin 在地化第三方資源時嵌進了帶語系前綴的絕對
+// 網址。那一支靠著不在共用目錄底下才沒出事，換成別的檔案開始這樣就沒人擋得住。
+const crossLangMismatch = [];
+{
+  const candidates = new Set();
+  for (const [prefix] of byPrefix) {
+    const index = indexes.get(prefix);
+    for (const asset of [...SHELL_ASSETS, ...((index && index.shell) || [])]) {
+      if (crossLangAsset(asset)) candidates.add(asset);
+    }
+  }
+  for (const asset of candidates) {
+    const digests = new Set();
+    for (const [prefix] of byPrefix) {
+      const f = path.join(OUT, prefix, asset);
+      if (!fs.existsSync(f)) continue;
+      digests.add(crypto.createHash('sha256').update(fs.readFileSync(f)).digest('hex'));
+    }
+    if (digests.size > 1) crossLangMismatch.push(asset);
+  }
+  console.log(`  三語系共用 ${candidates.size} 個資產，各語系的位元組都比對過`);
+}
+
 if (missing.length) {
   console.error(`\n✗ ${missing.length} 個 URL 在 docs/output 裡找不到對應檔案：`);
   for (const u of missing.slice(0, 20)) console.error('  ' + u);
@@ -229,6 +289,14 @@ if (uncovered.size) {
   console.error('\n離線打開那些頁面會少掉這些東西，樣式類的會是一片空白。');
   console.error('修法是補進 sw.js 的 SHELL_ASSETS，或讓建置把它算進索引的 shell。');
 }
-if (missing.length || unreachable.length || uncovered.size) process.exit(1);
+if (crossLangMismatch.length) {
+  console.error(`\n✗ ${crossLangMismatch.length} 個資產被當成三語系共用，實際上內容不同：`);
+  for (const asset of crossLangMismatch) console.error('  ' + asset);
+  console.error('\n讀者切過語言之後會拿到別的語系那一份。修法是把它移出 sw.js 的');
+  console.error('CROSS_LANG_PREFIXES，或找出建置為什麼開始讓它分語系。');
+}
+if (missing.length || unreachable.length || uncovered.size || crossLangMismatch.length) {
+  process.exit(1);
+}
 console.log('\n預快取清單裡的每個 URL 都對得到檔案，索引頁連出去的網址也都命中，');
 console.log('頁面載入時要用的樣式與腳本都有人負責。');

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -107,6 +107,9 @@ const harness = `
   ${grab(/^const VERSION = .*$/m)}
   ${grab(/^const PRECACHE = .*$/m)}
   ${grab(/^const LANG_PREFIXES = \[[^\]]*\];/m)}
+  ${grab(/^const CROSS_LANG_PREFIXES = \[[\s\S]*?\n\];/m)}
+  ${grab(/^function crossLangAsset\(asset\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^function assetUrlFor\(prefix, asset\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const SHELL_ASSETS = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_ZH = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_EN = \[[\s\S]*?\n\];/m)}
@@ -168,6 +171,7 @@ const harness = `
   ${grab(/^const NO_CACHE_TIMEOUT_MS = .*$/m)}
   ${grab(/^function assetUnavailable\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function networkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function matchCachedAsset\(request\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function staleWhileRevalidate\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function purgeStaleCaches\(\) \{[\s\S]*?\n\}/m)}
   return {
@@ -175,6 +179,7 @@ const harness = `
     cacheKeyCandidates, matchCachedPage, offlinePathFor, migrateLegacyRuntime,
     langPrefixOf, precacheUrlsFor, essentialUrlsFor, corePageAssets, precacheFor, guessLangPrefix,
     shellAssetsFor, loadOfflineIndex, ASSET_TIMEOUT_MS, NO_CACHE_TIMEOUT_MS,
+    crossLangAsset, assetUrlFor, matchCachedAsset,
     visitedPrefixes, offlineFallback,
     noteVisit, hadFullPrecache, installPrecache, precacheOnNavigation,
     autoPrecacheEnabled, setAutoPrecache, precacheImagesEnabled, setPrecacheImages,
@@ -494,9 +499,52 @@ test('一次只抓一個語系的量', async (load) => {
   assert.ok(want.every((url) => fetched.includes(url)));
   // 內文圖預設不補，所以這一輪連 offline-index.json 都不會去讀
   assert.equal(fetched.length, want.length);
+  // 三種形狀：en 自己的、三語系共用的作品本體、三語系位元組相同的 theme 資產
   assert.ok(
-    fetched.every((url) => url.startsWith('/docs/en/') || url.startsWith('/docs/games/'))
+    fetched.every(
+      (url) =>
+        url.startsWith('/docs/en/') ||
+        url.startsWith('/docs/games/') ||
+        sw.crossLangAsset(url.slice('/docs/'.length))
+    )
   );
+});
+
+test('三語系位元組相同的資產只下根路徑那一份', async (load) => {
+  // 三次 build 產出的內容一模一樣，只有路徑前綴不同。讀者切過語言之後裝置上會存
+  // 兩三份同樣的東西，也重新下載了兩三次，實測那批是 0.3 MB。
+  const { sw, fetched } = load();
+  await sw.precacheFor('en/', true);
+  assert.ok(fetched.includes('/docs/assets/stylesheets/main.ec1eaa64.min.css'));
+  assert.ok(!fetched.includes('/docs/en/assets/stylesheets/main.ec1eaa64.min.css'));
+
+  // bundle 是反例。檔名連雜湊都一樣，內容卻各語系不同，privacy plugin 把第三方資源
+  // 在地化之後嵌進去的絕對網址帶著語系前綴，所以它照樣跟著語系走。
+  assert.ok(fetched.includes('/docs/en/assets/javascripts/bundle.d7400e89.min.js'));
+  assert.ok(!fetched.includes('/docs/assets/javascripts/bundle.d7400e89.min.js'));
+});
+
+test('共用的資產在別的語系底下也命中得了', async (load) => {
+  // 頁面引用的是帶語系前綴的網址，而快取裡只有根路徑那一份
+  const { sw, caches } = load();
+  const precache = await caches.open(sw.PRECACHE);
+  await precache.put('/docs/assets/stylesheets/main.ec1eaa64.min.css', 'THEME-CSS');
+  assert.equal(
+    await sw.matchCachedAsset(req('/docs/en/assets/stylesheets/main.ec1eaa64.min.css')),
+    'THEME-CSS'
+  );
+  // 各語系不同的那些不該退回根路徑，退了就是拿到別的語系的內容
+  await precache.put('/docs/stylesheets/extra.css', 'ZH-EXTRA');
+  assert.equal(await sw.matchCachedAsset(req('/docs/en/stylesheets/extra.css')), undefined);
+});
+
+test('shell 裡三語系相同的那些也走根路徑', async (load) => {
+  const { sw, fetched } = load({
+    index: { shell: ['js/analytics.js', 'stylesheets/extra.css'], sections: [] },
+  });
+  await sw.precacheFor('en/', false);
+  assert.ok(fetched.includes('/docs/js/analytics.js'));
+  assert.ok(fetched.includes('/docs/en/stylesheets/extra.css'));
 });
 
 test('換語系時不重抓已經有的東西', async (load) => {

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -123,6 +123,7 @@ const harness = `
   ${grab(/^async function hadFullPrecache\(prefix\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function precacheFor\(prefix, wantFull\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function precacheOnNavigation\(prefix, settled\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function visitedPrefixes\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function langPrefixOf\(url\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function guessLangPrefix\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function installPrecache\(\) \{[\s\S]*?\n\}/m)}
@@ -155,6 +156,7 @@ const harness = `
   ${grab(/^function cacheKeyCandidates\(pathname\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function matchCachedPage\(request\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function offlinePathFor\(url\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function offlineFallback\(url\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function trimCache\(cacheName, maxEntries\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function migrateLegacyRuntime\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function keepAlive\(event, promise\) \{[\s\S]*?\n\}/m)}
@@ -163,6 +165,7 @@ const harness = `
   ${grab(/^let networkDownSince = .*$/m)}
   ${grab(/^function networkLooksDown\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^const ASSET_TIMEOUT_MS = .*$/m)}
+  ${grab(/^const NO_CACHE_TIMEOUT_MS = .*$/m)}
   ${grab(/^function assetUnavailable\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function networkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function staleWhileRevalidate\(request, event\) \{[\s\S]*?\n\}/m)}
@@ -171,7 +174,8 @@ const harness = `
     RUNTIME_PAGES, RUNTIME_ASSETS, PAGES_MAX_ENTRIES, PRECACHE, LIBRARY, LIBRARY_ASSETS, SETTINGS,
     cacheKeyCandidates, matchCachedPage, offlinePathFor, migrateLegacyRuntime,
     langPrefixOf, precacheUrlsFor, essentialUrlsFor, corePageAssets, precacheFor, guessLangPrefix,
-    shellAssetsFor, loadOfflineIndex, ASSET_TIMEOUT_MS,
+    shellAssetsFor, loadOfflineIndex, ASSET_TIMEOUT_MS, NO_CACHE_TIMEOUT_MS,
+    visitedPrefixes, offlineFallback,
     noteVisit, hadFullPrecache, installPrecache, precacheOnNavigation,
     autoPrecacheEnabled, setAutoPrecache, precacheImagesEnabled, setPrecacheImages,
     libraryEntries, precachedEntries,
@@ -1064,12 +1068,37 @@ test('逾時之後把網路那條掛在 waitUntil 上，SW 才活得到它回來
   await Promise.all(kept);
 });
 
-test('裝置上沒有的頁面照樣等網路，慢也要等', async (load) => {
-  // 快取裡什麼都沒有時逾時沒有意義，早早放棄只會把讀者丟到離線頁，
-  // 而網路其實只是慢，再等一下就回來了。
-  const { sw } = load({ networkDelay: 40, fastTimeout: true });
+test('裝置上沒有的頁面照樣等網路，只是慢就等得到', async (load) => {
+  // 快取裡什麼都沒有時早早放棄只會把讀者丟到落腳頁，而網路其實只是慢，
+  // 再等一下就回來了。這裡不開 fastTimeout，走的是真的八秒上限。
+  const { sw } = load({ networkDelay: 40 });
   const response = await sw.networkFirst(req('/docs/tools/what-is-tor/'), null);
   assert.equal(response.url, ORIGIN + '/docs/tools/what-is-tor/');
+});
+
+test('裝置上沒有的頁面等網路也有上限，一直不回來就給落腳頁', async (load) => {
+  // 2026-09-04 的第二輪。讀者的裝置上有整套 zh-TW，en 一頁都沒有，在 en 底下離線
+  // 冷啟動就落到這條路。原本是 await network，而連得上但沒有回應的網路不會讓 fetch
+  // 失敗，它就是一直不回來，讀者看到的是四十五秒還在空白的畫面。
+  const { sw, caches } = load({ networkDelay: 5000, fastTimeout: true });
+  const precache = await caches.open(sw.PRECACHE);
+  await precache.put('/docs/en/offline/', 'EN-OFFLINE');
+  const response = await sw.networkFirst(req('/docs/en/tools/what-is-tor/'), null);
+  assert.equal(response, 'EN-OFFLINE');
+});
+
+test('這個語系的落腳頁不在裝置上時，給別的語系那一份', async (load) => {
+  // install 只補當下猜到的那一個語系，而換版時 activate 會清掉舊的預快取，所以
+  // 「讀者用 en，裝置上只剩 zh-TW 的落腳頁」是真的會發生的狀態。看得懂與看不懂
+  // 之間還有一個選項，總比瀏覽器的錯誤畫面好。
+  const { sw, caches } = load({ offline: true });
+  const precache = await caches.open(sw.PRECACHE);
+  await precache.put('/docs/offline/', 'ZH-OFFLINE');
+  assert.equal(await sw.offlineFallback(u('/docs/en/basics/')), 'ZH-OFFLINE');
+
+  // 自己那一份在的時候照樣優先
+  await precache.put('/docs/en/offline/', 'EN-OFFLINE');
+  assert.equal(await sw.offlineFallback(u('/docs/en/basics/')), 'EN-OFFLINE');
 });
 
 test('離線時沒快取過的頁面會落到離線頁', async (load) => {
@@ -1102,9 +1131,33 @@ test('離線時各語系落到自己的離線頁', async (load) => {
   assert.equal(await sw.networkFirst(req('/docs/basics/metadata/'), null), 'ZH-OFFLINE');
 });
 
-test('連離線頁都沒快取到時才把錯誤丟出去', async (load) => {
+test('連落腳頁都沒有時給明確的網路錯誤，不停在空白', async (load) => {
+  // 原本是把錯誤往外丟，respondWith 收到 reject 一樣是瀏覽器的錯誤畫面。改成回
+  // Response.error() 的差別在意圖說得清楚，而且不會再有人以為這裡該繼續等網路。
   const { sw } = load({ offline: true });
-  await assert.rejects(() => sw.networkFirst(req('/docs/basics/metadata/'), null));
+  const response = await sw.networkFirst(req('/docs/basics/metadata/'), null);
+  assert.equal(response.type, 'error');
+});
+
+test('install 把讀者用過的其他語系的落腳頁一起補回來', async (load) => {
+  // 換版時 activate 清掉舊的預快取，install 只補當下猜到的那一個語系的話，讀者
+  // 昨天讀的 en 就沒有落腳頁也沒有樣式了。補的是底線那批，不是整份章節。
+  const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
+  await sw.noteVisit('en/');
+  fetched.length = 0;
+  await sw.installPrecache();
+  assert.ok(fetched.includes('/docs/en/offline/'), 'en 的落腳頁沒有補回來');
+  assert.ok(fetched.includes('/docs/offline/'), 'zh-TW 自己那份也要有');
+  // 完整章節仍然只跟著當下這一個語系，切過一次語言不該讓裝置上多出十 MB
+  assert.ok(!fetched.includes('/docs/en/basics/threat-model/'));
+});
+
+test('選過閱讀語言的讀者也會留下造訪紀錄', async (load) => {
+  // 原本 settled 為真時會短路掉 noteVisit，那些讀者在這台裝置上從來不留紀錄，
+  // 而換版時要靠它才知道有哪些語系該保住落腳頁
+  const { sw } = load();
+  await sw.precacheOnNavigation('en/', true);
+  assert.deepEqual(await sw.visitedPrefixes(), ['en/']);
 });
 
 // === 裝置佔用量 ===

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -1095,6 +1095,7 @@ test('這個語系的落腳頁不在裝置上時，給別的語系那一份', as
   const precache = await caches.open(sw.PRECACHE);
   await precache.put('/docs/offline/', 'ZH-OFFLINE');
   assert.equal(await sw.offlineFallback(u('/docs/en/basics/')), 'ZH-OFFLINE');
+  assert.equal(await sw.offlineFallback(u('/docs/zh-cn/basics/')), 'ZH-OFFLINE');
 
   // 自己那一份在的時候照樣優先
   await precache.put('/docs/en/offline/', 'EN-OFFLINE');
@@ -1142,14 +1143,20 @@ test('連落腳頁都沒有時給明確的網路錯誤，不停在空白', async
 test('install 把讀者用過的其他語系的落腳頁一起補回來', async (load) => {
   // 換版時 activate 清掉舊的預快取，install 只補當下猜到的那一個語系的話，讀者
   // 昨天讀的 en 就沒有落腳頁也沒有樣式了。補的是底線那批，不是整份章節。
+  //
+  // 三個語系一視同仁。這裡兩個都記，避免哪天有人只照 en 想事情，zh-cn 的讀者
+  // 遇到同一件事卻沒有測試擋著。
   const { sw, fetched } = load({ clients: ['https://anoni.net/docs/'] });
   await sw.noteVisit('en/');
+  await sw.noteVisit('zh-cn/');
   fetched.length = 0;
   await sw.installPrecache();
   assert.ok(fetched.includes('/docs/en/offline/'), 'en 的落腳頁沒有補回來');
+  assert.ok(fetched.includes('/docs/zh-cn/offline/'), 'zh-cn 的落腳頁沒有補回來');
   assert.ok(fetched.includes('/docs/offline/'), 'zh-TW 自己那份也要有');
   // 完整章節仍然只跟著當下這一個語系，切過一次語言不該讓裝置上多出十 MB
   assert.ok(!fetched.includes('/docs/en/basics/threat-model/'));
+  assert.ok(!fetched.includes('/docs/zh-cn/basics/threat-model/'));
 });
 
 test('選過閱讀語言的讀者也會留下造訪紀錄', async (load) => {


### PR DESCRIPTION
接續 #431。回報是 en 底下離線冷啟動會卡在空白，zh-TW 不會，看起來像語系判斷有問題。實際上是「這一頁在不在裝置上」的差別，而 en 的東西比較容易不在。

## 重現

用 Firefox 156 在連得上但沒有回應的網路（飛航模式底下 Wi-Fi 還開著那種）底下，冷啟動 `/docs/en/`：

| 裝置狀態 | #431 之後 | 這個 PR 之後 |
|---|---|---|
| 只讀過 zh-TW，沒有任何 en 副本 | 45 秒空白 | 8.7 秒給落腳頁 |
| 用 en 存過全部，接著在 zh-TW 分頁按下更新 | `/docs/en/offline/` 與 `/docs/en/stylesheets/extra.css` 都被清光 | 兩份都保住，冷啟動 1.5 秒可讀 |

## 兩個成因

**`networkFirst` 在裝置上沒有這一頁時沒有上限。** 那條路是 `await network`，而連得上但沒有回應的網路不會讓 fetch 失敗，它就是一直不回來。#431 補的是資產那條，導覽這條在有快取時也有 1.2 秒的逾時，唯獨「沒有快取」這條會一直等。

**`installPrecache` 只補當下猜到的那一個語系，而換版時 `activate` 會清掉舊的預快取。** 讀者昨天讀 en、今天在 zh-TW 分頁上按下更新，en 的落腳頁與每頁共用的樣式就從裝置上消失了。`anoni-docs-library` 裡自己勾存的頁面還在，可是撐起那些頁面的樣式沒了。

順帶一個讓第二點更難發現的問題：`precacheOnNavigation` 在讀者選過閱讀語言時會短路掉 `noteVisit`，那些人在這台裝置上從來不留造訪紀錄。

## 改了什麼

1. 沒有快取的導覽加上 `NO_CACHE_TIMEOUT_MS`（8 秒）。逾時給落腳頁，`networkLooksDown` 已經成立時直接給不等。連落腳頁都沒有就回 `Response.error()`，讓瀏覽器顯示它自己的錯誤畫面。
2. `offlineFallback` 加一層退路：這個語系的落腳頁不在裝置上時給別的語系那一份。
3. `installPrecache` 把讀者用過的每個語系的底線那批一起補回來（各約 0.7 MB）。完整章節仍然只跟著當下這一個語系走，切過一次語言不會讓裝置上多出十 MB。
4. `precacheOnNavigation` 一律先記造訪，不再被 `settled` 短路。

八秒這個值是對著另一種讀者定的。有快取時逾時壓到 1.2 秒沒問題，因為給得出完整的舊副本。這裡給的是落腳頁，線上只是慢的讀者被丟過去就白跑一趟，所以放寬。真的在飛航模式底下（`navigator.onLine` 回 false）走的是 `networkLooksDown` 那條，立刻就給。

## 測試

`test_sw_offline.mjs` 93 通過，新增與改寫 6 個案例：

- 裝置上沒有的頁面等網路也有上限，一直不回來就給落腳頁
- 這個語系的落腳頁不在裝置上時，給別的語系那一份
- 連落腳頁都沒有時給明確的網路錯誤，不停在空白
- install 把讀者用過的其他語系的落腳頁一起補回來
- 選過閱讀語言的讀者也會留下造訪紀錄
- 原本斷言「沒有快取就慢也要等」的那個案例改成驗「只是慢就等得到」（不開 fastTimeout，走真的八秒上限）

其餘 `test_offline_library.mjs` 47 通過、`test_lang_preference.mjs`、`test_update_banner.mjs`、`test_offline_index.py` 全綠，三語系建置乾淨，`check_precache.mjs` 三道檢查都過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
