### PR TITLE
fix(pwa): 首頁進底線那批，離線時的語言導向才跳得過去

### DIFF
--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -709,13 +709,30 @@
           })[0];
           var pref = readPref();
           var goTo = langRedirectTo(IS_HOME, current && current.lang, pref, DEFAULT_LANG);
+          // 跳過去之前先確認那一頁打得開。
+          //
+          // PWA 的 start_url 是安裝當下那個語系的首頁，而讀者的閱讀語言可能是另一個，
+          // 所以每次冷啟動都會走這一跳。沒有網路又沒有副本的時候跳過去只會停在空白，
+          // 讀者反而失去手上這一頁。留在原地至少看得到內容，header 的語言切換器也還在。
+          //
+          // 有副本就跳。沒副本但看起來連得上網也跳，那是線上第一次造訪的正常情況。
+          function redirectTo(href) {
+            var go = function () {
+              // replace 而不是 assign，讓上一頁還是讀者原本來的地方
+              location.replace(href);
+            };
+            if (!window.caches || !window.caches.match) return go();
+            caches.match(href).then(function (hit) {
+              if (hit || navigator.onLine !== false) go();
+            }, go);
+          }
+
           if (goTo) {
             var target = links.filter(function (link) {
               return link.lang === goTo;
             })[0];
             if (target) {
-              // replace 而不是 assign，讓上一頁還是讀者原本來的地方
-              location.replace(target.href);
+              redirectTo(target.href);
               return;
             }
           }

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -193,6 +193,7 @@
       savedCount: "你自己選存的 {n} 頁",
       autoCount: "網站自動存的 {n} 頁",
       usage: "本站在這台裝置上佔用 {used}",
+      version: "離線內容版本 {version}",
       usageFree: "本站在這台裝置上佔用 {used}，可用空間還有 {free}",
       autoLabel: "自動存下核心章節與你讀過的頁面",
       autoHint: "關掉之後網站不再自動存任何內容，你讀過的頁面也不會留在裝置上。這一頁本身與它需要的樣式仍會留著（約 0.7 MB），沒有網路時你才進得來。你自己勾的頁面不受影響。",
@@ -244,6 +245,7 @@
       savedCount: "你自己选存的 {n} 页",
       autoCount: "网站自动存的 {n} 页",
       usage: "本站在这台设备上占用 {used}",
+      version: "离线内容版本 {version}",
       usageFree: "本站在这台设备上占用 {used}，可用空间还有 {free}",
       autoLabel: "自动存下核心章节与你读过的页面",
       autoHint: "关掉之后网站不再自动存任何内容，你读过的页面也不会留在设备上。这一页本身与它需要的样式仍会留着（约 0.7 MB），没有网络时你才进得来。你自己勾的页面不受影响。",
@@ -295,6 +297,7 @@
       savedCount: "{n} pages you chose to keep",
       autoCount: "{n} pages stored automatically",
       usage: "This site uses {used} on this device",
+      version: "Offline content version {version}",
       usageFree: "This site uses {used} on this device, with {free} still available",
       autoLabel: "Automatically store the core chapters and the pages you read",
       autoHint: "Turning this off stops the site from storing anything automatically, including the pages you read. This page itself and the styles it needs stay (about 0.7 MB), so you can still get here without a network. Pages you ticked are unaffected.",
@@ -444,6 +447,9 @@
     precacheImages: false,
     // 本站在裝置上佔用多少 byte，由 SW 量自己的快取算出來
     usage: null,
+    // 這台裝置上的 service worker 是哪一版。讀者回報離線出問題時，第一個要分辨的
+    // 就是他換到新版了沒。
+    version: null,
     // 瀏覽器給的配額，只用來算「還剩多少空間」
     estimate: null,
     // 讀者這一輪勾選的變動，套用之前不動快取
@@ -482,6 +488,7 @@
       state.autoPrecache = data.autoPrecache !== false;
       state.precacheImages = data.precacheImages === true;
       state.usage = typeof data.usage === "number" ? data.usage : null;
+      state.version = typeof data.version === "string" ? data.version : null;
       state.estimate = data.estimate || null;
       state.add.clear();
       state.remove.clear();
@@ -556,6 +563,14 @@
             : fill("usageFree", { used: size(state.usage), free: size(free) })
         )
       );
+    }
+    // 版本另起一行。讀者回報離線出問題時，這是分辨「換到新版了沒」唯一看得到的地方。
+    if (state.version) {
+      status.appendChild(document.createElement("br"));
+      const line = document.createElement("small");
+      line.className = "ol-version";
+      line.textContent = fill("version", { version: state.version });
+      status.appendChild(line);
     }
     return status;
   }

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -194,6 +194,12 @@
       autoCount: "網站自動存的 {n} 頁",
       usage: "本站在這台裝置上佔用 {used}",
       version: "離線內容版本 {version}",
+      readyOk: "沒有網路時，{items}都打得開。",
+      readyMissing: "沒有網路時打不開：{items}。連上網路後會自動補回來。",
+      readyJoin: "、",
+      readyHere: "這一頁",
+      readyHome: "首頁",
+      readyAssets: "樣式與程式",
       usageFree: "本站在這台裝置上佔用 {used}，可用空間還有 {free}",
       autoLabel: "自動存下核心章節與你讀過的頁面",
       autoHint: "關掉之後網站不再自動存任何內容，你讀過的頁面也不會留在裝置上。這一頁本身與它需要的樣式仍會留著（約 0.7 MB），沒有網路時你才進得來。你自己勾的頁面不受影響。",
@@ -246,6 +252,12 @@
       autoCount: "网站自动存的 {n} 页",
       usage: "本站在这台设备上占用 {used}",
       version: "离线内容版本 {version}",
+      readyOk: "没有网络时，{items}都打得开。",
+      readyMissing: "没有网络时打不开：{items}。连上网络后会自动补回来。",
+      readyJoin: "、",
+      readyHere: "这一页",
+      readyHome: "首页",
+      readyAssets: "样式与程序",
       usageFree: "本站在这台设备上占用 {used}，可用空间还有 {free}",
       autoLabel: "自动存下核心章节与你读过的页面",
       autoHint: "关掉之后网站不再自动存任何内容，你读过的页面也不会留在设备上。这一页本身与它需要的样式仍会留着（约 0.7 MB），没有网络时你才进得来。你自己勾的页面不受影响。",
@@ -298,6 +310,12 @@
       autoCount: "{n} pages stored automatically",
       usage: "This site uses {used} on this device",
       version: "Offline content version {version}",
+      readyOk: "Without a network, {items} all open.",
+      readyMissing: "Without a network these do not open: {items}. They come back once you are online.",
+      readyJoin: ", ",
+      readyHere: "this page",
+      readyHome: "the home page",
+      readyAssets: "styles and scripts",
       usageFree: "This site uses {used} on this device, with {free} still available",
       autoLabel: "Automatically store the core chapters and the pages you read",
       autoHint: "Turning this off stops the site from storing anything automatically, including the pages you read. This page itself and the styles it needs stay (about 0.7 MB), so you can still get here without a network. Pages you ticked are unaffected.",
@@ -450,6 +468,9 @@
     // 這台裝置上的 service worker 是哪一版。讀者回報離線出問題時，第一個要分辨的
     // 就是他換到新版了沒。
     version: null,
+    // 沒有網路時這台裝置上打得開什麼。容量數字回答不了「能不能用」，這裡直接去問
+    // 快取。讀者回報離線出問題時，這一行是唯一講得出「缺的是哪一塊」的地方。
+    readiness: null,
     // 瀏覽器給的配額，只用來算「還剩多少空間」
     estimate: null,
     // 讀者這一輪勾選的變動，套用之前不動快取
@@ -480,6 +501,51 @@
     if (window.anoniTrack) window.anoniTrack("offline-action", { action: action });
   }
 
+  // 沒有網路時這台裝置上打得開什麼。
+  //
+  // 容量數字回答不了「能不能用」。讀者存了兩百多頁，缺的卻可能是每頁都要的那個
+  // 樣式，那時佔用量看起來很健康，而每一頁打開都是空白。這裡直接去問 Cache
+  // Storage，缺哪一塊就說哪一塊。
+  //
+  // 首頁單獨列一項，因為它是 PWA 的 start_url，也是語言導向的落點。讀者的 PWA 從
+  // 另一個語系的首頁啟動時，那一跳的目標不在裝置上就會停在空白。
+  //
+  // 檢查的都是當下這個語系的網址。讀者到哪一個語系的這一頁，看到的就是那個語系的
+  // 狀態。管理頁不去猜他平常讀哪一個：那個偏好存在瀏覽器的持久儲存裡，而這支程式
+  // 刻意一個字都不碰（見底下那條測試）。
+  function readinessTargets() {
+    const here = location.href.split("#")[0].split("?")[0];
+    const links = document.querySelectorAll
+      ? Array.prototype.slice.call(document.querySelectorAll("link[rel=stylesheet]"))
+      : [];
+    const styles = links
+      .map((link) => link.href)
+      .filter((href) => href && href.indexOf(location.origin) === 0);
+    return [
+      { key: "readyHere", hrefs: [here] },
+      { key: "readyHome", hrefs: [new URL("../", location.href).href] },
+      { key: "readyAssets", hrefs: styles },
+    ];
+  }
+
+  function checkReadiness() {
+    if (!window.caches || !window.caches.match) return Promise.resolve(null);
+    // 這一行是額外的資訊，算不出來就不顯示，不能讓它擋住整個狀態列
+    const targets = readinessTargets();
+    return Promise.all(
+      targets.map((target) =>
+        Promise.all(target.hrefs.map((href) => caches.match(href))).then((hits) =>
+          hits.length && hits.every(Boolean) ? null : target.key
+        )
+      )
+    )
+      .then((missing) => ({
+        missing: missing.filter(Boolean),
+        all: targets.map((target) => target.key),
+      }))
+      .catch(() => null);
+  }
+
   function refreshStatus() {
     return ask({ type: "OFFLINE_STATUS", url: location.href }).then((data) => {
       if (data.type !== "status") throw new Error("bad-status");
@@ -492,7 +558,11 @@
       state.estimate = data.estimate || null;
       state.add.clear();
       state.remove.clear();
-    });
+    }).then(() =>
+      checkReadiness().then((readiness) => {
+        state.readiness = readiness;
+      })
+    );
   }
 
   // 網站自動存的那批也算在裝置上，勾選框對它們沒有意義，顯示成已存並停用
@@ -545,7 +615,9 @@
     status.appendChild(
       document.createTextNode(fill("savedCount", { n: state.saved.size }))
     );
-    status.appendChild(document.createTextNode("、"));
+    // 這個分隔符原本寫死成頓號，英文版於是變成
+    // 「0 pages you chose to keep、0 pages stored automatically」。跟著語系走。
+    status.appendChild(document.createTextNode(t.readyJoin));
     status.appendChild(
       document.createTextNode(fill("autoCount", { n: state.precached.size }))
     );
@@ -561,6 +633,19 @@
           free === null
             ? fill("usage", { used: size(state.usage) })
             : fill("usageFree", { used: size(state.usage), free: size(free) })
+        )
+      );
+    }
+    // 「能不能用」直接寫出來，缺哪一塊就講哪一塊
+    if (state.readiness) {
+      // 並列的連接符跟著語系走。中文用頓號，英文用逗號加空格。
+      const names = (keys) => keys.map((key) => t[key]).join(t.readyJoin);
+      status.appendChild(document.createElement("br"));
+      status.appendChild(
+        document.createTextNode(
+          state.readiness.missing.length
+            ? fill("readyMissing", { items: names(state.readiness.missing) })
+            : fill("readyOk", { items: names(state.readiness.all) })
         )
       );
     }

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -471,10 +471,23 @@ async function loadOfflineIndex(prefix) {
 // 進不去的話整個功能等於不存在。少了它，沒快取過的網址在離線時會一路走到
 // networkFirst 最後的 throw，讀者看到的是瀏覽器自己的網路錯誤畫面。
 //
-// 這一批約 0.7 MB（含索引 shell 欄位那批每頁共用的樣式與腳本），相對於完整章節的
-// 十 MB 是可以接受的底線。
+// 這一批約 0.97 MB（首頁、離線閱讀頁，加上索引 shell 欄位那批每頁共用的樣式與腳本），
+// 相對於完整章節的十 MB 是可以接受的底線。三語系共用的資產只算一份，讀者用過第二個
+// 語系時實際多下的是 0.64 MB。
+// 底線那批裡的頁面。essentialUrlsFor 與 hadFullPrecache 共用這一份：後者要挑一個
+// 「只有完整章節才會有」的頁面當探針，兩邊寫在一起才不會不同步。2026-09-04 首頁進了
+// 底線那批之後，探針原本還指著首頁，只存過底線的裝置就被當成上一版有完整章節。
+const ESSENTIAL_PAGES = ["", "offline/"];
+
 function essentialUrlsFor(prefix) {
-  const urls = [SCOPE_PATH + prefix + "offline/"];
+  // 首頁跟離線閱讀頁一起進來。首頁是 PWA 的 start_url，也是語言導向的落點：讀者的
+  // PWA 是從 zh-TW 的首頁裝的，那一頁的 JS 讀到閱讀語言是 en 就 location.replace 到
+  // en 的首頁。離線時那一跳的目標不在裝置上，讀者會先看到 zh-TW 一眼，接著停在空白，
+  // 而他明明存著整套 en。
+  //
+  // 關掉自動存的讀者更需要它。那些人裝置上只有這一批，少了首頁，PWA 冷啟動的第一個
+  // 網址就落在快取外面。
+  const urls = ESSENTIAL_PAGES.map((page) => SCOPE_PATH + prefix + page);
   for (const asset of SHELL_ASSETS) {
     urls.push(assetUrlFor(prefix, asset));
   }
@@ -506,7 +519,8 @@ async function noteVisit(prefix) {
 async function hadFullPrecache(prefix) {
   const pages = CORE_PAGES_BY_PREFIX[prefix] || CORE_PAGES_ZH;
   // 挑一個不在底線那批裡的頁面當探針，有它就代表上一版下的是完整章節
-  const probe = SCOPE_PATH + prefix + pages.find((page) => page !== "offline/");
+  const probe =
+    SCOPE_PATH + prefix + pages.find((page) => !ESSENTIAL_PAGES.includes(page));
   for (const name of await caches.keys()) {
     if (!name.startsWith("anoni-docs-precache-")) continue;
     if (await (await caches.open(name)).match(probe)) return true;
@@ -863,6 +877,9 @@ async function handleLibraryMessage(data, port) {
       precached: await precachedEntries(prefix),
       autoPrecache: await autoPrecacheEnabled(),
       precacheImages: await precacheImagesEnabled(),
+      // 這台裝置上跑的是哪一版。讀者回報「離線打不開」時，第一個要分辨的就是他的
+      // service worker 換到新版了沒，而那件事在裝置上原本沒有任何地方看得出來。
+      version: VERSION,
       // 本站佔用自己算，見 cacheUsage。estimate 只拿來報「裝置還剩多少空間」，
       // 那是配額問題，本來就該問瀏覽器。
       usage: await cacheUsage(),

--- a/tools/check_precache.mjs
+++ b/tools/check_precache.mjs
@@ -61,6 +61,7 @@ const harness = `
   ${grab(/^const GAME_APPS = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_BY_PREFIX = \{[\s\S]*?\n\};/m)}
   ${grab(/^function precacheUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^const ESSENTIAL_PAGES = \[[^\]]*\];/m)}
   ${grab(/^function essentialUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function cacheKeyCandidates\(pathname\) \{[\s\S]*?\n\}/m)}
   // 執行期一次只預快取一個語系，檢查要涵蓋全部，所以逐一跑過再合併

--- a/tools/test_lang_preference.mjs
+++ b/tools/test_lang_preference.mjs
@@ -37,7 +37,32 @@ const found = src.match(re);
 if (!found) throw new Error('base.html 裡找不到 langRedirectTo');
 const langRedirectTo = new Function(`${found[0]}\nreturn langRedirectTo;`)();
 
+// 導向前的那道確認也抽出來。PWA 的 start_url 是安裝當下那個語系的首頁，讀者的閱讀
+// 語言是另一個的話，每次冷啟動都會走這一跳，而離線時跳到沒有副本的地方就是空白。
+// 這個函式裡有巢狀的 function，非貪婪比對會停在裡面那個的結尾，所以用縮排定位
+// 外層的收尾括號。base.html 裡它縮排十格。
+const reRedirect = /^ {10}function redirectTo\(href\) \{[\s\S]*?\n {10}\}/m;
+const foundRedirect = src.match(reRedirect);
+if (!foundRedirect) throw new Error('base.html 裡找不到 redirectTo');
+const loadRedirect = (opts) => {
+  const calls = [];
+  const location = { replace: (href) => calls.push(href) };
+  const navigator = { onLine: opts.onLine };
+  const caches = opts.noCaches
+    ? undefined
+    : { match: async (href) => (opts.cached || []).includes(href) ? 'HIT' : undefined };
+  const window = { caches };
+  const redirectTo = new Function(
+    'window', 'caches', 'navigator', 'location',
+    `${foundRedirect[0]}\nreturn redirectTo;`
+  )(window, caches, navigator, location);
+  return { redirectTo, calls };
+};
+
 const ZH = 'zh-TW';
+
+const HOME_EN = 'https://anoni.net/docs/en/';
+
 
 let passed = 0;
 let failed = 0;
@@ -76,6 +101,38 @@ test('認不出當前語言時不動', () => {
   assert.equal(langRedirectTo(true, undefined, 'en', ZH), null);
   assert.equal(langRedirectTo(true, null, 'en', ZH), null);
 });
+
+test('離線時跳過去的那一頁沒有副本就留在原地', async () => {
+  // PWA 從 zh-TW 的首頁啟動，讀者的閱讀語言是 en，每次冷啟動都會走這一跳。裝置上
+  // 沒有 en 首頁的時候跳過去只會停在空白，讀者反而失去手上這一頁看得到的內容。
+  const { redirectTo, calls } = loadRedirect({ onLine: false, cached: [] });
+  redirectTo(HOME_EN);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, []);
+});
+
+test('離線但裝置上有那一頁就照跳', async () => {
+  const { redirectTo, calls } = loadRedirect({ onLine: false, cached: [HOME_EN] });
+  redirectTo(HOME_EN);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, [HOME_EN]);
+});
+
+test('線上第一次造訪沒有副本也照跳', async () => {
+  // 沒有副本是線上讀者的正常狀態，這裡不該擋
+  const { redirectTo, calls } = loadRedirect({ onLine: true, cached: [] });
+  redirectTo(HOME_EN);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, [HOME_EN]);
+});
+
+test('瀏覽器沒有 Cache Storage 時照舊直接跳', async () => {
+  const { redirectTo, calls } = loadRedirect({ onLine: false, noCaches: true });
+  redirectTo(HOME_EN);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, [HOME_EN]);
+});
+
 
 for (const [name, fn] of tests) {
   try {

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -872,11 +872,22 @@ test('service worker 還在準備時，清單先畫出來不必等它', async ()
   assert.deepEqual(sectionNames(root), ['首頁', '概念', '場景']);
 });
 
-test('狀態列寫出這台裝置上的離線內容版本', async () => {
+test('狀態列寫出這台裝置上的離線內容版本，三個語系都有', async () => {
   // 讀者回報離線出問題時，第一個要分辨的是他的 service worker 換到新版了沒，
-  // 而那件事在裝置上原本沒有任何地方看得出來
-  const { root } = await load({ version: '202609042020' });
-  assert.ok(root.querySelector('.ol-status').textContent.includes('202609042020'));
+  // 而那件事在裝置上原本沒有任何地方看得出來。
+  //
+  // 三個語系各驗一次。這一頁是三語系共用的同一支程式，字串靠 documentElement.lang
+  // 挑，而 zh-CN 版的那個屬性是 "zh"，漏一組就是那個語系的讀者看到空白或英文。
+  for (const [lang, needle] of [
+    ['zh-TW', '離線內容版本'],
+    ['zh', '离线内容版本'],
+    ['en', 'Offline content version'],
+  ]) {
+    const { root } = await load({ lang, version: '202609042020' });
+    const text = root.querySelector('.ol-status').textContent;
+    assert.ok(text.includes(needle), `${lang} 應該看到「${needle}」`);
+    assert.ok(text.includes('202609042020'), `${lang} 應該看到版本號`);
+  }
 });
 
 test('舊版 service worker 不回版本時狀態列照樣畫得出來', async () => {

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -205,6 +205,7 @@ const makeServiceWorker = (opts) => {
             autoPrecache: state.autoPrecache,
             precacheImages: state.precacheImages,
             estimate: opts.estimate || null,
+            version: opts.version,
           });
         } else if (message.type === 'OFFLINE_ADD') {
           // 模擬網路很差：service worker 收到了，但一筆都還沒回報
@@ -869,6 +870,20 @@ test('service worker 還在準備時，清單先畫出來不必等它', async ()
   const { root } = await load({ noRegistration: true });
   assert.ok(root.querySelector('.ol-status').textContent.includes('還在準備'));
   assert.deepEqual(sectionNames(root), ['首頁', '概念', '場景']);
+});
+
+test('狀態列寫出這台裝置上的離線內容版本', async () => {
+  // 讀者回報離線出問題時，第一個要分辨的是他的 service worker 換到新版了沒，
+  // 而那件事在裝置上原本沒有任何地方看得出來
+  const { root } = await load({ version: '202609042020' });
+  assert.ok(root.querySelector('.ol-status').textContent.includes('202609042020'));
+});
+
+test('舊版 service worker 不回版本時狀態列照樣畫得出來', async () => {
+  // 讀者的裝置上還跑著上一版時，OFFLINE_STATUS 的回覆裡沒有這個欄位
+  const { root } = await load({});
+  assert.ok(root.querySelector('.ol-status'));
+  assert.ok(!root.querySelector('.ol-version'));
 });
 
 test('三個語系各自挑到自己那組字串', async () => {

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -166,12 +166,17 @@ class FakeText extends FakeElement {
 
 // 根節點的 id 決定原始碼畫哪一種介面：offline-library 是管理頁，start-offline 是
 // 起步索引頁的路徑按鈕。查別的 id 一律回 null，兩個根節點不會同時存在。
-const makeDocument = (root, lang) => ({
+const makeDocument = (root, lang, opts = {}) => ({
   documentElement: { lang },
   head: new FakeElement('head'),
   getElementById: (id) => (id === root.id ? root : null),
   createElement: (tag) => new FakeElement(tag),
   createTextNode: (text) => new FakeText(text),
+  // 離線可用性那一行要知道這一頁載入了哪些樣式表
+  querySelectorAll: (selector) =>
+    selector === 'link[rel=stylesheet]'
+      ? (opts.stylesheets || []).map((href) => ({ href }))
+      : [],
 });
 
 // ---------------------------------------------------------------------------
@@ -358,15 +363,22 @@ const tick = (n = 6) =>
 const load = async (opts = {}) => {
   const root = new FakeElement('div');
   root.id = opts.picker ? 'start-offline' : 'offline-library';
-  const document = makeDocument(root, opts.lang || 'zh-TW');
+  const document = makeDocument(root, opts.lang || 'zh-TW', opts);
   const sw = makeServiceWorker(opts);
   const navigator = {
     serviceWorker: sw.api,
     onLine: opts.online !== false,
   };
-  const window = { __anoniServiceWorker: opts.swFlag !== false };
+  // 離線可用性那一行去問 Cache Storage。opts.cached 沒給就當這個瀏覽器沒有這個 API，
+  // 那一行不顯示，其餘照舊。
+  const caches =
+    opts.cached === undefined
+      ? undefined
+      : { match: async (href) => (opts.cached.includes(href) ? 'HIT' : undefined) };
+  const window = { __anoniServiceWorker: opts.swFlag !== false, caches };
   const location = {
     href: opts.picker ? 'https://anoni.net/docs/start/' : 'https://anoni.net/docs/offline/',
+    origin: 'https://anoni.net',
   };
   const fetched = [];
   const fetchStub = async (url) => {
@@ -400,10 +412,13 @@ const load = async (opts = {}) => {
   }
   new Function(
     'document', 'window', 'navigator', 'location', 'fetch', 'MessageChannel', 'setTimeout', 'URL',
+    'caches',
     src
-  )(document, window, navigator, location, fetchStub, MessageChannelStub, setTimeout, URL);
+  )(document, window, navigator, location, fetchStub, MessageChannelStub, setTimeout, URL, caches);
 
-  await tick(12);
+  // 等初始化那串 promise 跑完。狀態回覆之後還要問一輪 Cache Storage 算離線可用性，
+  // 輪數不夠的話會停在「還在準備」，而畫面上看起來只是狀態列的字不一樣。
+  await tick(24);
   return { root, sw, fetched, document };
 };
 
@@ -872,6 +887,37 @@ test('service worker 還在準備時，清單先畫出來不必等它', async ()
   assert.deepEqual(sectionNames(root), ['首頁', '概念', '場景']);
 });
 
+test('狀態列直接回答沒有網路時打不打得開，三個語系都有', async () => {
+  // 容量數字回答不了這件事。讀者存了兩百多頁，缺的卻可能是每頁都要的那個樣式，
+  // 那時佔用量看起來很健康，而每一頁打開都是空白。
+  const HERE = 'https://anoni.net/docs/offline/';
+  const HOME = 'https://anoni.net/docs/';
+  const CSS = 'https://anoni.net/docs/stylesheets/extra.css';
+  for (const [lang, ok, missing] of [
+    ['zh-TW', '沒有網路時，這一頁、首頁、樣式與程式都打得開', '沒有網路時打不開：首頁'],
+    ['zh', '没有网络时，这一页、首页、样式与程序都打得开', '没有网络时打不开：首页'],
+    ['en', 'Without a network, this page, the home page, styles and scripts all open', 'these do not open: the home page'],
+  ]) {
+    const all = await load({ lang, stylesheets: [CSS], cached: [HERE, HOME, CSS] });
+    const allText = all.root.querySelector('.ol-status').textContent;
+    assert.ok(allText.includes(ok), `${lang} 全部都在時該有「${ok}」，實際是：${allText}`);
+
+    // 首頁不在裝置上：PWA 的 start_url 與語言導向的落點就是它
+    const partial = await load({ lang, stylesheets: [CSS], cached: [HERE, CSS] });
+    assert.ok(
+      partial.root.querySelector('.ol-status').textContent.includes(missing),
+      `${lang} 缺首頁時應該看到「${missing}」`
+    );
+  }
+});
+
+test('瀏覽器沒有 Cache Storage 時不畫那一行，其餘照舊', async () => {
+  const { root } = await load({ precached: ['basics/'] });
+  const text = root.querySelector('.ol-status').textContent;
+  assert.ok(!text.includes('沒有網路時'));
+  assert.ok(text.includes('網站自動存的'));
+});
+
 test('狀態列寫出這台裝置上的離線內容版本，三個語系都有', async () => {
   // 讀者回報離線出問題時，第一個要分辨的是他的 service worker 換到新版了沒，
   // 而那件事在裝置上原本沒有任何地方看得出來。
@@ -895,6 +941,14 @@ test('舊版 service worker 不回版本時狀態列照樣畫得出來', async (
   const { root } = await load({});
   assert.ok(root.querySelector('.ol-status'));
   assert.ok(!root.querySelector('.ol-version'));
+});
+
+test('英文版的並列用逗號，不吃到中文頓號', async () => {
+  // 原本狀態列第一行的分隔符寫死成頓號，英文版於是變成
+  // 「0 pages you chose to keep、0 pages stored automatically」
+  const { root } = await load({ lang: 'en', precached: ['basics/'] });
+  const text = root.querySelector('.ol-status').textContent;
+  assert.ok(!text.includes('、'), `英文版不該出現頓號，實際是：${text}`);
 });
 
 test('三個語系各自挑到自己那組字串', async () => {

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -116,6 +116,7 @@ const harness = `
   ${grab(/^const GAME_APPS = \[[\s\S]*?\n\];/m)}
   ${grab(/^const CORE_PAGES_BY_PREFIX = \{[\s\S]*?\n\};/m)}
   ${grab(/^function precacheUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^const ESSENTIAL_PAGES = \[[^\]]*\];/m)}
   ${grab(/^function essentialUrlsFor\(prefix\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function corePageAssets\(prefix, index\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function shellAssetsFor\(prefix, index\) \{[\s\S]*?\n\}/m)}
@@ -478,10 +479,23 @@ test('install 在新裝置上只補底線，在換版的裝置上照舊補完整
   assert.deepEqual(fresh.fetched.slice().sort(), fresh.sw.essentialUrlsFor('').slice().sort());
 
   const upgrade = load({ clients: here });
-  await (await upgrade.caches.open('anoni-docs-precache-202601010000')).put('/docs/', 'HOME');
+  // 拿一個不在底線那批裡的頁面當上一版的證據。首頁現在也屬於底線（它是 PWA 的
+  // start_url），拿它當證據的話，只存過底線的裝置會被誤認成上一版有完整章節。
+  await (await upgrade.caches.open('anoni-docs-precache-202601010000')).put(
+    '/docs/guides/',
+    'PAGE'
+  );
   assert.equal(await upgrade.sw.hadFullPrecache(''), true);
   assert.equal(await upgrade.sw.installPrecache(), '');
   assert.ok(upgrade.fetched.includes('/docs/tools/what-is-tor/'));
+});
+
+test('首頁進了底線那批，探針要跟著換一個頁面', async (load) => {
+  // essentialUrlsFor 與 hadFullPrecache 共用 ESSENTIAL_PAGES，寫在一起才不會不同步
+  const { sw } = load();
+  const essential = sw.essentialUrlsFor('');
+  assert.ok(essential.includes('/docs/'), '首頁不在底線那批裡，PWA 的 start_url 就沒人存');
+  assert.ok(essential.includes('/docs/offline/'));
 });
 
 test('只存過底線那批的裝置不算有完整章節', async (load) => {


### PR DESCRIPTION
接續 #431、#433。回報是 en 讀者刷掉 PWA 重開，**會先看到 zh-TW 一眼再跳到 en**，然後停在那裡。那句「先看到 zh-TW」是這次的關鍵線索。

## 那一跳是設計內的

PWA 的 `start_url` 是安裝當下那個語系的首頁。讀者是從 zh-TW 頁面裝的，之後把閱讀語言切成 en，於是每次冷啟動都是：

1. 載入 `/docs/`（zh-TW 首頁）
2. `base.html` 的語言偏好腳本讀到 `anoni-docs-lang=en`
3. `location.replace('/docs/en/')`

離線時這條路要**兩個首頁都在裝置上**。而 `essentialUrlsFor` 只有 `offline/` 與 app shell，首頁從來不在裡面。#433 讓 install 替讀者用過的每個語系補底線那批，補的也是沒有首頁的那一份。

## 改了什麼

`essentialUrlsFor` 補上首頁。它是 PWA 的 `start_url`，也是那一跳的落點，而關掉「自動存下內容」的讀者整台裝置只有這一批，少了首頁連 PWA 的第一個網址都落在快取外面。

底線那批的頁面抽成 `ESSENTIAL_PAGES`，`hadFullPrecache` 的探針跟著它走。探針原本挑「第一個不是 `offline/` 的頁面」，那正好是首頁，首頁進來之後只存過底線的裝置會被誤認成上一版有完整章節，換版時整份章節白重下一遍。這個坑是加首頁的當下就踩到的，測試紅燈才發現。

`base.html` 的那一跳加一道確認：離線又沒有副本就留在原地。跳過去只會停在空白，而讀者手上這一頁至少看得到，header 的語言切換器也還在。有副本、或 `navigator.onLine` 不是 `false`，照跳。

離線閱讀頁的狀態列多一行版本（`離線內容版本 202609042020`）。讀者回報離線出問題時，第一個要分辨的是他的 service worker 換到新版了沒，那件事在裝置上原本沒有任何地方看得出來，只能靠猜。

## 成本

| | 之前 | 之後 |
|---|---|---|
| 底線那批（關掉自動存的讀者） | 0.74 MB、17 個 URL | 0.97 MB、18 個 URL |
| 換版時替其他語系補的底線 | 0.41 MB、5 個 URL | 0.64 MB、6 個 URL |

多的就是那個語系的首頁（zh-TW 234 KB、en 235 KB、zh-cn 222 KB）。

## 驗證

本機測試站這次架成跟正式站一樣的 `/docs/` 結構（語言切換器的連結是 `extra.alternate` 寫死的 `/docs/…`，站在根路徑的話那些連結與快取 key 對不上，先前幾輪的端對端因此驗不到這一段）。

Firefox 156、連得上但沒有回應的網路、PWA 從 zh-TW 首頁冷啟動、閱讀語言 en：

```
t+1.6s  /docs/     lang=zh-TW  ready=interactive  body=1890
t+2.1s  /docs/en/  lang=en     ready=complete     body=8866
```

測試：`test_sw_offline.mjs` 97 通過（新增「首頁進了底線那批，探針要跟著換一個頁面」，並把「上一版有完整章節」的證據從首頁換成 `guides/`），`test_lang_preference.mjs` 10 通過（新增 4 個案例涵蓋那道確認的四種分支），`test_offline_library.mjs` 49 通過（新增版本顯示與舊版 service worker 不回版本的情況），`test_offline_index.py` 全綠，三語系建置乾淨，`check_precache.mjs` 四道檢查都過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
