### PR TITLE
fix(pwa): 離線落腳頁改用轉址，跨語系時用讀者的語言解釋一次

### DIFF
--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -198,6 +198,7 @@
       readyMissing: "沒有網路時打不開：{items}。連上網路後會自動補回來。",
       readyJoin: "、",
       readyHere: "這一頁",
+      fallbackNotice: "你要開的頁面不在裝置上，你的語言也還沒有存下離線閱讀頁，所以看到的是另一個語言的版本。連上網路之後，用你的語言打開離線閱讀頁就會存進來。",
       readyHome: "首頁",
       readyAssets: "樣式與程式",
       usageFree: "本站在這台裝置上佔用 {used}，可用空間還有 {free}",
@@ -256,6 +257,7 @@
       readyMissing: "没有网络时打不开：{items}。连上网络后会自动补回来。",
       readyJoin: "、",
       readyHere: "这一页",
+      fallbackNotice: "你要开的页面不在设备上，你的语言也还没有存下离线阅读页，所以看到的是另一个语言的版本。连上网络之后，用你的语言打开离线阅读页就会存进来。",
       readyHome: "首页",
       readyAssets: "样式与程序",
       usageFree: "本站在这台设备上占用 {used}，可用空间还有 {free}",
@@ -314,6 +316,7 @@
       readyMissing: "Without a network these do not open: {items}. They come back once you are online.",
       readyJoin: ", ",
       readyHere: "this page",
+      fallbackNotice: "The page you opened is not on this device, and this offline reading page is not stored in your language either, so you are seeing another language's version. Open this page in your language once you are online and it will be stored.",
       readyHome: "the home page",
       readyAssets: "styles and scripts",
       usageFree: "This site uses {used} on this device, with {free} still available",
@@ -361,6 +364,10 @@
   };
 
   const t = STRINGS[document.documentElement.lang] || STRINGS["zh-TW"];
+
+  // 網址上的語系代號對到這裡的字串組。service worker 把讀者帶到別的語言這一頁時，
+  // 會在網址上帶 from，值是他本來要的那個語系（見 sw.js 的 langCodeOf）。
+  const LANG_BY_CODE = { "zh-tw": "zh-TW", "zh-cn": "zh", en: "en" };
   const fill = (key, vars) =>
     Object.keys(vars || {}).reduce(
       (text, name) => text.split("{" + name + "}").join(vars[name]),
@@ -600,6 +607,19 @@
     // 轉圈的圖案對讀螢幕的人沒有意義，狀態要用屬性講
     node.setAttribute("aria-busy", "true");
     return node;
+  }
+
+  // service worker 把讀者從一個沒存下來的網址帶到這一頁，而他要的語言在這台裝置上
+  // 沒有這一頁時，會在網址上帶 from。用他要的那個語言解釋一次，不然畫面上就是莫名
+  // 其妙跳出一個看不懂的語言。
+  function renderFallbackNotice() {
+    const from = new URL(location.href).searchParams.get("from");
+    const strings = STRINGS[LANG_BY_CODE[from]];
+    // 帶的語系就是這一頁自己的語言時沒什麼要解釋的
+    if (!strings || strings === t) return null;
+    const notice = el("p", "ol-fallback");
+    notice.textContent = strings.fallbackNotice;
+    return notice;
   }
 
   function renderStatus() {
@@ -891,6 +911,8 @@
   // 判斷，也不因為有提醒就改變按鈕的行為，選擇仍然是讀者的。
   function renderPicker(message) {
     root.textContent = "";
+    const notice = renderFallbackNotice();
+    if (notice) root.appendChild(notice);
     root.appendChild(renderStatus());
 
     if (!state.index) {
@@ -981,6 +1003,8 @@
       return;
     }
     root.textContent = "";
+    const notice = renderFallbackNotice();
+    if (notice) root.appendChild(notice);
     root.appendChild(renderStatus());
 
     if (state.swMissing) return renderSections();

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -1061,18 +1061,42 @@ function offlinePathFor(url) {
 
 // 離線時的落腳頁。先找這個語系自己那一份，沒有就給別的語系。
 //
-// 「沒有」是真的會發生的狀態：install 只補當下猜到的那一個語系，而換版時 activate
-// 會清掉舊的預快取，所以讀者昨天讀 en、今天在 zh-TW 分頁上按下更新，en 的落腳頁
-// 就不在裝置上了。看得懂與看不懂之間還有一個選項，總比瀏覽器的錯誤畫面好，那一頁
-// 上還有「你的裝置上還存著哪些內容」可以看。
+// 「沒有」是真的會發生的狀態：install 只補讀者用過的語系，而換版時 activate 會清掉
+// 舊的預快取，所以讀者昨天讀 en、今天在 zh-TW 分頁上按下更新，en 的落腳頁可能就不在
+// 裝置上了。
+//
+// 用轉址而不是把內容直接回給原本的網址。直接回傳的話，頁面的 location 還是讀者要開
+// 的那一個（例如 /docs/en/basics/threat-model/），而管理頁靠 location 算出索引與各頁
+// 的網址，算出來全是 404，整份清單畫不出來。讀者看到的是一頁靜態說明，而那一頁存在
+// 的理由正是告訴他「裝置上還有哪些讀得到」。轉址之後網址列也對得上，他知道自己被帶
+// 到哪裡，而 302 不留在 history，按上一頁不會回到那個打不開的網址。
+//
+// 退到別的語系時網址帶上 from。那一頁會用讀者要的語言說明發生了什麼事，不然畫面上
+// 就是莫名其妙跳出一個看不懂的語言。
+//
+// 目標跟當前網址一樣就跳過，自己轉自己會轉不完。
 async function offlineFallback(url) {
-  const own = await caches.match(offlinePathFor(url));
-  if (own) return own;
+  const own = offlinePathFor(url);
+  const paths = [own];
   for (const prefix of LANG_PREFIXES) {
-    const hit = await caches.match(SCOPE_PATH + prefix + "offline/");
-    if (hit) return hit;
+    const path = SCOPE_PATH + prefix + "offline/";
+    if (paths.indexOf(path) === -1) paths.push(path);
+  }
+  for (const path of paths) {
+    if (path === url.pathname) continue;
+    if (!(await caches.match(url.origin + path))) continue;
+    const target = new URL(url.origin + path);
+    if (path !== own) target.searchParams.set("from", langCodeOf(url));
+    return Response.redirect(target.href, 302);
   }
   return undefined;
+}
+
+// 網址屬於哪個語系，回的是網址上看得到的那個代號（zh-tw、zh-cn、en）。落腳頁靠它
+// 知道讀者本來要的是哪一種語言。
+function langCodeOf(url) {
+  const prefix = langPrefixOf(url);
+  return prefix ? prefix.replace(/\/$/, "") : "zh-tw";
 }
 
 // event 可能不存在（例如未來從別處呼叫），沒有就退回 fire-and-forget

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -377,7 +377,10 @@ const load = async (opts = {}) => {
       : { match: async (href) => (opts.cached.includes(href) ? 'HIT' : undefined) };
   const window = { __anoniServiceWorker: opts.swFlag !== false, caches };
   const location = {
-    href: opts.picker ? 'https://anoni.net/docs/start/' : 'https://anoni.net/docs/offline/',
+    // opts.from 模擬 service worker 轉址過來時帶的語系（見 sw.js 的 offlineFallback）
+    href:
+      (opts.picker ? 'https://anoni.net/docs/start/' : 'https://anoni.net/docs/offline/') +
+      (opts.from ? '?from=' + opts.from : ''),
     origin: 'https://anoni.net',
   };
   const fetched = [];
@@ -941,6 +944,26 @@ test('舊版 service worker 不回版本時狀態列照樣畫得出來', async (
   const { root } = await load({});
   assert.ok(root.querySelector('.ol-status'));
   assert.ok(!root.querySelector('.ol-version'));
+});
+
+test('被帶到別的語言那一頁時，用讀者要的語言解釋一次', async () => {
+  // service worker 找不到讀者那個語系的落腳頁時會轉到別的語系那一份。畫面上莫名
+  // 其妙跳出看不懂的語言，總要有人講一句發生了什麼事，而那句話要用他看得懂的語言。
+  const en = await load({ lang: 'zh-TW', from: 'en' });
+  const enText = en.root.querySelector('.ol-fallback');
+  assert.ok(enText, 'en 讀者落到中文那一頁時應該有提示');
+  assert.ok(enText.textContent.includes('The page you opened is not on this device'));
+
+  const cn = await load({ lang: 'en', from: 'zh-cn' });
+  assert.ok(cn.root.querySelector('.ol-fallback').textContent.includes('你要开的页面不在设备上'));
+});
+
+test('落到自己語言那一頁時不用解釋', async () => {
+  const same = await load({ lang: 'zh-TW', from: 'zh-tw' });
+  assert.equal(same.root.querySelector('.ol-fallback'), null);
+
+  const plain = await load({ lang: 'zh-TW' });
+  assert.equal(plain.root.querySelector('.ol-fallback'), null);
 });
 
 test('英文版的並列用逗號，不吃到中文頓號', async () => {

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -161,6 +161,7 @@ const harness = `
   ${grab(/^async function matchCachedPage\(request\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function offlinePathFor\(url\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function offlineFallback\(url\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^function langCodeOf\(url\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function trimCache\(cacheName, maxEntries\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function migrateLegacyRuntime\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^function keepAlive\(event, promise\) \{[\s\S]*?\n\}/m)}
@@ -181,7 +182,7 @@ const harness = `
     langPrefixOf, precacheUrlsFor, essentialUrlsFor, corePageAssets, precacheFor, guessLangPrefix,
     shellAssetsFor, loadOfflineIndex, ASSET_TIMEOUT_MS, NO_CACHE_TIMEOUT_MS,
     crossLangAsset, assetUrlFor, matchCachedAsset,
-    visitedPrefixes, offlineFallback,
+    visitedPrefixes, offlineFallback, langCodeOf,
     noteVisit, hadFullPrecache, installPrecache, precacheOnNavigation,
     autoPrecacheEnabled, setAutoPrecache, precacheImagesEnabled, setPrecacheImages,
     libraryEntries, precachedEntries,
@@ -273,6 +274,9 @@ const load = (opts = {}) => {
 };
 
 const req = (pathname) => ({ url: ORIGIN + pathname });
+// 落腳頁是用轉址給的，看的是 Location 標頭而不是內容
+const redirectTo = (response) =>
+  response && response.status === 302 ? response.headers.get('location') : response;
 const u = (pathname) => new URL(pathname, ORIGIN);
 
 let passed = 0;
@@ -970,7 +974,7 @@ test('清除過的裝置離線時仍看得到離線提示頁', async (load) => {
   net.offline = true;
 
   const response = await sw.networkFirst(req('/docs/tools/what-is-tor/'), null);
-  assert.equal(response.url, '/docs/offline/');
+  assert.equal(redirectTo(response), ORIGIN + '/docs/offline/');
 });
 
 test('關掉自動存之後，離線提示頁照樣留著', async (load) => {
@@ -979,7 +983,10 @@ test('關掉自動存之後，離線提示頁照樣留著', async (load) => {
   await sw.precacheFor('');
   net.offline = true;
 
-  assert.equal((await sw.networkFirst(req('/docs/basics/metadata/'), null)).url, '/docs/offline/');
+  assert.equal(
+    redirectTo(await sw.networkFirst(req('/docs/basics/metadata/'), null)),
+    ORIGIN + '/docs/offline/'
+  );
 });
 
 test('狀態查詢回得出已存的、網站存的與空間用量', async (load) => {
@@ -1146,7 +1153,7 @@ test('裝置上沒有的頁面等網路也有上限，一直不回來就給落�
   const precache = await caches.open(sw.PRECACHE);
   await precache.put('/docs/en/offline/', 'EN-OFFLINE');
   const response = await sw.networkFirst(req('/docs/en/tools/what-is-tor/'), null);
-  assert.equal(response, 'EN-OFFLINE');
+  assert.equal(redirectTo(response), ORIGIN + '/docs/en/offline/');
 });
 
 test('這個語系的落腳頁不在裝置上時，給別的語系那一份', async (load) => {
@@ -1156,12 +1163,22 @@ test('這個語系的落腳頁不在裝置上時，給別的語系那一份', as
   const { sw, caches } = load({ offline: true });
   const precache = await caches.open(sw.PRECACHE);
   await precache.put('/docs/offline/', 'ZH-OFFLINE');
-  assert.equal(await sw.offlineFallback(u('/docs/en/basics/')), 'ZH-OFFLINE');
-  assert.equal(await sw.offlineFallback(u('/docs/zh-cn/basics/')), 'ZH-OFFLINE');
+  // 退到別的語系時網址帶上 from，那一頁才知道要用哪個語言解釋這件事
+  assert.equal(
+    redirectTo(await sw.offlineFallback(u('/docs/en/basics/'))),
+    ORIGIN + '/docs/offline/?from=en'
+  );
+  assert.equal(
+    redirectTo(await sw.offlineFallback(u('/docs/zh-cn/basics/'))),
+    ORIGIN + '/docs/offline/?from=zh-cn'
+  );
 
-  // 自己那一份在的時候照樣優先
+  // 自己那一份在的時候照樣優先，而且不帶 from
   await precache.put('/docs/en/offline/', 'EN-OFFLINE');
-  assert.equal(await sw.offlineFallback(u('/docs/en/basics/')), 'EN-OFFLINE');
+  assert.equal(
+    redirectTo(await sw.offlineFallback(u('/docs/en/basics/'))),
+    ORIGIN + '/docs/en/offline/'
+  );
 });
 
 test('離線時沒快取過的頁面會落到離線頁', async (load) => {
@@ -1172,7 +1189,10 @@ test('離線時沒快取過的頁面會落到離線頁', async (load) => {
   const response = await sw.networkFirst(req('/docs/basics/metadata/'), null);
   // 走到這裡代表 networkFirst 沒有把錯誤往外丟。丟出去的話 respondWith 會 reject，
   // 讀者看到的是瀏覽器自己的網路錯誤畫面，站台的離線頁等於白做。
-  assert.equal(response, 'ZH-OFFLINE');
+  //
+  // 給的是轉址而不是內容。直接回內容的話，頁面的 location 還是讀者原本要開的那一個，
+  // 管理頁靠它算索引與各頁網址，算出來全是 404，整份清單畫不出來。
+  assert.equal(redirectTo(response), ORIGIN + '/docs/offline/');
 });
 
 test('離線時快取過的頁面直接回快取，不落到離線頁', async (load) => {
@@ -1190,8 +1210,38 @@ test('離線時各語系落到自己的離線頁', async (load) => {
   await precache.put('/docs/offline/', 'ZH-OFFLINE');
   await precache.put('/docs/en/offline/', 'EN-OFFLINE');
 
-  assert.equal(await sw.networkFirst(req('/docs/en/basics/metadata/'), null), 'EN-OFFLINE');
-  assert.equal(await sw.networkFirst(req('/docs/basics/metadata/'), null), 'ZH-OFFLINE');
+  // 自己那一份在的時候不帶 from，讀者看到的就是他的語言，沒什麼要解釋的
+  assert.equal(
+    redirectTo(await sw.networkFirst(req('/docs/en/basics/metadata/'), null)),
+    ORIGIN + '/docs/en/offline/'
+  );
+  assert.equal(
+    redirectTo(await sw.networkFirst(req('/docs/basics/metadata/'), null)),
+    ORIGIN + '/docs/offline/'
+  );
+});
+
+test('已經在落腳頁的網址上就不轉給自己', async (load) => {
+  // 正常情況走不到這裡（那一頁在快取裡的話 matchCachedPage 早就命中了），可是萬一
+  // 走到，轉給自己就是一圈轉不完的轉址
+  const { sw, caches } = load({ offline: true });
+  const precache = await caches.open(sw.PRECACHE);
+  await precache.put('/docs/offline/', 'ZH-OFFLINE');
+  assert.equal(await sw.offlineFallback(u('/docs/offline/')), undefined);
+
+  await precache.put('/docs/en/offline/', 'EN-OFFLINE');
+  assert.equal(
+    redirectTo(await sw.offlineFallback(u('/docs/en/offline/'))),
+    ORIGIN + '/docs/offline/?from=en'
+  );
+});
+
+test('語系代號用網址上看得到的那個', async (load) => {
+  // 落腳頁靠它知道讀者本來要的是哪一種語言，值要跟網址上的區段一致
+  const { sw } = load();
+  assert.equal(sw.langCodeOf(u('/docs/basics/')), 'zh-tw');
+  assert.equal(sw.langCodeOf(u('/docs/zh-cn/basics/')), 'zh-cn');
+  assert.equal(sw.langCodeOf(u('/docs/en/basics/')), 'en');
 });
 
 test('連落腳頁都沒有時給明確的網路錯誤，不停在空白', async (load) => {


### PR DESCRIPTION
回報是離線走到沒存下來的頁面時，其他語系的讀者會被丟到看不懂的中文頁。查下去發現除了語言不對，**那一頁本身也是壞的**。

## 實測（改之前）

裝置上只有 zh-TW 的內容，離線開 `/docs/en/basics/threat-model/`：

```
url:      /en/basics/threat-model/      ← 網址還是原本那個
lang:     zh-TW                         ← 內容是繁體中文版
status:   null                          ← 管理頁的狀態列沒畫出來
sections: 0                             ← 一個章節都沒有
```

## 兩個問題

**那一頁是壞的。** service worker 把落腳頁的內容直接回給讀者要開的網址，所以頁面的 `location` 還是 `/docs/en/basics/threat-model/`，而 `offline-library.js` 靠 `location` 算索引與各頁網址，算出來是 `/docs/en/basics/offline-index.json`，404。整份清單畫不出來，讀者看到的只是一頁靜態說明，而那一頁存在的理由正是告訴他「裝置上還有哪些讀得到」。這跟語系無關，同語系走到沒存的頁面也一樣壞。

**語言不對。** `offlineFallback` 依 `LANG_PREFIXES = ["", "zh-cn/", "en/"]` 依序找，第一個就是 zh-TW。這是 #433 加退路時的取捨（看不懂總比瀏覽器的錯誤畫面好），但沒處理讀者根本不知道發生什麼事。

## 改了什麼

`Response.redirect(落腳頁, 302)` 取代直接回傳內容。網址列對得上，`location` 對了清單就正常，讀者也知道自己被帶到哪裡。302 不留在 history，按上一頁不會回到那個打不開的網址。目標跟當前網址一樣時跳過，自己轉自己會轉不完。

退到別的語系時網址帶上 `from`，值是讀者本來要的語系代號（`zh-tw`、`zh-cn`、`en`，跟網址上看得到的一致）。落腳頁讀到就用**那個語言**顯示一句說明。落到自己語言那一份時不帶，也就不解釋。

## 實測（改之後）

```
url:      /offline/
search:   ?from=en
notice:   The page you opened is not on this device, and this offline reading page
          is not stored in your language either, so you are seeing another
          language's version. Open this page in your language once you are online
          and it will be stored.
sections: 24                            ← 清單正常
status:   你自己選存的 0 頁、網站自動存的 43 頁…（完整狀態列）
```

## 測試

`test_sw_offline.mjs` 99 通過。六個原本斷言「回傳內容」的案例改成驗 `Location`，新增：

- 已經在落腳頁的網址上就不轉給自己（防轉址循環）
- 退到別的語系時網址帶上 `from`，自己那一份在的時候不帶
- 語系代號用網址上看得到的那個

`test_offline_library.mjs` 54 通過，新增「被帶到別的語言那一頁時用讀者要的語言解釋一次」（en 落到 zh-TW、zh-CN 落到 en 各驗一次）與「落到自己語言那一頁時不用解釋」。

其餘 `test_lang_preference.mjs`、`test_update_banner.mjs`、`test_offline_index.py` 全綠，三語系建置乾淨，`check_precache.mjs` 四道檢查都過，`docs_style_lint.py` 對新文案 0 error 0 warn。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
