### PR TITLE
feat(vault): 用 passkey 解鎖的本機加密暫存區，先做地基

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -162,6 +162,12 @@ jobs:
       - name: 本機檔案加密
         run: node tools/test_agecrypt.mjs
 
+      # 加密暫存區：那 32 個位元組直接當 age 私鑰用，編碼錯一個位元組加密照樣成功，要等
+      # 到換裝置解不開才發現。這裡把編碼、加密、解密的往返跑一遍，另守金鑰不落地與
+      # passkey 一定建成 discoverable 兩條規則
+      - name: 加密暫存區
+        run: node tools/test_vault.mjs
+
       # passkey 鑰匙：替身的 navigator.credentials 讓 typage 的 webauthn 模組在 Node 跑起來，
       # PRF 段落用 Node 內建的 crypto 獨立算一次對照。另守三語系頁面、import map 與 nav 的接線
       - name: passkey 鑰匙

--- a/docs/zh-TW/community/vault-lab.md
+++ b/docs/zh-TW/community/vault-lab.md
@@ -1,0 +1,111 @@
+---
+title: 加密暫存區（實驗）
+description: 用 passkey 解鎖的本機加密儲存，實驗階段。建立時把資料金鑰放進 passkey 的 user.id，之後只要驗證就能解開。
+search:
+  exclude: true
+hide:
+  - navigation
+offline_assets:
+  - utils/vendor/age/age-encryption/dist/armor.js
+  - utils/vendor/age/age-encryption/dist/cbor.js
+  - utils/vendor/age/age-encryption/dist/format.js
+  - utils/vendor/age/age-encryption/dist/index.js
+  - utils/vendor/age/age-encryption/dist/io.js
+  - utils/vendor/age/age-encryption/dist/recipients.js
+  - utils/vendor/age/age-encryption/dist/stream.js
+  - utils/vendor/age/age-encryption/dist/webauthn.js
+  - utils/vendor/age/age-encryption/dist/x25519.js
+  - utils/vendor/age/noble-ciphers/_arx.js
+  - utils/vendor/age/noble-ciphers/_poly1305.js
+  - utils/vendor/age/noble-ciphers/chacha.js
+  - utils/vendor/age/noble-ciphers/utils.js
+  - utils/vendor/age/noble-curves/abstract/curve.js
+  - utils/vendor/age/noble-curves/abstract/edwards.js
+  - utils/vendor/age/noble-curves/abstract/fft.js
+  - utils/vendor/age/noble-curves/abstract/hash-to-curve.js
+  - utils/vendor/age/noble-curves/abstract/modular.js
+  - utils/vendor/age/noble-curves/abstract/montgomery.js
+  - utils/vendor/age/noble-curves/abstract/oprf.js
+  - utils/vendor/age/noble-curves/abstract/weierstrass.js
+  - utils/vendor/age/noble-curves/ed25519.js
+  - utils/vendor/age/noble-curves/nist.js
+  - utils/vendor/age/noble-curves/utils.js
+  - utils/vendor/age/noble-hashes/_md.js
+  - utils/vendor/age/noble-hashes/_u64.js
+  - utils/vendor/age/noble-hashes/hkdf.js
+  - utils/vendor/age/noble-hashes/hmac.js
+  - utils/vendor/age/noble-hashes/pbkdf2.js
+  - utils/vendor/age/noble-hashes/scrypt.js
+  - utils/vendor/age/noble-hashes/sha2.js
+  - utils/vendor/age/noble-hashes/sha3.js
+  - utils/vendor/age/noble-hashes/utils.js
+  - utils/vendor/age/noble-post-quantum/_crystals.js
+  - utils/vendor/age/noble-post-quantum/hybrid.js
+  - utils/vendor/age/noble-post-quantum/ml-kem.js
+  - utils/vendor/age/noble-post-quantum/utils.js
+  - utils/vendor/age/scure-base/index.js
+  - js/vault.js
+  - js/vault-lab.js
+---
+
+# 加密暫存區（實驗）
+
+一個用 passkey 解鎖的本機加密儲存。建立時產生一把資料金鑰，放進 passkey 的 `user.id`，之後在任何有這把 passkey 的裝置上驗證一次就能解開。不必記密語。
+
+這一頁是實驗，內容暫時只有一個文字欄位。真正要放的是 checklist 那類讀者主動打開才看的東西。
+
+<script type="importmap">
+{
+  "imports": {
+    "age-encryption": "../../utils/vendor/age/age-encryption/dist/index.js",
+    "@noble/ciphers/chacha.js": "../../utils/vendor/age/noble-ciphers/chacha.js",
+    "@noble/curves/abstract/edwards.js": "../../utils/vendor/age/noble-curves/abstract/edwards.js",
+    "@noble/curves/abstract/fft.js": "../../utils/vendor/age/noble-curves/abstract/fft.js",
+    "@noble/curves/abstract/montgomery.js": "../../utils/vendor/age/noble-curves/abstract/montgomery.js",
+    "@noble/curves/abstract/weierstrass.js": "../../utils/vendor/age/noble-curves/abstract/weierstrass.js",
+    "@noble/curves/ed25519.js": "../../utils/vendor/age/noble-curves/ed25519.js",
+    "@noble/curves/nist.js": "../../utils/vendor/age/noble-curves/nist.js",
+    "@noble/curves/utils.js": "../../utils/vendor/age/noble-curves/utils.js",
+    "@noble/hashes/hkdf": "../../utils/vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hkdf.js": "../../utils/vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hmac": "../../utils/vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/hmac.js": "../../utils/vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/scrypt.js": "../../utils/vendor/age/noble-hashes/scrypt.js",
+    "@noble/hashes/sha2": "../../utils/vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha2.js": "../../utils/vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha3.js": "../../utils/vendor/age/noble-hashes/sha3.js",
+    "@noble/hashes/utils": "../../utils/vendor/age/noble-hashes/utils.js",
+    "@noble/hashes/utils.js": "../../utils/vendor/age/noble-hashes/utils.js",
+    "@noble/post-quantum/hybrid.js": "../../utils/vendor/age/noble-post-quantum/hybrid.js",
+    "@scure/base": "../../utils/vendor/age/scure-base/index.js"
+  }
+}
+</script>
+
+<div id="vault-lab"></div>
+<script src="../../js/vault.js"></script>
+<script src="../../js/vault-lab.js"></script>
+
+## 它怎麼運作
+
+資料金鑰是 32 個隨機位元組，那正好也是一把 age 私鑰的長度，所以直接拿來加密，輸出是標準 age 檔。金鑰放在 passkey 的 `user.id` 裡，每次驗證時原樣回傳，任何 provider、任何裝置都一樣。[實驗頁](passkey-lab.md)量的就是這件事。
+
+密文存在這台裝置的 IndexedDB。解鎖之後金鑰只留在記憶體，分頁關掉就沒了。
+
+## 跟站上檔案加密的差別
+
+[本機檔案加密](../utils/age.md)的 passkey 模式走 WebAuthn 的 PRF 擴充，保證是「就算密碼管理器的 vault 洩漏，也算不出金鑰」。代價是 iPhone 配第三方密碼管理器拿不到 PRF。
+
+這一層改把金鑰放進 `user.id`，任何支援 passkey 的環境都能用，代價是金鑰跟著 credential 存在 vault 裡，能解開 vault 的人就能解開這裡的資料。兩種取捨各有適合的東西，所以是兩套並存而不是互相取代。
+
+## 備援金鑰
+
+沒有 WebAuthn 的環境（例如 Tor Browser）只剩備援私鑰這條路，passkey 全丟了也一樣。建立時可以產生一把，公鑰會被加進收件人，私鑰只顯示一次，自己存進密碼管理器。
+
+用備援私鑰解開是唯讀的，看得到內容也匯得出去，改不了。資料金鑰在 passkey 裡，備援那條路拿不到它。
+
+## 換一台裝置
+
+passkey 有同步（Bitwarden、iCloud 鑰匙圈）的話，那台裝置直接解得開。不同步的環境要另外處理，那部分還沒做。
+
+匯出的是標準 age 檔，可以自己搬到另一台裝置匯入。

--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -1,0 +1,251 @@
+/*
+ * 加密暫存區的介面。實驗階段，先驗整條路走不走得通。
+ *
+ * 邏輯全在 vault.js（window.anoniVault），這裡只有畫面與狀態。內容暫時是一個文字欄位
+ * 當試驗品，之後要接的是 checklist 那類讀者主動打開才看的東西。
+ *
+ * 金鑰從頭到尾不出現在畫面上，也不進剪貼簿。備援私鑰只在剛產生時顯示一次，那是讀者
+ * 唯一要自己收好的東西。
+ */
+(function () {
+  const root = document.getElementById("vault-lab");
+  if (!root) return;
+
+  const el = (tag, cls, text) => {
+    const node = document.createElement(tag);
+    if (cls) node.className = cls;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  };
+  const button = (label, cls, onClick) => {
+    const node = el("button", "vl-btn" + (cls ? " " + cls : ""), label);
+    node.type = "button";
+    node.addEventListener("click", onClick);
+    return node;
+  };
+
+  const state = {
+    exists: false,
+    unlocked: false,
+    readOnly: false,   // 用備援私鑰進來的，改不了也存不回去
+    data: null,
+    backupRecipient: "",
+    shownSecret: null,
+    message: "",
+    busy: false,
+  };
+
+  const vault = () => window.anoniVault;
+
+  function say(text) {
+    state.message = text;
+    render();
+  }
+
+  async function guard(run) {
+    if (state.busy) return;
+    state.busy = true;
+    render();
+    try {
+      await run();
+    } catch (err) {
+      const name = err && err.name === "NotAllowedError" ? "你取消了，或者驗證沒有完成。" : null;
+      say(name || "沒有成功：" + (err && err.message ? err.message : String(err)));
+    }
+    state.busy = false;
+    render();
+  }
+
+  async function refresh() {
+    state.exists = await vault().exists();
+  }
+
+  const create = () =>
+    guard(async () => {
+      await vault().create(state.backupRecipient || null);
+      state.unlocked = true;
+      state.readOnly = false;
+      state.data = {};
+      await refresh();
+      say("建好了。這台裝置之後按一次指紋就能進來。");
+    });
+
+  const unlock = () =>
+    guard(async () => {
+      await vault().unlock();
+      state.data = await vault().read();
+      state.unlocked = true;
+      state.readOnly = false;
+      say("");
+    });
+
+  const unlockBackup = (secret) =>
+    guard(async () => {
+      state.data = await vault().unlockWithBackup(secret);
+      state.unlocked = true;
+      state.readOnly = true;
+      say("用備援私鑰進來的，看得到也匯得出去，改不了。要改回到有 passkey 的裝置。");
+    });
+
+  const save = (text) =>
+    guard(async () => {
+      state.data = Object.assign({}, state.data, { note: text });
+      await vault().save(state.data, state.backupRecipient || null);
+      say("存好了。");
+    });
+
+  const makeBackup = () =>
+    guard(async () => {
+      const age = await import("age-encryption");
+      const identity = await age.generateX25519Identity();
+      state.backupRecipient = await age.identityToRecipient(identity);
+      state.shownSecret = identity;
+      say("備援私鑰只顯示這一次，存進密碼管理器。");
+    });
+
+  const exportBlob = () =>
+    guard(async () => {
+      const bytes = await vault().exportBlob();
+      const url = URL.createObjectURL(new Blob([bytes], { type: "application/octet-stream" }));
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "anoni-vault.age";
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 10000);
+      say("匯出的是標準 age 檔，另一台裝置可以匯進去。");
+    });
+
+  const importBlob = (file) =>
+    guard(async () => {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      await vault().importBlob(bytes);
+      state.unlocked = false;
+      state.data = null;
+      await refresh();
+      say("匯進來了。用 passkey 或備援私鑰解開。");
+    });
+
+  const clear = () =>
+    guard(async () => {
+      await vault().clear();
+      state.unlocked = false;
+      state.data = null;
+      state.shownSecret = null;
+      await refresh();
+      say("清掉了。密碼管理器裡那把 passkey 要自己刪。");
+    });
+
+  function renderLocked() {
+    if (!state.exists) {
+      root.appendChild(
+        el("p", "vl-hint", "這台裝置上還沒有暫存區。建立時會產生一把 passkey，之後每次進來按一次指紋就好，不必記密語。")
+      );
+      const label = el("label", "vl-label", "備援金鑰（公鑰，age1 開頭，可留空）");
+      const row = el("div", "vl-row");
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "vl-backup";
+      input.placeholder = "age1…";
+      input.value = state.backupRecipient;
+      input.addEventListener("input", () => {
+        state.backupRecipient = input.value;
+      });
+      row.appendChild(input);
+      row.appendChild(button("產生一把", null, makeBackup));
+      label.appendChild(row);
+      root.appendChild(label);
+      root.appendChild(
+        el("p", "vl-hint", "沒有 WebAuthn 的環境（例如 Tor Browser）只剩備援私鑰這條路，passkey 全丟了也一樣。留空就沒有那條退路。")
+      );
+      if (state.shownSecret) {
+        root.appendChild(el("p", "vl-secret", state.shownSecret));
+        root.appendChild(el("p", "vl-hint", "備援私鑰，只顯示這一次。存進密碼管理器，放在跟這台裝置不同的地方。"));
+      }
+      root.appendChild(button("建立暫存區", "vl-primary", create));
+      return;
+    }
+
+    root.appendChild(el("p", "vl-hint", "這台裝置上有一份鎖著的暫存區。"));
+    const actions = el("div", "vl-actions");
+    actions.appendChild(button("用 passkey 解開", "vl-primary", unlock));
+    root.appendChild(actions);
+
+    const label = el("label", "vl-label", "或者貼備援私鑰（AGE-SECRET-KEY-1 開頭）");
+    const input = document.createElement("input");
+    input.type = "password";
+    input.className = "vl-secret-in";
+    input.placeholder = "AGE-SECRET-KEY-1…";
+    label.appendChild(input);
+    root.appendChild(label);
+    root.appendChild(button("用備援私鑰解開", null, () => unlockBackup(input.value)));
+  }
+
+  function renderUnlocked() {
+    root.appendChild(
+      el("p", "vl-hint", state.readOnly ? "唯讀。" : "解開了。關掉這個分頁就會重新鎖上。")
+    );
+
+    const label = el("label", "vl-label", "隨手記（試驗用的內容）");
+    const box = document.createElement("textarea");
+    box.className = "vl-note";
+    box.rows = 6;
+    box.value = (state.data && state.data.note) || "";
+    box.disabled = state.readOnly;
+    label.appendChild(box);
+    root.appendChild(label);
+
+    const actions = el("div", "vl-actions");
+    if (!state.readOnly) actions.appendChild(button("儲存", "vl-primary", () => save(box.value)));
+    actions.appendChild(button("匯出", null, exportBlob));
+    actions.appendChild(
+      button("鎖上", null, () => {
+        vault().lock();
+        state.unlocked = false;
+        state.data = null;
+        say("鎖上了。");
+      })
+    );
+    root.appendChild(actions);
+  }
+
+  function render() {
+    root.textContent = "";
+
+    if (!vault() || !vault().available()) {
+      root.appendChild(el("p", "vl-hint", "這個瀏覽器用不了，它需要 WebAuthn 與 IndexedDB。"));
+      return;
+    }
+
+    if (state.busy) {
+      const busy = el("p", "vl-hint");
+      const spin = el("span", "anoni-spinner");
+      spin.setAttribute("aria-hidden", "true");
+      busy.appendChild(spin);
+      busy.appendChild(document.createTextNode(" 等你在瀏覽器的提示裡完成"));
+      busy.setAttribute("aria-busy", "true");
+      root.appendChild(busy);
+      return;
+    }
+
+    if (state.unlocked) renderUnlocked();
+    else renderLocked();
+
+    if (state.message) root.appendChild(el("p", "vl-msg", state.message));
+
+    if (state.exists) {
+      const danger = el("div", "vl-actions");
+      danger.appendChild(button("清除這台裝置上的暫存區", null, clear));
+      const file = document.createElement("input");
+      file.type = "file";
+      file.className = "vl-file";
+      file.accept = ".age";
+      file.addEventListener("change", () => {
+        if (file.files && file.files[0]) importBlob(file.files[0]);
+      });
+      danger.appendChild(file);
+      root.appendChild(danger);
+    }
+  }
+
+  refresh().then(render, render);
+})();

--- a/docs/zh-TW/js/vault.js
+++ b/docs/zh-TW/js/vault.js
@@ -1,0 +1,258 @@
+/*
+ * 加密暫存區：用 passkey 解鎖的本機儲存
+ *
+ * === 為什麼不是 PRF ===
+ *
+ * WebAuthn 的 PRF 擴充是「用 passkey 算出金鑰」的正規做法，站上的檔案加密走的就是它。
+ * 可是 Apple 不把擴充的資料交給 iCloud 鑰匙圈以外的 provider，iPhone 配 Bitwarden 就
+ * 拿不到金鑰，largeBlob 撞的是同一面牆。要做到「讀者從頭到尾只按指紋」，那條路走不通。
+ *
+ * 這裡改用核心欄位 user.id。建立 passkey 時把 32 個隨機位元組放進去，之後每次驗證都
+ * 原樣回傳，任何 provider、任何裝置都一樣。2026-09-05 在 iPhone 配 Bitwarden 上實測
+ * 過，量測頁留在 community/passkey-lab。
+ *
+ * 代價要說清楚：金鑰跟著 credential 存在密碼管理器的 vault 裡，能解開 vault 的人就能
+ * 解開這裡的資料。PRF 那條路的保證是「就算 vault 洩漏也算不出金鑰」，這條沒有。換到的
+ * 是所有支援 passkey 的環境都能用。
+ *
+ * === 那 32 個位元組就是一把 age 私鑰 ===
+ *
+ * age 的 identity 本來就是 32 位元組的 X25519 私鑰，所以 user.id 直接拿來用，不必再
+ * 衍生。加密走站上既有的 age 實作，輸出是標準 age 檔，備援公鑰當第二收件人，匯出的
+ * 東西跟本機檔案加密那邊同一個格式，命令列也解得開。
+ *
+ * === 幾條規則 ===
+ *
+ * 金鑰不出現在畫面上，也不進剪貼簿。量測頁把它印出來是為了比對，這裡不會。
+ *
+ * 解鎖一次，金鑰留在記憶體，分頁關掉就沒了。不寫進任何儲存空間，這一點有測試守著。
+ *
+ * 只放讀者主動打開才需要的資料。語系偏好那種在頁面載入路徑上的東西不能放進來，否則
+ * 每次開站都要先按一次指紋。
+ *
+ * 加第二台裝置：passkey 有同步就不必做什麼。不同步的環境要用同一個 user.id 在那台
+ * 建立一把新的，所以得先在已解鎖的裝置上把金鑰帶過去，那是 exportKey 的用途。
+ */
+(function () {
+  const DB_NAME = "anoni-vault";
+  const STORE = "blob";
+  const BLOB_KEY = "main";
+  const KEY_BYTES = 32;
+  const RP_NAME = "anoni.net";
+  const CRED_NAME = "anoni.net 加密暫存區";
+
+  // 解鎖之後的金鑰只活在這裡。分頁關掉、重新整理都會沒有，這是刻意的。
+  let unlockedKey = null;
+  let agePromise = null;
+
+  const lib = () => {
+    if (!agePromise) agePromise = import("age-encryption");
+    return agePromise;
+  };
+
+  // --- IndexedDB：只存一份密文，不需要 schema ---
+
+  function openDb() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  function withStore(mode, run) {
+    return openDb().then(
+      (db) =>
+        new Promise((resolve, reject) => {
+          const tx = db.transaction(STORE, mode);
+          const request = run(tx.objectStore(STORE));
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+          tx.oncomplete = () => db.close();
+        })
+    );
+  }
+
+  const readBlob = () => withStore("readonly", (store) => store.get(BLOB_KEY));
+  const writeBlob = (bytes) => withStore("readwrite", (store) => store.put(bytes, BLOB_KEY));
+  const dropBlob = () => withStore("readwrite", (store) => store.delete(BLOB_KEY));
+
+  // --- passkey：只用核心欄位，沒有任何擴充 ---
+
+  async function createCredential(keyBytes) {
+    const cred = await navigator.credentials.create({
+      publicKey: {
+        rp: { name: RP_NAME, id: location.hostname },
+        // user.id 就是金鑰。name 與 displayName 會顯示在密碼管理器裡，寫得讓讀者認得出來。
+        user: { id: keyBytes, name: CRED_NAME, displayName: CRED_NAME },
+        challenge: crypto.getRandomValues(new Uint8Array(32)),
+        pubKeyCredParams: [
+          { type: "public-key", alg: -8 },
+          { type: "public-key", alg: -7 },
+          { type: "public-key", alg: -257 },
+        ],
+        // discoverable 才會在驗證時回傳 userHandle，那是整條路的前提
+        authenticatorSelection: { residentKey: "required", userVerification: "required" },
+        timeout: 120000,
+      },
+    });
+    if (!cred) throw new Error("cancelled");
+    return cred;
+  }
+
+  async function keyFromCredential() {
+    const assertion = await navigator.credentials.get({
+      publicKey: {
+        challenge: crypto.getRandomValues(new Uint8Array(32)),
+        // 空的清單讓讀者自己挑，也才走得到 discoverable 那條路
+        allowCredentials: [],
+        userVerification: "required",
+        timeout: 120000,
+      },
+    });
+    const handle = assertion && assertion.response && assertion.response.userHandle;
+    if (!handle) throw new Error("no-handle");
+    const bytes = new Uint8Array(handle);
+    if (bytes.length !== KEY_BYTES) throw new Error("bad-handle");
+    return bytes;
+  }
+
+  // --- 金鑰的形狀轉換 ---
+
+  // age 的 identity 就是 32 位元組的 X25519 私鑰，bech32 編碼之後長成 AGE-SECRET-KEY-1…
+  // 編碼方式跟 typage 的 generateX25519Identity 一模一樣，那邊也是隨機 32 位元組直接編。
+  async function identityOf(keyBytes) {
+    const { bech32 } = await import("@scure/base");
+    return bech32.encodeFromBytes("AGE-SECRET-KEY-", keyBytes).toUpperCase();
+  }
+
+  async function recipientOf(identity) {
+    const age = await lib();
+    return age.identityToRecipient(identity);
+  }
+
+  // --- 加解密 ---
+
+  async function encryptData(data, keyBytes, backupRecipient) {
+    const age = await lib();
+    const identity = await identityOf(keyBytes);
+    const encrypter = new age.Encrypter();
+    encrypter.addRecipient(await recipientOf(identity));
+    if (backupRecipient) encrypter.addRecipient(backupRecipient.trim());
+    const json = new TextEncoder().encode(JSON.stringify(data));
+    return encrypter.encrypt(json);
+  }
+
+  async function decryptData(bytes, identity) {
+    const age = await lib();
+    const decrypter = new age.Decrypter();
+    decrypter.addIdentity(identity);
+    const out = await decrypter.decrypt(bytes, "uint8array");
+    return JSON.parse(new TextDecoder().decode(out));
+  }
+
+  // --- 對外的介面 ---
+
+  const api = {
+    available() {
+      return !!(window.PublicKeyCredential && window.indexedDB && window.crypto);
+    },
+
+    locked() {
+      return unlockedKey === null;
+    },
+
+    async exists() {
+      const blob = await readBlob();
+      return !!blob;
+    },
+
+    // 建立：先產生金鑰，用它建 passkey，再寫一份空的密文進去。
+    // 順序是刻意的，passkey 沒建成功就什麼都不留。
+    async create(backupRecipient) {
+      const keyBytes = crypto.getRandomValues(new Uint8Array(KEY_BYTES));
+      await createCredential(keyBytes);
+      unlockedKey = keyBytes;
+      await api.save({}, backupRecipient);
+      return true;
+    },
+
+    async unlock() {
+      const keyBytes = await keyFromCredential();
+      const blob = await readBlob();
+      if (blob) {
+        // 解得開才算數，解不開代表這把 passkey 不是當初那一把
+        await decryptData(blob, await identityOf(keyBytes));
+      }
+      unlockedKey = keyBytes;
+      return true;
+    },
+
+    // 備援私鑰那條路：Tor Browser 那種沒有 WebAuthn 的環境，或 passkey 全丟了。
+    //
+    // 它解得開資料，卻拿不到資料金鑰，因為那把金鑰在 passkey 的 user.id 裡。所以這條
+    // 路是唯讀的，讀者看得到內容也匯得出去，要恢復寫入得回到有 passkey 的裝置，或者
+    // 把匯出的內容倒進一個新建的暫存區。
+    async unlockWithBackup(secret) {
+      const blob = await readBlob();
+      if (!blob) throw new Error("empty");
+      unlockedKey = null;
+      return decryptData(blob, secret.trim());
+    },
+
+    async read() {
+      if (!unlockedKey) throw new Error("locked");
+      const blob = await readBlob();
+      if (!blob) return {};
+      return decryptData(blob, await identityOf(unlockedKey));
+    },
+
+    async save(data, backupRecipient) {
+      if (!unlockedKey) throw new Error("locked");
+      const bytes = await encryptData(data, unlockedKey, backupRecipient);
+      await writeBlob(bytes);
+      return true;
+    },
+
+    // 匯出就是那份密文，標準 age 檔，另一台裝置匯入或用命令列解都可以
+    async exportBlob() {
+      const blob = await readBlob();
+      if (!blob) throw new Error("empty");
+      return blob;
+    },
+
+    async importBlob(bytes) {
+      await writeBlob(bytes);
+      return true;
+    },
+
+    // 帶著金鑰去另一台裝置建立 passkey 時用得到。回的是原始位元組，呼叫端負責不要
+    // 讓它落在畫面或剪貼簿上。
+    exportKey() {
+      if (!unlockedKey) throw new Error("locked");
+      return unlockedKey.slice();
+    },
+
+    async adopt(keyBytes) {
+      await createCredential(keyBytes);
+      unlockedKey = keyBytes;
+      return true;
+    },
+
+    lock() {
+      unlockedKey = null;
+    },
+
+    async clear() {
+      unlockedKey = null;
+      await dropBlob();
+      return true;
+    },
+  };
+
+  window.anoniVault = api;
+})();

--- a/tools/test_vault.mjs
+++ b/tools/test_vault.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * 加密暫存區的核心測試。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * 這一層的整個立論是「user.id 那 32 個位元組直接就是一把 age 私鑰」。編碼錯一個位元
+ * 組，加密看起來照樣成功，讀者要等到換裝置解不開才發現，而那時候資料已經累積了一陣
+ * 子。這裡把編碼、加密、解密的往返在 Node 上跑一遍，用的是 vendor 裡那份 typage。
+ *
+ * 另外守兩條規則：金鑰不進任何持久儲存，以及 passkey 一定要建成 discoverable。後者
+ * 少了的話驗證時不會回傳 userHandle，整條路就斷了，而那在瀏覽器上不會報錯，只會拿到
+ * 一個空值。
+ *
+ * === 怎麼驗 ===
+ *
+ * 跟 test_agecrypt.mjs 同一套做法：函式從 vault.js 原地抽出來執行，typage 從 vendor
+ * 複製成 node_modules 的形狀載入。
+ *
+ * 用法：
+ *   node tools/test_vault.mjs
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, '..', 'docs', 'zh-TW', 'js', 'vault.js');
+const VENDOR = path.join(HERE, '..', 'docs', 'zh-TW', 'utils', 'vendor', 'age');
+const src = fs.readFileSync(SRC, 'utf8');
+
+const PKG_DIRS = {
+  'age-encryption': 'age-encryption',
+  '@noble/ciphers': 'noble-ciphers',
+  '@noble/curves': 'noble-curves',
+  '@noble/hashes': 'noble-hashes',
+  '@noble/post-quantum': 'noble-post-quantum',
+  '@scure/base': 'scure-base',
+};
+
+function copyTree(from, to) {
+  fs.mkdirSync(to, { recursive: true });
+  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+    const a = path.join(from, entry.name);
+    const b = path.join(to, entry.name);
+    if (entry.isDirectory()) copyTree(a, b);
+    else fs.copyFileSync(a, b);
+  }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'anoni-vault-'));
+for (const [name, dir] of Object.entries(PKG_DIRS)) {
+  copyTree(path.join(VENDOR, dir), path.join(tmp, 'node_modules', name));
+}
+const nm = (p) => pathToFileURL(path.join(tmp, 'node_modules', p)).href;
+const age = await import(nm('age-encryption/dist/index.js'));
+const base = await import(nm('@scure/base/index.js'));
+
+const grab = (re) => {
+  const m = src.match(re);
+  if (!m) throw new Error(`vault.js 裡找不到 ${re}`);
+  return m[0];
+};
+
+// 抽出來的函式在 vault.js 裡靠 lib() 與 import("@scure/base") 拿相依，這裡直接餵進去
+const harness = `
+  const lib = async () => age;
+  const importBase = async () => base;
+  ${grab(/^  async function identityOf\(keyBytes\) \{[\s\S]*?\n  \}/m).replace('await import("@scure/base")', 'await importBase()')}
+  ${grab(/^  async function recipientOf\(identity\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  async function encryptData\(data, keyBytes, backupRecipient\) \{[\s\S]*?\n  \}/m)}
+  ${grab(/^  async function decryptData\(bytes, identity\) \{[\s\S]*?\n  \}/m)}
+  return { identityOf, recipientOf, encryptData, decryptData };
+`;
+const vault = new Function('age', 'base', harness)(age, base);
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test('那 32 個位元組編出來的 identity 跟 typage 自己產的同一個形狀', async () => {
+  const key = new Uint8Array(32).fill(7);
+  const identity = await vault.identityOf(key);
+  assert.match(identity, /^AGE-SECRET-KEY-1[0-9A-Z]+$/);
+
+  const mine = await vault.identityOf(key);
+  assert.equal(mine, identity, '同一把金鑰每次都要編出同一個 identity');
+
+  // typage 自己產的那一把拿來比長度與前綴，確認我們沒有編成別的東西
+  const theirs = await age.generateX25519Identity();
+  assert.equal(identity.length, theirs.length);
+});
+
+test('金鑰算得出收件人，而且不同金鑰算出不同收件人', async () => {
+  const a = await vault.recipientOf(await vault.identityOf(new Uint8Array(32).fill(1)));
+  const b = await vault.recipientOf(await vault.identityOf(new Uint8Array(32).fill(2)));
+  assert.match(a, /^age1[0-9a-z]+$/);
+  assert.notEqual(a, b);
+});
+
+test('加密再解密，內容一個位元組不差', async () => {
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const data = { note: '一段有中文的內容\n第二行', list: [1, 2, 3], when: '2026-09-05' };
+  const blob = await vault.encryptData(data, key, null);
+  const back = await vault.decryptData(blob, await vault.identityOf(key));
+  assert.deepEqual(back, data);
+});
+
+test('換一把金鑰解不開', async () => {
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const other = crypto.getRandomValues(new Uint8Array(32));
+  const blob = await vault.encryptData({ a: 1 }, key, null);
+  await assert.rejects(() => vault.decryptData(blob, vault.identityOf(other).then((i) => i)));
+});
+
+test('帶了備援公鑰時，備援私鑰也解得開同一份', async () => {
+  // 這是 Tor Browser 那種沒有 WebAuthn 的環境唯一的路，也是 passkey 全丟時的救援
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const backupIdentity = await age.generateX25519Identity();
+  const backupRecipient = await age.identityToRecipient(backupIdentity);
+  const data = { note: '救援用' };
+
+  const blob = await vault.encryptData(data, key, backupRecipient);
+  assert.deepEqual(await vault.decryptData(blob, await vault.identityOf(key)), data);
+  assert.deepEqual(await vault.decryptData(blob, backupIdentity), data);
+});
+
+test('沒帶備援公鑰時，備援私鑰解不開', async () => {
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const backupIdentity = await age.generateX25519Identity();
+  const blob = await vault.encryptData({ a: 1 }, key, null);
+  await assert.rejects(() => vault.decryptData(blob, backupIdentity));
+});
+
+test('輸出是標準 age 檔，命令列那邊也認得', async () => {
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const blob = await vault.encryptData({ a: 1 }, key, null);
+  const head = Buffer.from(blob.slice(0, 30)).toString('latin1');
+  assert.ok(head.startsWith('age-encryption.org/v1\n'), '檔頭不是 age 的版本行');
+});
+
+test('整支程式不把金鑰寫進任何持久儲存', () => {
+  // 解鎖之後金鑰只活在記憶體裡，分頁關掉就沒了。這條規則寫壞了不會有任何症狀，
+  // 只會讓一把長期有效的金鑰躺在裝置上。
+  assert.ok(
+    !/localStorage|sessionStorage|document\.cookie/.test(src),
+    'vault.js 不該碰那幾種儲存'
+  );
+  // IndexedDB 只存密文，存進去的東西必須是 encryptData 的輸出
+  assert.ok(/writeBlob\(bytes\)/.test(src));
+  assert.ok(!/writeBlob\((unlockedKey|keyBytes)/.test(src), '金鑰不該被寫進資料庫');
+});
+
+test('passkey 一定建成 discoverable，否則驗證時拿不回 userHandle', () => {
+  assert.ok(
+    /residentKey: "required"/.test(src),
+    'residentKey 不是 required 的話，驗證時 userHandle 會是空的，整條路會斷'
+  );
+  assert.ok(/userVerification: "required"/.test(src));
+  // user.id 必須就是那把金鑰，放別的東西進去就沒有意義了
+  assert.ok(/user: \{ id: keyBytes,/.test(src));
+});
+
+test('拿回來的 userHandle 長度不對就當失敗', () => {
+  // provider 動過那個欄位的話寧可停下來，不要拿一把錯的金鑰去解密
+  assert.ok(/bytes\.length !== KEY_BYTES/.test(src));
+});
+
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    passed += 1;
+    console.log('  ✓ ' + name);
+  } catch (err) {
+    failed += 1;
+    console.error('  ✗ ' + name);
+    console.error('    ' + String(err.message).split('\n').join('\n    '));
+  }
+}
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log(`\n${passed} 通過，${failed} 失敗`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
接續 #443 量到的結果。目標是「讀者只按指紋、不必記密語」的加密儲存，之後要放語系以外的偏好、已讀文章、長期 checklist 那類東西。

## 為什麼不是 PRF

PRF 擴充是正規做法，站上的檔案加密走的就是它。但 Apple 不把擴充的資料交給 iCloud 鑰匙圈以外的 provider，iPhone 配 Bitwarden 拿不到金鑰，`largeBlob` 撞同一面牆。

改用核心欄位 `user.id`：建立 passkey 時把 32 個隨機位元組放進去，每次驗證原樣回傳，任何 provider 都一樣。#443 那一頁在真機上量過。

**代價**：金鑰跟著 credential 存在密碼管理器的 vault 裡，能解開 vault 的人就能解開這裡的資料。PRF 那條路「就算 vault 洩漏也算不出金鑰」的保證換掉了。已經跟 @toomore 確認過可以接受。兩套並存，檔案加密照舊走 PRF。

## 那 32 個位元組直接就是一把 age 私鑰

age 的 identity 本來就是 32 位元組的 X25519 私鑰，所以 `user.id` 拿來就能用，不必再衍生。加密走既有的 age 實作，輸出是標準 age 檔，備援公鑰當第二收件人，匯出的東西命令列也解得開。

備援那條路是**唯讀**的：它解得開資料，卻拿不到資料金鑰（那把在 passkey 裡）。要恢復寫入得回到有 passkey 的裝置。

## 規則（寫在 vault.js 頂部）

- 金鑰不出現在畫面上，也不進剪貼簿
- 解鎖一次，金鑰留在記憶體，分頁關掉就沒了，不寫進任何儲存空間
- IndexedDB 只存密文
- 只放讀者主動打開才需要的資料。語系偏好那種在頁面載入路徑上的不能放進來，否則每次開站都要先按指紋
- 加第二台裝置：passkey 有同步就不必做什麼，不同步的環境要用同一個 `user.id` 建立，那部分還沒做

## 端對端

Chrome 虛擬驗證器，`community/vault-lab`：

```
2 建立: ok        → 解開了。關掉這個分頁就會重新鎖上。
3 儲存: ok        → 存好了。
4 鎖上: ok        → 這台裝置上有一份鎖著的暫存區。
5 解開: ok        → 內容回來了: "第一筆內容\n有中文"
6 清除: ok        → 回到沒有暫存區的狀態
```

備援那一輪：

```
1 私鑰形狀: AGE-SECRET-KEY-1E8LQ… len=74
4 用備援私鑰解開: ok  → 內容: "備援要讀得到的內容"
4 唯讀: true          有沒有儲存鈕: false
```

## 測試

新增 `tools/test_vault.mjs`，10 個案例，已加進 `tools-tests.yml`。守的是編碼、加密解密往返、備援那條路、換一把金鑰解不開、輸出是標準 age 檔，以及兩條規則：金鑰不進持久儲存、`residentKey` 一定是 `required`（少了的話驗證時 `userHandle` 會是空的，整條路會斷而且不報錯）。

`test_agecrypt.mjs` 28、`test_passkey.mjs` 9 照舊通過，三語系建置乾淨，`check_precache.mjs` 四道檢查都過。

## 還沒做的

介面只有一個文字欄位當試驗品，真正要接的資料還沒接。不同步環境的「加第二台裝置」流程沒做。這一頁不進 nav 也不進搜尋，等機制穩了再談要不要搬到 `utils/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
