### PR TITLE
fix(vault): 每一步的結果寫在畫面上，空的跟壞掉要分得出來

### DIFF
--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -26,6 +26,7 @@
 
   const state = {
     exists: false,
+    blobSize: 0,
     unlocked: false,
     readOnly: false,   // 用備援私鑰進來的，改不了也存不回去
     data: null,
@@ -57,7 +58,8 @@
   }
 
   async function refresh() {
-    state.exists = await vault().exists();
+    state.blobSize = await vault().size();
+    state.exists = state.blobSize > 0;
   }
 
   const create = () =>
@@ -67,7 +69,7 @@
       state.readOnly = false;
       state.data = {};
       await refresh();
-      say("建好了。這台裝置之後按一次指紋就能進來。");
+      say("建好了，裡面還是空的。打字之後要按儲存才會留下來。");
     });
 
   const unlock = () =>
@@ -76,7 +78,9 @@
       state.data = await vault().read();
       state.unlocked = true;
       state.readOnly = false;
-      say("");
+      await refresh();
+      const n = Object.keys(state.data || {}).length;
+      say(n ? "解開了，讀到 " + n + " 個項目。" : "解開了，裡面還沒有東西。打字之後按儲存。");
     });
 
   const unlockBackup = (secret) =>
@@ -91,7 +95,8 @@
     guard(async () => {
       state.data = Object.assign({}, state.data, { note: text });
       await vault().save(state.data, state.backupRecipient || null);
-      say("存好了。");
+      await refresh();
+      say("存好了，密文 " + state.blobSize + " 個位元組。鎖上再解開就會看到同樣的內容。");
     });
 
   const makeBackup = () =>
@@ -165,7 +170,9 @@
       return;
     }
 
-    root.appendChild(el("p", "vl-hint", "這台裝置上有一份鎖著的暫存區。"));
+    root.appendChild(
+      el("p", "vl-hint", "這台裝置上有一份鎖著的暫存區，密文 " + state.blobSize + " 個位元組。")
+    );
     const actions = el("div", "vl-actions");
     actions.appendChild(button("用 passkey 解開", "vl-primary", unlock));
     root.appendChild(actions);
@@ -181,8 +188,14 @@
   }
 
   function renderUnlocked() {
+    const items = Object.keys(state.data || {}).length;
     root.appendChild(
-      el("p", "vl-hint", state.readOnly ? "唯讀。" : "解開了。關掉這個分頁就會重新鎖上。")
+      el(
+        "p",
+        "vl-hint",
+        (state.readOnly ? "唯讀，看得到也匯得出去，改不了。" : "解開了，關掉這個分頁就會重新鎖上。") +
+          (items ? "裡面有 " + items + " 個項目。" : "裡面還沒有東西，打字之後按儲存。")
+      )
     );
 
     const label = el("label", "vl-label", "隨手記（試驗用的內容）");

--- a/docs/zh-TW/js/vault.js
+++ b/docs/zh-TW/js/vault.js
@@ -171,6 +171,13 @@
       return !!blob;
     },
 
+    // 密文多大。畫面上要能講出「這台裝置上有沒有東西、有多少」，讀者才分得出
+    // 「解開了但裡面是空的」跟「根本沒解開」。
+    async size() {
+      const blob = await readBlob();
+      return blob ? blob.length || blob.byteLength || 0 : 0;
+    },
+
     // 建立：先產生金鑰，用它建 passkey，再寫一份空的密文進去。
     // 順序是刻意的，passkey 沒建成功就什麼都不留。
     async create(backupRecipient) {


### PR DESCRIPTION
回報是解開之後看不到內容。

解鎖那一步其實成功了（文字框有出現），只是裡面本來就沒有東西。建立完的暫存區是空的，要打字按儲存才會留下東西，而原本的訊息只說「建好了」，讀者不會知道還有一步，畫面看起來就跟壞掉一樣。

## 每一步都寫出結果

```
建好了，裡面還是空的。打字之後要按儲存才會留下來。
存好了，密文 237 個位元組。鎖上再解開就會看到同樣的內容。
這台裝置上有一份鎖著的暫存區，密文 237 個位元組。
解開了，裡面有 1 個項目。
解開了，裡面還沒有東西，打字之後按儲存。
```

密文的位元組數是刻意露出來的。讀者分得出「解開了但是空的」跟「根本沒存進去」，回報問題時也講得出哪一步斷了。`vault.js` 為此多一支 `size()`。

## 端對端

同一套流程重跑，訊息如上，內容照樣原樣回來（`"第一筆內容\n有中文"`）。`test_vault.mjs` 10 通過，`docs_style_lint.py` 0 error 0 warn。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
