### PR TITLE
fix(vault): 寫入等交易 commit 才回報成功

### DIFF
--- a/docs/zh-TW/js/vault.js
+++ b/docs/zh-TW/js/vault.js
@@ -64,15 +64,34 @@
     });
   }
 
+  // 寫入要等交易 commit 才算數。
+  //
+  // request.onsuccess 只代表那一個請求被接受了，資料還在交易裡。在那個時間點回報成功
+  // 的話，畫面會說「存好了」，而讀者這時重新整理，交易還沒 commit 就被中斷，東西就
+  // 沒了。實際遇到的症狀是建立完存第一筆存不進去，重新整理再存一次才留得住。
   function withStore(mode, run) {
     return openDb().then(
       (db) =>
         new Promise((resolve, reject) => {
           const tx = db.transaction(STORE, mode);
           const request = run(tx.objectStore(STORE));
-          request.onsuccess = () => resolve(request.result);
+          let result;
+          request.onsuccess = () => {
+            result = request.result;
+          };
           request.onerror = () => reject(request.error);
-          tx.oncomplete = () => db.close();
+          tx.oncomplete = () => {
+            db.close();
+            resolve(result);
+          };
+          tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+          };
+          tx.onabort = () => {
+            db.close();
+            reject(tx.error);
+          };
         })
     );
   }

--- a/tools/test_vault.mjs
+++ b/tools/test_vault.mjs
@@ -164,6 +164,22 @@ test('passkey 一定建成 discoverable，否則驗證時拿不回 userHandle', 
   assert.ok(/user: \{ id: keyBytes,/.test(src));
 });
 
+test('寫入等交易 commit 才回報成功', () => {
+  // request.onsuccess 只代表請求被接受，資料還在交易裡。在那時回報成功的話，畫面會
+  // 說「存好了」，而讀者這時重新整理就沒了。實際遇到的症狀是建立完存第一筆存不進去，
+  // 重新整理再存一次才留得住。
+  const block = src.match(/function withStore\(mode, run\) \{[\s\S]*?\n  \}/)[0];
+  assert.ok(
+    /tx\.oncomplete = \(\) => \{[\s\S]*?resolve\(result\)/.test(block),
+    'resolve 要放在 tx.oncomplete 裡'
+  );
+  assert.ok(
+    !/request\.onsuccess = \(\) => resolve/.test(block),
+    'request.onsuccess 不能直接 resolve'
+  );
+  assert.ok(/tx\.onabort/.test(block), '交易被中止時要 reject，不能靜靜卡住');
+});
+
 test('拿回來的 userHandle 長度不對就當失敗', () => {
   // provider 動過那個欄位的話寧可停下來，不要拿一把錯的金鑰去解密
   assert.ok(/bytes\.length !== KEY_BYTES/.test(src));


### PR DESCRIPTION
回報是建立完暫存區之後存不進東西，要重新整理、解開、再存一次才留得住。

## 原因

`withStore` 在 `request.onsuccess` 就 resolve：

```js
request.onsuccess = () => resolve(request.result);
tx.oncomplete = () => db.close();
```

那只代表那一個請求被接受了，資料還在交易裡沒有 commit。所以畫面說「存好了」的時候，東西不一定真的落地，讀者這時重新整理或關掉分頁，第一筆就沒了。Chrome 的實作比較寬容，看不太出來，iOS Safari 會遇到。

## 改法

`resolve` 移到 `tx.oncomplete`，另外補上 `tx.onerror` 與 `tx.onabort` 的 reject，交易被中止時要報錯而不是靜靜卡住。

## 端對端重現

照回報的情境走一次：建立、存第一筆、**立刻重新整理**、解開。

```
1 儲存後: 存好了，密文 235 個位元組。鎖上再解開就會看到同樣的內容。
2 重整後: 這台裝置上有一份鎖著的暫存區，密文 235 個位元組。
3 解開:   解開了，讀到 1 個項目。
3 內容:   "建立之後的第一筆"
```

`test_vault.mjs` 11 通過，新增一條守著這件事：`resolve` 要在 `tx.oncomplete` 裡、`request.onsuccess` 不能直接 resolve、`tx.onabort` 要有 reject。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
