### PR TITLE
fix(vault): 打字當下就記住，重繪不再把還沒儲存的內容弄丟

### DIFF
--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -30,6 +30,12 @@
     unlocked: false,
     readOnly: false,   // 用備援私鑰進來的，改不了也存不回去
     data: null,
+    // 文字框裡「還沒儲存」的內容。
+    //
+    // 畫面每次重繪都會重建 textarea，而重繪比想像中頻繁：訊息更新、進出忙碌狀態都會。
+    // 只讀按下儲存那一刻的 DOM 值，中間發生任何一次重繪，讀到的就是空字串，然後畫面
+    // 說存好了，存進去的卻是空的。所以打字當下就同步到這裡，重繪從這裡取值。
+    draft: null,
     backupRecipient: "",
     shownSecret: null,
     message: "",
@@ -68,6 +74,7 @@
       state.unlocked = true;
       state.readOnly = false;
       state.data = {};
+      state.draft = "";
       await refresh();
       say("建好了，裡面還是空的。打字之後要按儲存才會留下來。");
     });
@@ -76,6 +83,7 @@
     guard(async () => {
       await vault().unlock();
       state.data = await vault().read();
+      state.draft = (state.data && state.data.note) || "";
       state.unlocked = true;
       state.readOnly = false;
       await refresh();
@@ -86,14 +94,15 @@
   const unlockBackup = (secret) =>
     guard(async () => {
       state.data = await vault().unlockWithBackup(secret);
+      state.draft = (state.data && state.data.note) || "";
       state.unlocked = true;
       state.readOnly = true;
       say("用備援私鑰進來的，看得到也匯得出去，改不了。要改回到有 passkey 的裝置。");
     });
 
-  const save = (text) =>
+  const save = () =>
     guard(async () => {
-      state.data = Object.assign({}, state.data, { note: text });
+      state.data = Object.assign({}, state.data, { note: state.draft || "" });
       await vault().save(state.data, state.backupRecipient || null);
       await refresh();
       say("存好了，密文 " + state.blobSize + " 個位元組。鎖上再解開就會看到同樣的內容。");
@@ -126,6 +135,7 @@
       await vault().importBlob(bytes);
       state.unlocked = false;
       state.data = null;
+      state.draft = null;
       await refresh();
       say("匯進來了。用 passkey 或備援私鑰解開。");
     });
@@ -135,6 +145,7 @@
       await vault().clear();
       state.unlocked = false;
       state.data = null;
+      state.draft = null;
       state.shownSecret = null;
       await refresh();
       say("清掉了。密碼管理器裡那把 passkey 要自己刪。");
@@ -202,19 +213,24 @@
     const box = document.createElement("textarea");
     box.className = "vl-note";
     box.rows = 6;
-    box.value = (state.data && state.data.note) || "";
+    box.value = state.draft !== null ? state.draft : (state.data && state.data.note) || "";
     box.disabled = state.readOnly;
+    // 打字當下就記起來，重繪才不會把還沒儲存的東西弄丟
+    box.addEventListener("input", () => {
+      state.draft = box.value;
+    });
     label.appendChild(box);
     root.appendChild(label);
 
     const actions = el("div", "vl-actions");
-    if (!state.readOnly) actions.appendChild(button("儲存", "vl-primary", () => save(box.value)));
+    if (!state.readOnly) actions.appendChild(button("儲存", "vl-primary", save));
     actions.appendChild(button("匯出", null, exportBlob));
     actions.appendChild(
       button("鎖上", null, () => {
         vault().lock();
         state.unlocked = false;
         state.data = null;
+        state.draft = null;
         say("鎖上了。");
       })
     );


### PR DESCRIPTION
回報是在 IronFox 上儲存的提示有出現，內容卻沒有進到輸入框。

## 原因

textarea 是 uncontrolled 的，只在按下儲存那一刻從 DOM 讀值：

```js
actions.appendChild(button("儲存", "vl-primary", () => save(box.value)));
```

而畫面每次重繪都會重建那個 textarea，新的那個從 `state.data.note` 取值。訊息更新、進出忙碌狀態都會重繪，只要在打完字與按下儲存之間插進來一次，讀到的就是空字串。然後畫面說「存好了」，存進去的是空的。

## 改法

打字當下就同步到 `state.draft`，重繪從那裡取值，儲存也不再碰 DOM。解鎖、鎖上、清除、匯入時各自重設它。

## 對照

同一個腳本，流程是「打字 → 按匯出讓畫面重繪一輪 → 儲存 → 鎖上 → 解開」：

| | 重繪後框裡 | 儲存的密文 | 解開後 |
|---|---|---|---|
| 舊版 | `""` | 211 位元組 | `""` |
| 新版 | 內容還在 | 244 位元組 | 內容回來 |

那 33 個位元組的差就是內容本身。IronFox 的重繪時序跟 Chrome 不同，所以在那邊比較容易踩到，但這個缺陷跟瀏覽器無關，Chrome 上照樣重現得出來。

`test_vault.mjs` 11 通過，`docs_style_lint.py` 0 error 0 warn。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
