### PR TITLE
feat(vault): 一把鑰匙同時服務暫存區與檔案加密

### DIFF
--- a/docs/zh-TW/community/vault-lab.md
+++ b/docs/zh-TW/community/vault-lab.md
@@ -92,6 +92,14 @@ offline_assets:
 
 密文存在這台裝置的 IndexedDB。解鎖之後金鑰只留在記憶體，分頁關掉就沒了。
 
+## 一把鑰匙服務兩件事
+
+建立時同時要求 PRF 擴充。拿得到的話，這把鑰匙也能給[本機檔案加密](../utils/age.md)用，那邊選 passkey 模式時挑同一把就好，密碼管理器裡不必留兩筆。已經在這裡建過的人不需要再去[鑰匙頁](../utils/passkey.md)建。
+
+PRF 拿不到不算失敗，暫存區走的是 `user.id` 那條，跟 PRF 無關。iPhone 配第三方密碼管理器就是這種情況，建出來的鑰匙只給暫存區用。
+
+PRF 的秘密是建立當下由 authenticator 產生的，所以**在哪裡建立決定了這把鑰匙有沒有那個能力**，之後換到支援的裝置也補不回來。想要兩種能力都有，在電腦上建第一把（Bitwarden 的瀏覽器擴充、Windows Hello、Mac 都可以），或者在 iPhone 上選 iCloud 鑰匙圈。
+
 ## 跟站上檔案加密的差別
 
 [本機檔案加密](../utils/age.md)的 passkey 模式走 WebAuthn 的 PRF 擴充，保證是「就算密碼管理器的 vault 洩漏，也算不出金鑰」。代價是 iPhone 配第三方密碼管理器拿不到 PRF。

--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -70,13 +70,19 @@
 
   const create = () =>
     guard(async () => {
-      await vault().create(state.backupRecipient || null);
+      const made = await vault().create(state.backupRecipient || null);
       state.unlocked = true;
       state.readOnly = false;
       state.data = {};
       state.draft = "";
       await refresh();
-      say("建好了，裡面還是空的。打字之後要按儲存才會留下來。");
+      // 這一把拿到了哪些能力要當場講。PRF 的秘密是建立當下產生的，換到別的裝置補不回來，
+      // 讀者知道了才決定要不要換個地方重建一把。
+      say(
+        made && made.hasPrf
+          ? "建好了，裡面還是空的。這一把同時能給本機檔案加密用，那邊選 passkey 模式時挑同一把就好。打字之後要按儲存才會留下來。"
+          : "建好了，裡面還是空的。這個環境算不出檔案加密要用的金鑰，所以這一把只給暫存區用，兩種都想要的話換到電腦上再建一把。打字之後要按儲存才會留下來。"
+      );
     });
 
   const unlock = () =>

--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -44,6 +44,26 @@
 
   const vault = () => window.anoniVault;
 
+  // 文字框只建立一次，之後跨重繪重用同一個節點。
+  //
+  // render 每次都清空 root 再重建全部，如果連文字框一起重建，正在打的字會受兩種傷：
+  // 焦點跑掉，還有中文輸入法的組字被中斷。組字中途被打斷的話那段字根本不會進到 value，
+  // input 事件也不會帶著它，於是畫面說存好了，存進去的是空的。
+  //
+  // appendChild 對已經在文件裡的節點是移動而不是複製，所以每次重繪把它掛回新的位置就好。
+  let noteBox = null;
+
+  function getNoteBox() {
+    if (noteBox) return noteBox;
+    noteBox = document.createElement("textarea");
+    noteBox.className = "vl-note";
+    noteBox.rows = 6;
+    noteBox.addEventListener("input", () => {
+      state.draft = noteBox.value;
+    });
+    return noteBox;
+  }
+
   function say(text) {
     state.message = text;
     render();
@@ -108,10 +128,17 @@
 
   const save = () =>
     guard(async () => {
-      state.data = Object.assign({}, state.data, { note: state.draft || "" });
+      // 文字框不再被重建，所以直接讀它最準。draft 留著當備援，兩邊取比較長的那個。
+      const typed = noteBox ? noteBox.value : "";
+      const note = typed.length >= (state.draft || "").length ? typed : state.draft;
+      state.data = Object.assign({}, state.data, { note: note || "" });
+      state.draft = note || "";
       await vault().save(state.data, state.backupRecipient || null);
       await refresh();
-      say("存好了，密文 " + state.blobSize + " 個位元組。鎖上再解開就會看到同樣的內容。");
+      // 字數寫出來，存進去的是不是空的一眼就看得到
+      say(
+        "存好了，內容 " + (note || "").length + " 個字，密文 " + state.blobSize + " 個位元組。鎖上再解開就會看到同樣的內容。"
+      );
     });
 
   const makeBackup = () =>
@@ -142,6 +169,7 @@
       state.unlocked = false;
       state.data = null;
       state.draft = null;
+      if (noteBox) noteBox.value = "";
       await refresh();
       say("匯進來了。用 passkey 或備援私鑰解開。");
     });
@@ -152,6 +180,7 @@
       state.unlocked = false;
       state.data = null;
       state.draft = null;
+      if (noteBox) noteBox.value = "";
       state.shownSecret = null;
       await refresh();
       say("清掉了。密碼管理器裡那把 passkey 要自己刪。");
@@ -216,15 +245,11 @@
     );
 
     const label = el("label", "vl-label", "隨手記（試驗用的內容）");
-    const box = document.createElement("textarea");
-    box.className = "vl-note";
-    box.rows = 6;
-    box.value = state.draft !== null ? state.draft : (state.data && state.data.note) || "";
+    const box = getNoteBox();
+    const want = state.draft !== null ? state.draft : (state.data && state.data.note) || "";
+    // 值只在真的不一樣時才寫回去。無條件指派會把游標推到最後，正在編輯的人會很困擾。
+    if (box.value !== want) box.value = want;
     box.disabled = state.readOnly;
-    // 打字當下就記起來，重繪才不會把還沒儲存的東西弄丟
-    box.addEventListener("input", () => {
-      state.draft = box.value;
-    });
     label.appendChild(box);
     root.appendChild(label);
 
@@ -237,6 +262,7 @@
         state.unlocked = false;
         state.data = null;
         state.draft = null;
+        if (noteBox) noteBox.value = "";
         say("鎖上了。");
       })
     );
@@ -244,6 +270,15 @@
   }
 
   function render() {
+    // 重繪會把文字框移出文件再掛回去，焦點與游標位置跟著沒了。實務上重繪都發生在按下
+    // 按鈕之後，焦點本來就在按鈕上，所以救不救得回來影響不大。留著這一段是為了將來
+    // 重繪如果由別的事情觸發，正在編輯的人不會被打斷。
+    //
+    // 救不回來的是忙碌畫面那一步：那時整個畫面只剩轉圈，文字框根本不在文件裡，
+    // 焦點已經散掉，下一次重繪也就無從得知它原本在哪。
+    const hadFocus = noteBox && document.activeElement === noteBox;
+    const caret = hadFocus ? [noteBox.selectionStart, noteBox.selectionEnd] : null;
+
     root.textContent = "";
 
     if (!vault() || !vault().available()) {
@@ -279,6 +314,11 @@
       });
       danger.appendChild(file);
       root.appendChild(danger);
+    }
+
+    if (hadFocus && noteBox.isConnected) {
+      noteBox.focus();
+      if (caret) noteBox.setSelectionRange(caret[0], caret[1]);
     }
   }
 

--- a/docs/zh-TW/js/vault.js
+++ b/docs/zh-TW/js/vault.js
@@ -102,6 +102,17 @@
 
   // --- passkey：只用核心欄位，沒有任何擴充 ---
 
+  // 建立一把 anoni.net 的鑰匙。它同時要兩種能力，讀者的密碼管理器裡因此只需要一筆。
+  //
+  // user.id 放資料金鑰，那是暫存區用的，任何 provider 都拿得回來。同時要求 PRF 擴充，
+  // 拿得到的話這把鑰匙也能給本機檔案加密用（那邊的收件人只認 rpId，不綁特定 credential，
+  // 所以挑同一把就行）。
+  //
+  // PRF 拿不到不算失敗。iPhone 配第三方密碼管理器就是這種情況，那時暫存區照樣能用，
+  // 少的只是檔案加密那項能力。回傳時把結果講出來，畫面才寫得出這一把拿到了哪些。
+  //
+  // PRF 的秘密是建立當下由 authenticator 產生的，所以「在哪裡建立」決定了這把鑰匙
+  // 有沒有那個能力，之後換到支援的裝置也補不回來。
   async function createCredential(keyBytes) {
     const cred = await navigator.credentials.create({
       publicKey: {
@@ -116,11 +127,13 @@
         ],
         // discoverable 才會在驗證時回傳 userHandle，那是整條路的前提
         authenticatorSelection: { residentKey: "required", userVerification: "required" },
+        extensions: { prf: {} },
         timeout: 120000,
       },
     });
     if (!cred) throw new Error("cancelled");
-    return cred;
+    const results = cred.getClientExtensionResults ? cred.getClientExtensionResults() : {};
+    return { hasPrf: !!(results.prf && results.prf.enabled) };
   }
 
   async function keyFromCredential() {
@@ -201,10 +214,10 @@
     // 順序是刻意的，passkey 沒建成功就什麼都不留。
     async create(backupRecipient) {
       const keyBytes = crypto.getRandomValues(new Uint8Array(KEY_BYTES));
-      await createCredential(keyBytes);
+      const made = await createCredential(keyBytes);
       unlockedKey = keyBytes;
       await api.save({}, backupRecipient);
-      return true;
+      return made;
     },
 
     async unlock() {
@@ -264,9 +277,9 @@
     },
 
     async adopt(keyBytes) {
-      await createCredential(keyBytes);
+      const made = await createCredential(keyBytes);
       unlockedKey = keyBytes;
-      return true;
+      return made;
     },
 
     lock() {

--- a/tools/test_vault.mjs
+++ b/tools/test_vault.mjs
@@ -164,6 +164,18 @@ test('passkey 一定建成 discoverable，否則驗證時拿不回 userHandle', 
   assert.ok(/user: \{ id: keyBytes,/.test(src));
 });
 
+test('建立時同時要 PRF，拿不到也不失敗', () => {
+  // 一把鑰匙服務兩件事：user.id 給暫存區，PRF 給本機檔案加密。讀者的密碼管理器裡
+  // 因此只需要一筆。iPhone 配第三方密碼管理器拿不到 PRF，那時暫存區照樣要能用。
+  const block = src.match(/async function createCredential\(keyBytes\) \{[\s\S]*?\n  \}/)[0];
+  assert.ok(/extensions: \{ prf: \{\} \}/.test(block), '建立時沒有要求 PRF');
+  assert.ok(
+    !/prf.*enabled[\s\S]{0,40}throw/.test(block),
+    'PRF 拿不到不該讓建立失敗，暫存區走的是 user.id 那條'
+  );
+  assert.ok(/hasPrf: !!\(results\.prf && results\.prf\.enabled\)/.test(block), '沒有把結果回報出去');
+});
+
 test('寫入等交易 commit 才回報成功', () => {
   // request.onsuccess 只代表請求被接受，資料還在交易裡。在那時回報成功的話，畫面會
   // 說「存好了」，而讀者這時重新整理就沒了。實際遇到的症狀是建立完存第一筆存不進去，


### PR DESCRIPTION
原本讀者的密碼管理器裡會有兩筆 `anoni.net` 的 passkey：鑰匙頁那把走 PRF 給檔案加密用，暫存區那把走 `user.id`。分不清哪把是哪把，刪錯一個就毀掉對應的資料。

## 為什麼合得起來

檔案加密那邊的收件人只認 `rpId`，不綁特定 credential：

```js
new age.webauthn.WebAuthnRecipient(identity ? { identity } : { rpId })
```

頁面上也標著識別字串是「選用」。所以只要暫存區那把鑰匙也帶 PRF，檔案加密頁挑同一把就能用，不需要改那邊任何程式。

## 改了什麼

暫存區建立時 `extensions: { prf: {} }`，拿得到就記下來。**PRF 拿不到不算失敗**，暫存區走的是 `user.id` 那條，跟 PRF 無關。

PRF 的秘密是建立當下由 authenticator 產生的，所以在哪裡建立決定了那把鑰匙有沒有那個能力，換到支援的裝置也補不回來。建立完的訊息因此要講清楚拿到了哪些：

> 有 PRF：建好了…這一把同時能給本機檔案加密用，那邊選 passkey 模式時挑同一把就好。
>
> 沒有：建好了…這個環境算不出檔案加密要用的金鑰，所以這一把只給暫存區用，兩種都想要的話換到電腦上再建一把。

## 端對端

Chrome 虛擬驗證器帶 `hasPrf`，在暫存區頁建一把，接著到檔案加密頁：

```
1 建立: 建好了…這一把同時能給本機檔案加密用…
2 passkey 模式: enabled
3 加密: 加密完成，檔頭確認只有 passkey 一個收件人。原始 30 B，輸出 381 B
```

不帶 `hasPrf` 的驗證器則走到另一條訊息，暫存區照樣建得起來也存得進東西。

## 測試

`test_vault.mjs` 12 通過，新增一條守著「建立時要求 PRF、拿不到不能讓建立失敗、結果要回報出去」。

## 還沒做的

鑰匙頁的建立流程沒改，它還是用 typage 的 `createCredential`（`user.id` 是 8 個位元組隨機值，給不了暫存區用）。文件上寫的是「已經在暫存區建過的人不需要再去鑰匙頁建」。要讓兩邊完全共用一支建立函式的話，鑰匙頁那邊要重寫，等這個機制穩了再說。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
