### PR TITLE
fix(vault): 補上樣式與版面順序，打字自動存

### DIFF
--- a/docs/zh-TW/community/vault-lab.md
+++ b/docs/zh-TW/community/vault-lab.md
@@ -82,6 +82,79 @@ offline_assets:
 }
 </script>
 
+<style>
+/*
+  這一頁的樣式。原本一條都沒寫，三個按鈕靠 appendChild 接在一起，中間連空白字元都沒有，
+  在手機上就是三個緊貼的目標，按「儲存」很容易點到旁邊的「匯出」跳出下載對話框。
+  按鈕之間留間距，觸控目標給到 2.75rem（約 44 px，觸控介面的建議下限）。
+  顏色用 theme 的變數，深色模式跟著走。
+*/
+#vault-lab .vl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.1rem 0;
+  align-items: center;
+}
+#vault-lab .vl-btn {
+  min-height: 2.75rem;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  cursor: pointer;
+}
+#vault-lab .vl-primary {
+  border-color: var(--md-primary-fg-color);
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  font-weight: 600;
+}
+#vault-lab .vl-btn:disabled { opacity: 0.5; cursor: default; }
+#vault-lab .vl-label {
+  display: block;
+  margin: 1.2rem 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+#vault-lab .vl-note {
+  width: 100%;
+  margin-top: 0.4rem;
+  padding: 0.6rem;
+  font-family: var(--md-code-font-family, monospace);
+  font-size: 0.78rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+#vault-lab .vl-row { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.4rem; }
+#vault-lab .vl-row input { flex: 1 1 auto; min-width: 0; }
+#vault-lab .vl-label input {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 0.78rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+#vault-lab .vl-secret {
+  word-break: break-all;
+  font-family: var(--md-code-font-family, monospace);
+  font-size: 0.72rem;
+  padding: 0.5rem;
+  border-radius: 0.3rem;
+  background: var(--md-code-bg-color);
+}
+#vault-lab .vl-msg { font-weight: 600; }
+#vault-lab .vl-hint { font-size: 0.72rem; opacity: 0.85; }
+#vault-lab .vl-file { font-size: 0.72rem; }
+</style>
+
 <div id="vault-lab"></div>
 <script src="../../js/vault.js"></script>
 <script src="../../js/vault-lab.js"></script>

--- a/docs/zh-TW/js/vault-lab.js
+++ b/docs/zh-TW/js/vault-lab.js
@@ -47,10 +47,14 @@
   //
   // 這一次改成讓文字框從建立到清除都待在同一個位置，不移動、不重建、不同步。render 只
   // 重畫上面那一塊，文字框這一塊只切換顯示與 disabled。沒有搬動就沒有那一整類問題。
-  const main = el("div", "vl-main");
+  // 三塊，順序就是讀者的閱讀順序：現在什麼狀態、內容、可以做什麼。
+  // 文字框那一塊 render 永遠不碰，前後兩塊照舊清空重畫。
+  const head = el("div", "vl-head");
   const noteArea = el("div", "vl-note-area");
-  root.appendChild(main);
+  const foot = el("div", "vl-foot");
+  root.appendChild(head);
   root.appendChild(noteArea);
+  root.appendChild(foot);
 
   const noteLabel = el("label", "vl-label", "隨手記（試驗用的內容）");
   const noteBox = document.createElement("textarea");
@@ -59,6 +63,33 @@
   noteLabel.appendChild(noteBox);
   noteArea.appendChild(noteLabel);
   noteArea.hidden = true;
+
+  // 打完字停一下就自動存。
+  //
+  // 「要記得按儲存」這件事本身就是一個會出錯的環節，而它出錯的樣子跟程式有 bug 一模
+  // 一樣：讀者解開之後看到空的，分不出是自己忘了按還是東西掉了。拿掉那個環節，順便
+  // 也拿掉按鈕與輸入框之間所有的時序問題。
+  //
+  // 手動那顆留著，想立刻確認存進去了的人有地方按。
+  let saveTimer = null;
+  noteBox.addEventListener("input", () => {
+    if (!state.unlocked || state.readOnly) return;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(autoSave, 800);
+  });
+
+  async function autoSave() {
+    if (!state.unlocked || state.readOnly || state.busy) return;
+    const note = noteBox.value;
+    try {
+      state.data = Object.assign({}, state.data, { note: note });
+      await vault().save(state.data, state.backupRecipient || null);
+      await refresh();
+      say("已自動存下，內容 " + note.length + " 個字，密文 " + state.blobSize + " 個位元組。");
+    } catch (err) {
+      say("自動儲存沒成功：" + (err && err.message ? err.message : String(err)));
+    }
+  }
 
   function say(text) {
     state.message = text;
@@ -96,8 +127,8 @@
       // 讀者知道了才決定要不要換個地方重建一把。
       say(
         made && made.hasPrf
-          ? "建好了，裡面還是空的。這一把同時能給本機檔案加密用，那邊選 passkey 模式時挑同一把就好。打字之後要按儲存才會留下來。"
-          : "建好了，裡面還是空的。這個環境算不出檔案加密要用的金鑰，所以這一把只給暫存區用，兩種都想要的話換到電腦上再建一把。打字之後要按儲存才會留下來。"
+          ? "建好了，裡面還是空的。這一把同時能給本機檔案加密用，那邊選 passkey 模式時挑同一把就好。打字就會自動存下來。"
+          : "建好了，裡面還是空的。這個環境算不出檔案加密要用的金鑰，所以這一把只給暫存區用，兩種都想要的話換到電腦上再建一把。打字就會自動存下來。"
       );
     });
 
@@ -109,8 +140,12 @@
       state.unlocked = true;
       state.readOnly = false;
       await refresh();
-      const n = Object.keys(state.data || {}).length;
-      say(n ? "解開了，讀到 " + n + " 個項目。" : "解開了，裡面還沒有東西。打字之後按儲存。");
+      const note = (state.data && state.data.note) || "";
+      say(
+        note.length
+          ? "解開了，裡面有 " + note.length + " 個字。"
+          : "解開了，裡面還沒有東西。打字就會自動存下來。"
+      );
     });
 
   const unlockBackup = (secret) =>
@@ -180,7 +215,7 @@
 
   function renderLocked() {
     if (!state.exists) {
-      main.appendChild(
+      head.appendChild(
         el("p", "vl-hint", "這台裝置上還沒有暫存區。建立時會產生一把 passkey，之後每次進來按一次指紋就好，不必記密語。")
       );
       const label = el("label", "vl-label", "備援金鑰（公鑰，age1 開頭，可留空）");
@@ -196,24 +231,24 @@
       row.appendChild(input);
       row.appendChild(button("產生一把", null, makeBackup));
       label.appendChild(row);
-      main.appendChild(label);
-      main.appendChild(
+      head.appendChild(label);
+      head.appendChild(
         el("p", "vl-hint", "沒有 WebAuthn 的環境（例如 Tor Browser）只剩備援私鑰這條路，passkey 全丟了也一樣。留空就沒有那條退路。")
       );
       if (state.shownSecret) {
-        main.appendChild(el("p", "vl-secret", state.shownSecret));
-        main.appendChild(el("p", "vl-hint", "備援私鑰，只顯示這一次。存進密碼管理器，放在跟這台裝置不同的地方。"));
+        head.appendChild(el("p", "vl-secret", state.shownSecret));
+        head.appendChild(el("p", "vl-hint", "備援私鑰，只顯示這一次。存進密碼管理器，放在跟這台裝置不同的地方。"));
       }
-      main.appendChild(button("建立暫存區", "vl-primary", create));
+      head.appendChild(button("建立暫存區", "vl-primary", create));
       return;
     }
 
-    main.appendChild(
+    head.appendChild(
       el("p", "vl-hint", "這台裝置上有一份鎖著的暫存區，密文 " + state.blobSize + " 個位元組。")
     );
     const actions = el("div", "vl-actions");
     actions.appendChild(button("用 passkey 解開", "vl-primary", unlock));
-    main.appendChild(actions);
+    head.appendChild(actions);
 
     const label = el("label", "vl-label", "或者貼備援私鑰（AGE-SECRET-KEY-1 開頭）");
     const input = document.createElement("input");
@@ -221,18 +256,20 @@
     input.className = "vl-secret-in";
     input.placeholder = "AGE-SECRET-KEY-1…";
     label.appendChild(input);
-    main.appendChild(label);
-    main.appendChild(button("用備援私鑰解開", null, () => unlockBackup(input.value)));
+    head.appendChild(label);
+    head.appendChild(button("用備援私鑰解開", null, () => unlockBackup(input.value)));
   }
 
   function renderUnlocked() {
-    const items = Object.keys(state.data || {}).length;
-    main.appendChild(
+    const note = (state.data && state.data.note) || "";
+    head.appendChild(
       el(
         "p",
         "vl-hint",
-        (state.readOnly ? "唯讀，看得到也匯得出去，改不了。" : "解開了，關掉這個分頁就會重新鎖上。") +
-          (items ? "裡面有 " + items + " 個項目。" : "裡面還沒有東西，打字之後按儲存。")
+        (state.readOnly
+          ? "唯讀，看得到也匯得出去，改不了。"
+          : "解開了，打字會自動存下來，關掉這個分頁就重新鎖上。") +
+          (note.length ? "目前有 " + note.length + " 個字。" : "目前還是空的。")
       )
     );
 
@@ -248,18 +285,19 @@
         say("鎖上了。");
       })
     );
-    main.appendChild(actions);
+    foot.appendChild(actions);
   }
 
   function render() {
     // 只重畫上面那一塊。文字框在 noteArea 裡，從頭到尾不動它，正在打的字與輸入法的
     // 組字都不會被打斷。
-    main.textContent = "";
+    head.textContent = "";
+    foot.textContent = "";
     noteArea.hidden = !(state.unlocked && vault() && vault().available() && !state.busy);
     noteBox.disabled = state.readOnly;
 
     if (!vault() || !vault().available()) {
-      main.appendChild(el("p", "vl-hint", "這個瀏覽器用不了，它需要 WebAuthn 與 IndexedDB。"));
+      head.appendChild(el("p", "vl-hint", "這個瀏覽器用不了，它需要 WebAuthn 與 IndexedDB。"));
       return;
     }
 
@@ -270,14 +308,14 @@
       busy.appendChild(spin);
       busy.appendChild(document.createTextNode(" 等你在瀏覽器的提示裡完成"));
       busy.setAttribute("aria-busy", "true");
-      main.appendChild(busy);
+      foot.appendChild(busy);
       return;
     }
 
     if (state.unlocked) renderUnlocked();
     else renderLocked();
 
-    if (state.message) main.appendChild(el("p", "vl-msg", state.message));
+    if (state.message) foot.appendChild(el("p", "vl-msg", state.message));
 
     if (state.exists) {
       const danger = el("div", "vl-actions");
@@ -290,13 +328,9 @@
         if (file.files && file.files[0]) importBlob(file.files[0]);
       });
       danger.appendChild(file);
-      main.appendChild(danger);
+      foot.appendChild(danger);
     }
 
-    if (hadFocus && noteBox.isConnected) {
-      noteBox.focus();
-      if (caret) noteBox.setSelectionRange(caret[0], caret[1]);
-    }
   }
 
   refresh().then(render, render);


### PR DESCRIPTION
真正的原因跟前四次修的都無關：**這一頁從來沒有任何樣式**。

三顆按鈕用 `appendChild` 接在一起，中間連空白字元都沒有，手機上按「儲存」很容易點到旁邊的「匯出」，跳出下載對話框。使用者要試好幾次才點得到儲存，於是看起來像「存不進去」。

線索一直在測試輸出裡。`innerText` 印出來是「儲存匯出鎖上」，我讀成文字都在，沒意識到那代表按鈕之間沒有間距。截一張圖就會看到，而我用 Chrome CDP 跑了十幾輪，一張都沒截。

## 三件事

**樣式。** 按鈕之間留 `0.75rem`，觸控目標給到 `2.75rem`（約 44 px），輸入框與提示都有規則，顏色用 theme 的變數所以深色模式跟著走。寫在頁面的 `<style>` 區塊，範圍限在這一頁。

**版面順序。** 畫面拆成狀態、內容、動作三塊，順序就是讀者的操作順序。原本文字框被推到清除按鈕與檔案選擇下面，要捲動才看得到，而按鈕在最上面。

**自動儲存。** 打完字停 0.8 秒就自己存。「要記得按儲存」本身就是一個會出錯的環節，而它出錯的樣子跟程式有 bug 一模一樣。手動那顆留著給想立刻確認的人。解開後的訊息也從「N 個項目」改成「N 個字」。

## 順手清掉一個殘骸

上一輪改寫 `render()` 開頭時刪掉了 `hadFocus` 的宣告，結尾的使用還留著，自動儲存因此報 `hadFocus is not defined`。那是截圖那一輪才抓到的，行為測試沒抓到是因為它只驗最終文字。

## 驗證

手機尺寸（390×844）截圖確認：文字框在按鈕上方，三顆按鈕間距分明。完全不按儲存的流程：

```
1 自動存: 已自動存下，內容 6 個字，密文 229 個位元組。
（重新整理）
2 解開:   解開了，裡面有 6 個字。
3 框裡:   "完全不按儲存"
```

`test_vault.mjs` 12 通過，`docs_style_lint.py` 0 error 0 warn。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
