### PR TITLE
feat(changelog): 補上 Tor Browser 16.0a11 與 Tails 7.12，Firefox 改兩週發布

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -20,6 +20,17 @@ A compromise on Tails means something different from a compromise on an ordinary
 
 The Tails project only distinguishes emergency from scheduled releases. The middle tier is a judgement community volunteers add after reading each advisory. Where the call is unclear, we round up.
 
+## Tails 7.12
+
+> 2026-09-03 · [Upstream announcement](https://tails.net/news/version_7.12/){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">Routine</span>Regular scheduled release, not an emergency security update. The announcement lists no fixed vulnerabilities, and upstream does not mention any being exploited.
+- Firefox moves to a two-week release cadence from September 2026, and Tor Browser and Tails follow. 7.12 is the first release on the new schedule, so updates arrive more often from here on.
+- Tor Browser updated to 15.0.21, which carries security fixes backported from Firefox 155.
+- Electrum updated from 4.7.2 to 4.8.1.
+- Updated some firmware packages, improving support for newer hardware such as graphics and Wi-Fi.
+- Automatic upgrades are available from Tails 7.0 or later. Fresh installations will erase existing Persistent Storage.
+
 ## Tails 7.11
 
 > 2026-08-19 · [Upstream announcement](https://tails.net/news/version_7.11/){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -13,7 +13,27 @@ Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top.
 - <span class="chan-tag chan-tag--stable">Stable</span>What regular users should run, versioned like 15.0.20.
 - <span class="chan-tag chan-tag--alpha">Alpha</span>Testing only. It may contain bugs affecting usability, security, and privacy, and is versioned with an a (16.0a10, for example). Do not use it if you need strong anonymity.
 
-Since 16.0a6 (May 2026) the alpha channel has been based on Firefox betas, rebasing in small steps. The beta line it follows became the new Firefox ESR 153 in July, which is why entries from 16.0a9 onward carry esr version numbers again: same line, not a return to the old base. Stable releases almost always carry Firefox or tor daemon security fixes, so install them as they appear.
+Since 16.0a6 (May 2026) the alpha channel has been based on Firefox betas, rebasing in small steps. The beta line it follows became the new Firefox ESR 153 in July, which is why entries from 16.0a9 onward carry esr version numbers again: same line, not a return to the old base. Stable releases almost always carry Firefox or tor daemon security fixes, so install them as they appear. Firefox moved to a two-week release cadence in September 2026 and Tor Browser follows, so stable updates now arrive more often than before.
+
+## Tor Browser 16.0a11 (alpha)
+
+> 2026-09-02 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a11/){target="_blank"}
+
+- <span class="chan-tag chan-tag--alpha">Alpha</span>The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
+- Rebased the Firefox base onto 153.2.0esr (tor-browser#45254), with Android GeckoView following, and backported security fixes from Firefox 155 (tor-browser#45259).
+- Local Network Access (LNA) restrictions are now always on for Android as defence in depth (tor-browser#44155). Pages can no longer reach local network or loopback addresses directly, which closes one route for probing other devices on the same network.
+- TorConnect redirections now go through the parent process (tor-browser#45264), the same fix that shipped in stable 15.0.21.
+- The build now pulls GCC sources from gcc.gnu.org (tor-browser-build#41860), and Go moves to 1.26.8 in the build toolchain.
+
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes.
+- Rebased the Firefox base onto 140.15.0esr (tor-browser#45253), with Android GeckoView following, and backported security fixes from Firefox 155 (tor-browser#45259).
+- Fixed `about:torconnect` not appearing when the browser starts outside private browsing mode (tor-browser#45223). TorConnect redirections now go through the parent process (tor-browser#45264).
+- NoScript updated to 13.6.32.1984, OpenSSL to 3.5.8, and Go to 1.25.14 in the build toolchain.
+- Upstream switched the 32-bit Linux notice to the expired-version message, and the tracking item states this is the final 15.0 release (tor-browser#44996). Per the plan announced with 16.0a9, the 16.0 stable series takes over in September, so anyone on 15.x can start preparing to move.
 
 ## Tor Browser 16.0a10 (alpha)
 
@@ -27,16 +47,6 @@ Since 16.0a6 (May 2026) the alpha channel has been based on Firefox betas, rebas
 - Disabled locale-based font rules as defence in depth against fingerprinting (tor-browser#44257).
 - Updated NoScript to 13.6.31.90301984 and OpenSSL to 3.5.8.
 - `about:torconnect` now reports an error when the tor daemon crashes (tor-browser#43570), and bridge settings update when a connection fails (tor-browser#43939).
-
-## Tor Browser 15.0.21
-
-> 2026-09-01 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
-
-- <span class="chan-tag chan-tag--stable">Stable</span>A small release focused on Firefox security fixes.
-- Rebased the Firefox base onto 140.15.0esr (tor-browser#45253), with Android GeckoView following, and backported security fixes from Firefox 155 (tor-browser#45259).
-- Fixed `about:torconnect` not appearing when the browser starts outside private browsing mode (tor-browser#45223). TorConnect redirections now go through the parent process (tor-browser#45264).
-- NoScript updated to 13.6.32.1984, OpenSSL to 3.5.8, and Go to 1.25.14 in the build toolchain.
-- Upstream switched the 32-bit Linux notice to the expired-version message, and the tracking item states this is the final 15.0 release (tor-browser#44996). Per the plan announced with 16.0a9, the 16.0 stable series takes over in September, so anyone on 15.x can start preparing to move.
 
 ## Tor Browser 15.0.20
 

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -20,6 +20,17 @@ Tails 上的漏洞后果跟一般操作系统不同。取得管理员权限等�
 
 Tails 官方只区分紧急发布与排程发布，中间那一层是社群志愿者读完公告后补的判断。判断不确定时以较高一级为准。
 
+## Tails 7.12
+
+> 2026-09-03 · [上游公告](https://tails.net/news/version_7.12/){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非紧急安全发布。公告没有列出这一版修掉的漏洞，上游也没有提到已被实际利用。
+- Firefox 从 2026 年 9 月起改为两周发布一次，Tor Browser 与 Tails 跟着改，7.12 是新节奏的第一版。往后的版本会来得更密，自动升级的提示也会更常出现。
+- Tor Browser 升至 15.0.21，该版带有从 Firefox 155 backport 的安全修补。
+- Electrum 从 4.7.2 升至 4.8.1。
+- 更新部分 firmware 套件，改善较新硬件的支持，包含显卡、Wi-Fi 等。
+- 可从 Tails 7.0 以后版本自动升级。全新安装会清除既有的 Persistent Storage。
+
 ## Tails 7.11
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -13,7 +13,27 @@ icon: simple/torbrowser
 - <span class="chan-tag chan-tag--stable">稳定版</span>一般用户用这个，版本号形如 15.0.20。
 - <span class="chan-tag chan-tag--alpha">Alpha</span>仅供测试，可能含影响可用性、安全与隐私的错误，版本号带 a（例如 16.0a10）。需要强匿名保护的人不要用。
 
-Alpha 从 16.0a6（2026 年 5 月）起改以 Firefox beta 为基底，逐版小步 rebase。追的那条 beta 线在 7 月成为新的 Firefox ESR 153，所以 16.0a9 之后的版号标示又回到 esr，那是同一条线的延续，不是换回旧基底。稳定版几乎每次发布都带 Firefox 或 tor daemon 的安全修补，看到新版就更新即可。
+Alpha 从 16.0a6（2026 年 5 月）起改以 Firefox beta 为基底，逐版小步 rebase。追的那条 beta 线在 7 月成为新的 Firefox ESR 153，所以 16.0a9 之后的版号标示又回到 esr，那是同一条线的延续，不是换回旧基底。稳定版几乎每次发布都带 Firefox 或 tor daemon 的安全修补，看到新版就更新即可。Firefox 从 2026 年 9 月起改为两周发布一次，Tor Browser 跟着改，稳定版的更新会比过去更密。
+
+## Tor Browser 16.0a11（Alpha 测试通道）
+
+> 2026-09-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a11/){target="_blank"}
+
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
+- Firefox 基底 rebase 至 153.2.0esr（tor-browser#45254），Android 版 GeckoView 同步，并从 Firefox 155 backport 安全修补（tor-browser#45259）。
+- Android 版一律启用本地网络访问（Local Network Access，LNA）限制，作为纵深防御（tor-browser#44155）。开启后网页不能直接连向局域网或本机地址，少掉一条探测同一个网络内其他设备的路。
+- TorConnect 的重定向改由父进程处理（tor-browser#45264），与稳定版 15.0.21 是同一项修正。
+- 构建流程改从 gcc.gnu.org 取得 GCC 源码（tor-browser-build#41860），构建工具链的 Go 升至 1.26.8。
+
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本。
+- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，并从 Firefox 155 backport 安全修补（tor-browser#45259）。
+- 修好在非隐私浏览模式启动浏览器时 `about:torconnect` 不显示的问题（tor-browser#45223）。TorConnect 的重定向改由父进程处理（tor-browser#45264）。
+- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，构建工具链的 Go 升至 1.25.14。
+- 上游把 32 位 Linux 的提示改成版本过期消息，跟踪项目写明这是 15.0 系列的最后一版（tor-browser#44996）。16.0 稳定版依 16.0a9 公告的规划在 9 月接手，还在 15.x 的人可以准备换过去。
 
 ## Tor Browser 16.0a10（Alpha 测试通道）
 
@@ -27,16 +47,6 @@ Alpha 从 16.0a6（2026 年 5 月）起改以 Firefox beta 为基底，逐版小
 - 停用以语系为基础的字体规则，作为浏览器指纹的纵深防御（tor-browser#44257）。
 - NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
 - tor daemon 崩溃时，`about:torconnect` 会显示错误信息（tor-browser#43570）。网桥连接失败时也会更新网桥设置的显示（tor-browser#43939）。
-
-## Tor Browser 15.0.21
-
-> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
-
-- <span class="chan-tag chan-tag--stable">稳定版</span>以 Firefox 安全修补为主的小版本。
-- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，并从 Firefox 155 backport 安全修补（tor-browser#45259）。
-- 修好在非隐私浏览模式启动浏览器时 `about:torconnect` 不显示的问题（tor-browser#45223）。TorConnect 的重定向改由父进程处理（tor-browser#45264）。
-- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，构建工具链的 Go 升至 1.25.14。
-- 上游把 32 位 Linux 的提示改成版本过期消息，跟踪项目写明这是 15.0 系列的最后一版（tor-browser#44996）。16.0 稳定版依 16.0a9 公告的规划在 9 月接手，还在 15.x 的人可以准备换过去。
 
 ## Tor Browser 15.0.20
 

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -20,6 +20,17 @@ Tails 上的漏洞後果跟一般作業系統不同。取得管理員權限等�
 
 Tails 官方只區分緊急釋出與排程釋出，中間那一層是社群志工讀完公告後補的判斷。判斷不確定時以較高一級為準。
 
+## Tails 7.12
+
+> 2026-09-03 · [上游公告](https://tails.net/news/version_7.12/){target="_blank"}
+
+- <span class="urg-tag urg-tag--routine">一般</span>例行排程版本，非緊急安全釋出。公告沒有列出這一版修掉的漏洞，上游也沒有提到已被實際利用。
+- Firefox 從 2026 年 9 月起改為兩週發布一次，Tor Browser 與 Tails 跟著改，7.12 是新節奏的第一版。往後的版本會來得更密，自動升級的提示也會更常出現。
+- Tor Browser 升至 15.0.21，該版帶有從 Firefox 155 backport 的安全修補。
+- Electrum 從 4.7.2 升至 4.8.1。
+- 更新部分 firmware 套件，改善較新硬體的支援，包含顯示卡、Wi-Fi 等。
+- 可從 Tails 7.0 以後版本自動升級。全新安裝會清除既有的 Persistent Storage。
+
 ## Tails 7.11
 
 > 2026-08-19 · [上游公告](https://tails.net/news/version_7.11/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -13,7 +13,27 @@ icon: simple/torbrowser
 - <span class="chan-tag chan-tag--stable">穩定版</span>一般使用者用這個，版本號形如 15.0.20。
 - <span class="chan-tag chan-tag--alpha">Alpha</span>僅供測試，可能含影響可用性、安全與隱私的錯誤，版本號帶 a（例如 16.0a10）。需要強匿名保護的人不要用。
 
-Alpha 從 16.0a6（2026 年 5 月）起改以 Firefox beta 為基底，逐版小步 rebase。追的那條 beta 線在 7 月成為新的 Firefox ESR 153，所以 16.0a9 之後的版號標示又回到 esr，那是同一條線的延續，不是換回舊基底。穩定版幾乎每次發布都帶 Firefox 或 tor daemon 的安全修補，看到新版就更新即可。
+Alpha 從 16.0a6（2026 年 5 月）起改以 Firefox beta 為基底，逐版小步 rebase。追的那條 beta 線在 7 月成為新的 Firefox ESR 153，所以 16.0a9 之後的版號標示又回到 esr，那是同一條線的延續，不是換回舊基底。穩定版幾乎每次發布都帶 Firefox 或 tor daemon 的安全修補，看到新版就更新即可。Firefox 從 2026 年 9 月起改為兩週發布一次，Tor Browser 跟著改，穩定版的更新會比過去更密。
+
+## Tor Browser 16.0a11（Alpha 測試通道）
+
+> 2026-09-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a11/){target="_blank"}
+
+- <span class="chan-tag chan-tag--alpha">Alpha</span>Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
+- Firefox 基底 rebase 至 153.2.0esr（tor-browser#45254），Android 版 GeckoView 同步，並從 Firefox 155 backport 安全修補（tor-browser#45259）。
+- Android 版一律啟用本機網路存取（Local Network Access，LNA）限制，作為深度防禦（tor-browser#44155）。開啟後網頁不能直接連向區域網路或本機位址，少掉一條探測同一個網路內其他裝置的路。
+- TorConnect 的重導改由父行程處理（tor-browser#45264），與穩定版 15.0.21 是同一項修正。
+- 建置流程改從 gcc.gnu.org 取得 GCC 原始碼（tor-browser-build#41860），建置工具鏈的 Go 升至 1.26.8。
+
+## Tor Browser 15.0.21
+
+> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
+
+- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本。
+- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，並從 Firefox 155 backport 安全修補（tor-browser#45259）。
+- 修好在非隱私瀏覽模式啟動瀏覽器時 `about:torconnect` 不顯示的問題（tor-browser#45223）。TorConnect 的重導改由父行程處理（tor-browser#45264）。
+- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，建置工具鏈的 Go 升至 1.25.14。
+- 上游把 32 位元 Linux 的提示改成版本過期訊息，追蹤項目寫明這是 15.0 系列的最後一版（tor-browser#44996）。16.0 穩定版依 16.0a9 公告的規劃在 9 月接手，還在 15.x 的人可以準備換過去。
 
 ## Tor Browser 16.0a10（Alpha 測試通道）
 
@@ -27,16 +47,6 @@ Alpha 從 16.0a6（2026 年 5 月）起改以 Firefox beta 為基底，逐版小
 - 停用以語系為基礎的字型規則，作為瀏覽器指紋的深度防禦（tor-browser#44257）。
 - NoScript 升至 13.6.31.90301984，OpenSSL 升至 3.5.8。
 - tor daemon 崩潰時，`about:torconnect` 會顯示錯誤訊息（tor-browser#43570）。橋接連線失敗時也會更新橋接設定的顯示（tor-browser#43939）。
-
-## Tor Browser 15.0.21
-
-> 2026-09-01 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15021/){target="_blank"}
-
-- <span class="chan-tag chan-tag--stable">穩定版</span>以 Firefox 安全修補為主的小版本。
-- Firefox 基底 rebase 至 140.15.0esr（tor-browser#45253），Android 版 GeckoView 同步，並從 Firefox 155 backport 安全修補（tor-browser#45259）。
-- 修好在非隱私瀏覽模式啟動瀏覽器時 `about:torconnect` 不顯示的問題（tor-browser#45223）。TorConnect 的重導改由父行程處理（tor-browser#45264）。
-- NoScript 升至 13.6.32.1984，OpenSSL 升至 3.5.8，建置工具鏈的 Go 升至 1.25.14。
-- 上游把 32 位元 Linux 的提示改成版本過期訊息，追蹤項目寫明這是 15.0 系列的最後一版（tor-browser#44996）。16.0 穩定版依 16.0a9 公告的規劃在 9 月接手，還在 15.x 的人可以準備換過去。
 
 ## Tor Browser 15.0.20
 


### PR DESCRIPTION
比對十二頁的上游來源後，只有兩則新版本沒收，三個語系都補上。

## 新增條目

### Tor Browser 16.0a11（Alpha），2026-09-02

- Firefox 基底 rebase 至 153.2.0esr（tor-browser#45254），Android 版 GeckoView 同步，並從 Firefox 155 backport 安全修補（#45259）
- Android 版一律啟用本機網路存取（LNA）限制。這一項查過 tor-browser#44155，內容是對 Mozilla bug 1971290「[meta] LNA permissions on Android」的稽核，所以條目寫的是本機網路存取限制，不用泛稱的強化帶過
- TorConnect 重導改由父行程處理（#45264），與穩定版 15.0.21 是同一項修正
- 建置流程改從 gcc.gnu.org 取得 GCC 原始碼（tor-browser-build#41860），Go 升至 1.26.8

### Tails 7.12，2026-09-03

- Tor Browser 升至 15.0.21、Electrum 4.7.2 到 4.8.1、更新部分韌體套件
- 急迫程度給「一般」。判準比照同頁的 7.9：一樣是例行排程版本、一樣只帶 Tor Browser 升級與韌體更新、公告一樣沒有列出漏洞。7.9 當時的 Tor Browser 15.0.16 頁上寫的是「重要的 Firefox 安全更新」，Tails 那則仍是「一般」，所以 7.12 跟著同一條線
- 利用狀態依 `CHANGELOG_SOURCES.md` 的第三種措辭處理，上游根本沒提，寫「上游也沒有提到已被實際利用」

## 順帶的兩項

Firefox 從 2026 年 9 月起改為兩週發布一次，Tor Browser 與 Tails 跟著改，Tails 7.12 是新節奏的第一版。這件事寫進 `tor.md` 的「兩個發布通道」段落與 Tails 7.12 條目，讀者之後看到更新變密不會以為出事。來源是 Tails 公告引的 [Mozilla dev-platform 公告](https://groups.google.com/a/mozilla.org/g/dev-platform/c/qlaQ1YSlOP8)。

修掉排序：15.0.21（09-01）原本排在 16.0a10（08-27）下面，跟頁面開頭寫的「新版本永遠在最上面」對不上。現在三語系都是 16.0a11、15.0.21、16.0a10、15.0.20。

## 其餘十頁確認過是最新

| 頁面 | 上游最新 | 說明 |
|---|---|---|
| `tor-daemon.md` | tor-0.4.9.11（06-25） | GitLab tag 沒有更新的 |
| `anti-censorship.md` | WebTunnel 0.0.6、Snowflake 2.14.1、lyrebird 0.8.1 | 三個 repo 的 tag 都對得上 |
| `arti.md` | arti-v2.6.0（09-01） | 已收 |
| `ooni.md` | probe 6.2.0、CLI v3.30.0 | GitHub releases API |
| `onionshare.md` | v2.6.5（07-28） | GitHub releases API |
| `ios.md`、`macos.md` | 08-17 那批 | Apple 安全更新總表最新一列是 08-18 的 Safari 26.6.1，站上沒有 Safari 頁 |
| `windows.md` | 8 月那輪 | 9 月 Patch Tuesday 是 2026-09-08，還沒到 |
| `android.md` | 2026-08-05 等級 | 9 月公告未發布，`bulletin/2026/2026-09-01` 回 404 |
| `grapheneos.md` | 2026081301（08-13） | releases.atom 之後沒有新版 |

## 檢查

- `python3 tools/docs_style_lint.py` 掃六個檔案：0 error、0 warn
- `node tools/check_invisible_chars.mjs` 掃 1019 個檔案：沒有可疑隱形字元
- grep 過 `docs/` 的 md、js、json、yml，`changelog/` 以外沒有引用這些版本號

沒有跑 mkdocs 建置。純內容編輯，沒有新增內部連結或錨點，front matter 也沒動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)