### PR TITLE
content(activity): 3D 作品那段補上地球儀截圖，三語系各用自己語言的版本

### DIFF
--- a/docs/en/activity/gg2026.md
+++ b/docs/en/activity/gg2026.md
@@ -46,6 +46,8 @@ Offline capability is the point, and it is also the proof. A tool that still run
 
 Alongside them are three 3D interactives about Tor: a [routing puzzle](../games/onion-routing.md), a [traffic flow view](../games/onion-rendezvous.md), and a [relay globe](../games/tor-network.md) built from real Onionoo data.
 
+![The Tor Relay Globe with the sphere turned to Asia, relays drawn as coloured dots inside their borders, and the left panel listing relay counts per country and a hosting provider ranking](https://assets.anoni.net/games/tor-network-globe-en.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+
 ### Store them before you need them
 
 Conference Wi-Fi is a poor moment to find out that a tool still needs downloading, and so is a shutdown. The [offline reading](../offline.md) page stores the pages you tick on your device, tools included, and afterwards the whole thing opens with the network off.

--- a/docs/zh-CN/activity/gg2026.md
+++ b/docs/zh-CN/activity/gg2026.md
@@ -46,6 +46,8 @@ icon: material/map-marker-radius
 
 旁边还有三件关于 Tor 怎么运作的 3D 作品，[路由解谜](../games/onion-routing.md)、[连线流量](../games/onion-rendezvous.md)，以及用 Onionoo 真实数据画出来的[中继地球仪](../games/tor-network.md)。
 
+![Tor 中继地球仪的画面，地球转到亚洲一侧，中继以彩色点分布在各国界内，左侧面板列出各国中继数与托管商排行](https://assets.anoni.net/games/tor-network-globe-zh-cn.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+
 ### 需要之前先存起来
 
 工具要用了才发现还得下载，通常已经来不及。会场的 Wi-Fi 如此，断网的时候更是。[离线阅读](../offline.md)页把你勾起来的页面存进设备，小工具一起带走，之后没有网络也打得开。

--- a/docs/zh-TW/activity/gg2026.md
+++ b/docs/zh-TW/activity/gg2026.md
@@ -46,6 +46,8 @@ icon: material/map-marker-radius
 
 旁邊還有三件關於 Tor 怎麼運作的 3D 作品，[路由解謎](../games/onion-routing.md)、[連線流量](../games/onion-rendezvous.md)，以及用 Onionoo 真實資料畫出來的[中繼地球儀](../games/tor-network.md)。
 
+![Tor 中繼地球儀的畫面，地球轉到亞洲一側，中繼以彩色點分布在各國界內，左側面板列出各國中繼數與托管商排行](https://assets.anoni.net/games/tor-network-globe.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
+
 ### 需要之前先存起來
 
 工具要用了才發現還得下載，通常已經來不及。會場的 Wi-Fi 如此，斷網的時候更是。[離線閱讀](../offline.md)頁把你勾起來的頁面存進裝置，小工具一起帶走，之後沒有網路也打得開。


### PR DESCRIPTION
接續 #454。現場頁提到中繼地球儀卻只有文字，桌上那台筆電擺的就是它，補一張畫面讓人認得出來。

## 語系配對

這張圖有三個語系版本，介面文字不同。配對照 `games/tor-network.md` 本來就在用的，沒有自己猜：

| 語系 | 檔案 | 面板標題 |
|---|---|---|
| zh-TW | `tor-network-globe.webp` | Tor 中繼地球儀 |
| zh-CN | `tor-network-globe-zh-cn.webp` | Tor 中继地球仪 |
| en | `tor-network-globe-en.webp` | Tor Relay Globe |

整行從對應語系的 `games/tor-network.md` 第 16 行照抄，alt text 與 `style` 都一致，同一張圖在站上的描述維持同一份。

## 驗證

- 三張圖先從 `assets.anoni.net` 抓回確認 `HTTP 200`、`image/webp`、`2560x1440`
- 實際開圖確認 zh-TW 是正體介面、en 是英文介面，沒有配錯
- 三語系 strict 建置通過，產物逐一確認吃到的是對應語系的檔名
- `docs_style_lint.py` 從 repo 根目錄跑，`0 error 0 warn`
- frontmatter 三份都用 `yaml.safe_load` 驗過（#454 踩過冒號讓 YAML 整份失效、strict 建置卻照樣 exit 0 的坑）
- 390 px 與 1280 px 都截圖看過。手機上面板文字會縮到讀不了，只看得出是一顆有資料的地球，跟 `games/tor-network.md` 本身在手機上的狀況一樣

🤖 Generated with [Claude Code](https://claude.com/claude-code)