### PR TITLE
content(activity): 六個專有名詞加腳註，用現場參加者讀不懂的地方決定加在哪

### DIFF
--- a/docs/en/activity/gg2026.md
+++ b/docs/en/activity/gg2026.md
@@ -35,16 +35,16 @@ Offline capability is the point, and it is also the proof. A tool that still run
 | [Passphrase and password generator](../utils/passphrase.md) | Diceware passphrases from a 7776-word list, or random passwords from a character set you pick, with the entropy shown |
 | [Local file encryption](../utils/age.md) | Encrypts a file or a block of text to the age format in the browser, and decrypts age files back. Standard output, readable by the age command-line tool anywhere |
 | [Passkey as your key](../utils/passkey.md) | Creates a passkey that computes the encryption key for the tool above, so there is no passphrase to remember |
-| [QR code generator](../utils/qrcode.md) | Turns onion addresses, bridge lines and other long strings into a QR code for the person in front of you, with no server in between |
+| [QR code generator](../utils/qrcode.md) | Turns onion addresses, bridge[^bridge] lines and other long strings into a QR code for the person in front of you, with no server in between |
 | [QR code reader](../utils/qr-read.md) | Reads a QR code out of an image without the image leaving your device, and isolates the host when the result is a URL |
 | [QR code frame stream](../utils/qr-stream.md) | Moves a file between two devices over screen and camera, with no pairing, no shared network and no server |
-| [File metadata remover](../utils/strip-metadata.md) | Strips EXIF, GPS, device model and author fields from photos, video, audio, Office documents and PDFs, listing what went and what stayed |
+| [File metadata remover](../utils/strip-metadata.md) | Strips EXIF[^exif], GPS, device model and author fields from photos, video, audio, Office documents and PDFs, listing what went and what stayed |
 | [Screenshot redaction](../utils/redact.md) | Fills names, avatars and conversations with solid black, then verifies pixel by pixel before handing the file back |
 | [URL cleaner](../utils/clean-url.md) | Removes tracking parameters and says who each one reports to, unwraps redirect links and isolates the real registrable domain |
 | [Invisible character detector](../utils/invisible.md) | Finds zero-width characters, direction controls, tag characters and lookalike letters used for leak tracing, phishing and prompt injection |
 | [What your browser gives away](../utils/leaks.md) | Lists what any site can read without asking, and marks what Tor Browser makes uniform |
 
-Alongside them are three 3D interactives about Tor: a [routing puzzle](../games/onion-routing.md), a [traffic flow view](../games/onion-rendezvous.md), and a [relay globe](../games/tor-network.md) built from real Onionoo data.
+Alongside them are three 3D interactives about Tor: a [routing puzzle](../games/onion-routing.md), a [traffic flow view](../games/onion-rendezvous.md), and a [relay globe](../games/tor-network.md) built from real Onionoo[^onionoo] data.
 
 ![The Tor Relay Globe with the sphere turned to Asia, relays drawn as coloured dots inside their borders, and the left panel listing relay counts per country and a hosting provider ranking](https://assets.anoni.net/games/tor-network-globe-en.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
@@ -58,7 +58,7 @@ If you want just the tools, tick the utilities section. If you have the bandwidt
 
 A passkey usually logs you in. We use it for something else, and there is no login, no account and no server anywhere in the flow. We ask it to compute an encryption key.
 
-WebAuthn's PRF extension lets a passkey hold a secret that never leaves the authenticator. The page sends an input, you approve with a fingerprint, face or PIN, and 32 bytes come back. Same passkey and same input, same 32 bytes, every time. [Local file encryption](../utils/age.md) wraps the age file key with that output, so without the passkey the file is ciphertext and nothing else. This is arithmetic rather than a gate drawn on a web page.
+WebAuthn's PRF extension[^prf] lets a passkey hold a secret that never leaves the authenticator. The page sends an input, you approve with a fingerprint, face or PIN, and 32 bytes come back. Same passkey and same input, same 32 bytes, every time. [Local file encryption](../utils/age.md) wraps the age file key with that output, so without the passkey the file is ciphertext and nothing else. This is arithmetic rather than a gate drawn on a web page.
 
 The site stores nothing, and it cannot: browsers refuse to tell a page whether a domain has a passkey, so we do not even know you made one.
 
@@ -66,11 +66,11 @@ Background is in [what is a passkey](../tools/what-is-passkey.md), and the tool 
 
 ??? note "What we are still working out, and the known limits"
 
-    The next step is an encrypted scratch area on the page itself, opened by the same passkey, for the kind of checklist you fill in on a laptop that other people can pick up. The current experiment puts the data key in the credential's `user.id` field instead of using PRF. Apple hands PRF material only to the iCloud Keychain, so an iPhone paired with a third-party password manager can create a passkey and still be unable to compute a key. `user.id` is a core field every provider returns. The cost is that the key then lives in the vault next to the credential, and the security ceiling drops to the security of that vault. We took that trade deliberately, because coverage on the devices people actually own matters more to us here than the ceiling.
+    The next step is an encrypted scratch area on the page itself, opened by the same passkey, for the kind of checklist you fill in on a laptop that other people can pick up. The current experiment puts the data key in the credential's `user.id`[^userid] field instead of using PRF. Apple hands PRF material only to the iCloud Keychain, so an iPhone paired with a third-party password manager can create a passkey and still be unable to compute a key. `user.id` is a core field every provider returns. The cost is that the key then lives in the vault next to the credential, and the security ceiling drops to the security of that vault. We took that trade deliberately, because coverage on the devices people actually own matters more to us here than the ceiling.
 
     The limits are worth stating plainly:
 
-    - The passkey is bound to the `anoni.net` RP ID, so mirrors and the onion address cannot use it.
+    - The passkey is bound to the `anoni.net` RP ID[^rpid], so mirrors and the onion address cannot use it.
     - Tor Browser disables WebAuthn entirely, so this path is closed there.
     - Firefox on Android and Windows 10 do not support PRF.
     - Lose the passkey and the data is gone, which is why the flow adds an X25519 backup key by default.
@@ -95,3 +95,15 @@ Most of us come from open-source and technology communities, and the day-to-day 
 - **Anonymous tips**: whisper@anoni.net, [GPG key on the contact page](../contact.md). We check it within a few hours during the event.
 
 The long version, covering why we came, which sessions overlap with our work, and which booths we plan to visit, is in [anoni.net at Global Gathering 2026](../blog/posts/2026-anoni-net-global-gathering.md).
+
+[^bridge]: A bridge is a Tor entry point that is not published in the public list. Ordinary entry addresses get blocked, and because bridges are unpublished they still get through in a censored network.
+
+[^exif]: EXIF is a block of information that photo and video files carry automatically, recording the time, the device model and, if location is on, the coordinates. None of it shows on screen, so the picture looks like an ordinary picture.
+
+[^onionoo]: Onionoo is the Tor Project's data service for relay status, listing which relays exist worldwide, which country each sits in and how much bandwidth it carries. The globe is drawn from it. It is a different thing from OONI, mentioned further down, which measures whether a given site is reachable from a given place.
+
+[^prf]: WebAuthn is the authentication mechanism built into browsers, and PRF is one of its extensions. In plain terms, your phone or computer holds a secret you never see, and each time you approve with a fingerprint, face or PIN it produces the same fixed result. That result is what we use as the encryption key, so the site never has to hold anything. The "authenticator" is whatever keeps that secret, which might be the secure chip in your phone or your password manager.
+
+[^userid]: `user.id` is a basic field in the passkey specification, normally holding an account identifier. We put the encryption key there instead, because every password manager returns that field, while PRF is unavailable in some combinations.
+
+[^rpid]: The RP ID is the domain name a passkey is tied to. A passkey only works on the domain it was created for, so a mirror or the onion address counts as a different place to the browser even when the content is identical, and the passkey cannot be used there.

--- a/docs/zh-CN/activity/gg2026.md
+++ b/docs/zh-CN/activity/gg2026.md
@@ -35,16 +35,16 @@ icon: material/map-marker-radius
 | [密语与密码生成器](../utils/passphrase.md) | 用 7776 字词表抽密语，或从你选的字符集抽密码，同时显示熵有多少 |
 | [本机文件加密](../utils/age.md) | 在浏览器里把文件或一段文字加密成 age 格式，也能解回来。输出是公开格式，任何装了 age 命令行工具的电脑都打得开 |
 | [passkey 钥匙](../utils/passkey.md) | 建一把 passkey 替上面那个工具算出密钥，不用记密语 |
-| [QR code 生成器](../utils/qrcode.md) | 把 onion 网址、bridge 这类很长又容易打错的字符串变成 QR code，中间不经过服务器 |
+| [QR code 生成器](../utils/qrcode.md) | 把 onion 网址、bridge[^bridge] 这类很长又容易打错的字符串变成 QR code，中间不经过服务器 |
 | [QR code 读取器](../utils/qr-read.md) | 读出图片里的 QR code，图片不离开设备，解出网址时把主机独立标出来 |
 | [QR code 影格串流](../utils/qr-stream.md) | 用屏幕与摄像头在两台设备之间传文件，没有配对、没有共用网络、没有服务器 |
-| [文件 metadata 清除器](../utils/strip-metadata.md) | 拿掉照片、视频、录音、Office 文档与 PDF 里的 EXIF、GPS、设备型号与作者字段，每一段的去留都列出来 |
+| [文件 metadata 清除器](../utils/strip-metadata.md) | 拿掉照片、视频、录音、Office 文档与 PDF 里的 EXIF[^exif]、GPS、设备型号与作者字段，每一段的去留都列出来 |
 | [截图遮蔽](../utils/redact.md) | 把名字、头像与对话填成实心黑色，交付之前逐像素确认每一处都是纯黑 |
 | [网址清理器](../utils/clean-url.md) | 移除追踪参数并说明是谁在追，拆掉转址包装，把真正的注册域名单独标出来 |
 | [隐形字符检测](../utils/invisible.md) | 找出零宽字符、方向控制、标签字符与同形字，外流追踪、钓鱼网址与藏给 AI 读的指令都会用到 |
 | [你的浏览器透露了什么](../utils/leaks.md) | 列出任何网站不必问你就拿得到的信息，并标出 Tor Browser 会统一掉哪些 |
 
-旁边还有三件关于 Tor 怎么运作的 3D 作品，[路由解谜](../games/onion-routing.md)、[连线流量](../games/onion-rendezvous.md)，以及用 Onionoo 真实数据画出来的[中继地球仪](../games/tor-network.md)。
+旁边还有三件关于 Tor 怎么运作的 3D 作品，[路由解谜](../games/onion-routing.md)、[连线流量](../games/onion-rendezvous.md)，以及用 Onionoo[^onionoo] 真实数据画出来的[中继地球仪](../games/tor-network.md)。
 
 ![Tor 中继地球仪的画面，地球转到亚洲一侧，中继以彩色点分布在各国界内，左侧面板列出各国中继数与托管商排行](https://assets.anoni.net/games/tor-network-globe-zh-cn.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
@@ -58,7 +58,7 @@ icon: material/map-marker-radius
 
 passkey 平常用来登录，站上的用法完全不同。没有登录、没有账号、没有服务器，我们只请它算出一把加密密钥。
 
-WebAuthn 的 PRF 扩展让 passkey 内部多藏一把秘密，永远不离开验证器。网页送一段输入过去，你用指纹、脸或 PIN 同意，就拿回固定 32 个字节。同一把 passkey 配同一段输入，每次都得到同一段输出。[本机文件加密](../utils/age.md)拿它去包 age 的 file key，没有 passkey 就算不出密钥，文件就是一堆密文。「验证通过才显示」是写在网页里的门禁，谁都绕得过，我们靠的是数学。
+WebAuthn 的 PRF 扩展[^prf]让 passkey 内部多藏一把秘密，永远不离开验证器。网页送一段输入过去，你用指纹、脸或 PIN 同意，就拿回固定 32 个字节。同一把 passkey 配同一段输入，每次都得到同一段输出。[本机文件加密](../utils/age.md)拿它去包 age 的 file key，没有 passkey 就算不出密钥，文件就是一堆密文。「验证通过才显示」是写在网页里的门禁，谁都绕得过，我们靠的是数学。
 
 站上什么都没存，而且也存不了。浏览器基于隐私不让网页查询某个域名有没有 passkey，所以我们连你建过没有都不知道。
 
@@ -66,11 +66,11 @@ WebAuthn 的 PRF 扩展让 passkey 内部多藏一把秘密，永远不离开验
 
 ??? note "还在解的问题与已知限制"
 
-    下一步是在页面上做一个加密暂存区，用同一把 passkey 打开，放 checklist 那类在别人也碰得到的笔记本电脑上填的东西。目前的实验把数据密钥放进 credential 的 `user.id` 字段，没有走 PRF。Apple 只把 PRF 需要的数据交给 iCloud 钥匙串，iPhone 配第三方密码管理器的组合建得出 passkey，却算不出密钥。`user.id` 是核心字段，任何 provider 都拿得回来。代价是密钥跟着 credential 存在密码管理器的 vault 里，安全性的上限降到跟 vault 一样。我们刻意做了这个交换，读者手上设备的支持程度比安全性的上限优先。
+    下一步是在页面上做一个加密暂存区，用同一把 passkey 打开，放 checklist 那类在别人也碰得到的笔记本电脑上填的东西。目前的实验把数据密钥放进 credential 的 `user.id`[^userid] 字段，没有走 PRF。Apple 只把 PRF 需要的数据交给 iCloud 钥匙串，iPhone 配第三方密码管理器的组合建得出 passkey，却算不出密钥。`user.id` 是核心字段，任何 provider 都拿得回来。代价是密钥跟着 credential 存在密码管理器的 vault 里，安全性的上限降到跟 vault 一样。我们刻意做了这个交换，读者手上设备的支持程度比安全性的上限优先。
 
     限制写明白比较好：
 
-    - passkey 绑在 `anoni.net` 这个 RP ID 上，镜像站与 onion 地址用不了。
+    - passkey 绑在 `anoni.net` 这个 RP ID[^rpid] 上，镜像站与 onion 地址用不了。
     - Tor Browser 整个关闭 WebAuthn，passkey 在它上面走不通。
     - Firefox Android 与 Windows 10 不支持 PRF。
     - passkey 丢了，数据就永远打不开，所以流程默认搭一把 X25519 备援密钥。
@@ -95,3 +95,15 @@ passkey 也很想在展位上聊。你服务的地区或威胁模型会让整套
 - **匿名线索**：whisper@anoni.net，[GPG 公钥在联络页](../contact.md)。活动期间几小时内查看。
 
 参加的原因、议程上有哪些相关场次、会去交流哪些展位，完整版在[匿名网络社区前往 Global Gathering 2026](../blog/posts/2026-anoni-net-global-gathering.md)。
+
+[^bridge]: bridge 是没有公开列在名单上的 Tor 入口节点。一般的入口地址会被封锁，bridge 没有公开，所以在封锁的环境下还连得进去。
+
+[^exif]: EXIF 是照片与视频文件里自动夹带的一段信息，记着拍摄时间与设备型号，开了定位的话还有坐标。画面上完全看不出来，照片看起来就是一张普通的照片。
+
+[^onionoo]: Onionoo 是 Tor 官方公布中继节点状态的数据服务，记录全球有哪些中继、位在哪个国家、带宽多少，地球仪的数据就来自它。跟本页后面提到的 OONI 是两回事，OONI 量的是某个网站在某个地方连不连得上。
+
+[^prf]: WebAuthn 是浏览器内建的认证机制，PRF 是它的一个扩展。你的手机或电脑里存着一串你看不到的秘密，每次要你用指纹、脸或 PIN 同意，才算得出一段固定的结果。这里拿那段结果当加密密钥，所以站上不需要保管任何东西。「验证器」指的就是保管那串秘密的地方，可能是手机里的安全芯片，也可能是你的密码管理器。
+
+[^userid]: `user.id` 是 passkey 规格里的一个基本字段，本来用来放账号的标识符。这里改放加密密钥，理由是所有厂牌的密码管理器都读得回这个字段，PRF 则有些组合拿不到。
+
+[^rpid]: RP ID 是 passkey 认的那个域名。passkey 只在建立时登记的域名上有效，所以就算镜像站与 onion 地址的内容一模一样，浏览器仍然当成不同的地方，那把 passkey 在上面用不了。

--- a/docs/zh-TW/activity/gg2026.md
+++ b/docs/zh-TW/activity/gg2026.md
@@ -35,16 +35,16 @@ icon: material/map-marker-radius
 | [密語與密碼產生器](../utils/passphrase.md) | 用 7776 字詞表抽密語，或從你選的字元集抽密碼，同時顯示熵有多少 |
 | [本機檔案加密](../utils/age.md) | 在瀏覽器裡把檔案或一段文字加密成 age 格式，也能解回來。輸出是公開格式，任何裝了 age 命令列工具的電腦都打得開 |
 | [passkey 鑰匙](../utils/passkey.md) | 建一把 passkey 替上面那個工具算出金鑰，不用記密語 |
-| [QR code 產生器](../utils/qrcode.md) | 把 onion 網址、bridge 這類很長又容易打錯的字串變成 QR code，中間不經過伺服器 |
+| [QR code 產生器](../utils/qrcode.md) | 把 onion 網址、bridge[^bridge] 這類很長又容易打錯的字串變成 QR code，中間不經過伺服器 |
 | [QR code 讀取器](../utils/qr-read.md) | 讀出圖片裡的 QR code，圖片不離開裝置，解出網址時把主機獨立標出來 |
 | [QR code 影格串流](../utils/qr-stream.md) | 用螢幕與鏡頭在兩台裝置之間傳檔案，沒有配對、沒有共用網路、沒有伺服器 |
-| [檔案 metadata 清除器](../utils/strip-metadata.md) | 拿掉照片、影片、錄音、Office 文件與 PDF 裡的 EXIF、GPS、裝置型號與作者欄位，每一段的去留都列出來 |
+| [檔案 metadata 清除器](../utils/strip-metadata.md) | 拿掉照片、影片、錄音、Office 文件與 PDF 裡的 EXIF[^exif]、GPS、裝置型號與作者欄位，每一段的去留都列出來 |
 | [截圖遮蔽](../utils/redact.md) | 把名字、頭像與對話填成實心黑色，交付之前逐像素確認每一處都是純黑 |
 | [網址清理器](../utils/clean-url.md) | 移除追蹤參數並說明是誰在追，拆掉轉址包裝，把真正的註冊網域單獨標出來 |
 | [隱形字元偵測](../utils/invisible.md) | 找出零寬字元、方向控制、標籤字元與同形字，外流追蹤、釣魚網址與藏給 AI 讀的指令都會用到 |
 | [你的瀏覽器透露了什麼](../utils/leaks.md) | 列出任何網站不必問你就拿得到的資訊，並標出 Tor Browser 會統一掉哪些 |
 
-旁邊還有三件關於 Tor 怎麼運作的 3D 作品，[路由解謎](../games/onion-routing.md)、[連線流量](../games/onion-rendezvous.md)，以及用 Onionoo 真實資料畫出來的[中繼地球儀](../games/tor-network.md)。
+旁邊還有三件關於 Tor 怎麼運作的 3D 作品，[路由解謎](../games/onion-routing.md)、[連線流量](../games/onion-rendezvous.md)，以及用 Onionoo[^onionoo] 真實資料畫出來的[中繼地球儀](../games/tor-network.md)。
 
 ![Tor 中繼地球儀的畫面，地球轉到亞洲一側，中繼以彩色點分布在各國界內，左側面板列出各國中繼數與托管商排行](https://assets.anoni.net/games/tor-network-globe.webp){style="border-radius: 10px;box-shadow:1px 1px 0.6rem #00aeff;"}
 
@@ -58,7 +58,7 @@ icon: material/map-marker-radius
 
 passkey 平常用來登入，站上的用法完全不同。沒有登入、沒有帳號、沒有伺服器，我們只請它算出一把加密金鑰。
 
-WebAuthn 的 PRF 擴充讓 passkey 內部多藏一把秘密，永遠不離開驗證器。網頁送一段輸入過去，你用指紋、臉或 PIN 同意，就拿回固定 32 個位元組。同一把 passkey 配同一段輸入，每次都得到同一段輸出。[本機檔案加密](../utils/age.md)拿它去包 age 的 file key，沒有 passkey 就算不出金鑰，檔案就是一堆密文。「驗證通過才顯示」是寫在網頁裡的門禁，誰都繞得過，我們靠的是數學。
+WebAuthn 的 PRF 擴充[^prf]讓 passkey 內部多藏一把秘密，永遠不離開驗證器。網頁送一段輸入過去，你用指紋、臉或 PIN 同意，就拿回固定 32 個位元組。同一把 passkey 配同一段輸入，每次都得到同一段輸出。[本機檔案加密](../utils/age.md)拿它去包 age 的 file key，沒有 passkey 就算不出金鑰，檔案就是一堆密文。「驗證通過才顯示」是寫在網頁裡的門禁，誰都繞得過，我們靠的是數學。
 
 站上什麼都沒存，而且也存不了。瀏覽器基於隱私不讓網頁查詢某個網域有沒有 passkey，所以我們連你建過沒有都不知道。
 
@@ -66,11 +66,11 @@ WebAuthn 的 PRF 擴充讓 passkey 內部多藏一把秘密，永遠不離開驗
 
 ??? note "還在解的問題與已知限制"
 
-    下一步是在頁面上做一個加密暫存區，用同一把 passkey 打開，放 checklist 那類在別人也碰得到的筆電上填的東西。目前的實驗把資料金鑰放進 credential 的 `user.id` 欄位，沒有走 PRF。Apple 只把 PRF 需要的資料交給 iCloud 鑰匙圈，iPhone 配第三方密碼管理器的組合建得出 passkey，卻算不出金鑰。`user.id` 是核心欄位，任何 provider 都拿得回來。代價是金鑰跟著 credential 存在密碼管理器的 vault 裡，安全性的上限降到跟 vault 一樣。我們刻意做了這個交換，讀者手上裝置的支援程度比安全性的上限優先。
+    下一步是在頁面上做一個加密暫存區，用同一把 passkey 打開，放 checklist 那類在別人也碰得到的筆電上填的東西。目前的實驗把資料金鑰放進 credential 的 `user.id`[^userid] 欄位，沒有走 PRF。Apple 只把 PRF 需要的資料交給 iCloud 鑰匙圈，iPhone 配第三方密碼管理器的組合建得出 passkey，卻算不出金鑰。`user.id` 是核心欄位，任何 provider 都拿得回來。代價是金鑰跟著 credential 存在密碼管理器的 vault 裡，安全性的上限降到跟 vault 一樣。我們刻意做了這個交換，讀者手上裝置的支援程度比安全性的上限優先。
 
     限制寫明白比較好：
 
-    - passkey 綁在 `anoni.net` 這個 RP ID 上，鏡像站與 onion 位址用不了。
+    - passkey 綁在 `anoni.net` 這個 RP ID[^rpid] 上，鏡像站與 onion 位址用不了。
     - Tor Browser 整個關閉 WebAuthn，passkey 在它上面走不通。
     - Firefox Android 與 Windows 10 不支援 PRF。
     - passkey 丟了，資料就永遠打不開，所以流程預設搭一把 X25519 備援金鑰。
@@ -95,3 +95,15 @@ passkey 也很想在攤位上聊。你服務的地區或威脅模型會讓整套
 - **匿名線索**：whisper@anoni.net，[GPG 公鑰在聯絡頁](../contact.md)。活動期間幾小時內查看。
 
 參加的原因、議程上有哪些相關場次、會去交流哪些攤位，完整版在[匿名網路社群前往 Global Gathering 2026](../blog/posts/2026-anoni-net-global-gathering.md)。
+
+[^bridge]: bridge 是沒有公開列在名單上的 Tor 入口節點。一般的入口位址會被封鎖，bridge 沒有公開，所以在封鎖的環境下還連得進去。
+
+[^exif]: EXIF 是照片與影片檔案裡自動夾帶的一段資訊，記著拍攝時間與裝置型號，開了定位的話還有座標。畫面上完全看不出來，照片看起來就是一張普通的照片。
+
+[^onionoo]: Onionoo 是 Tor 官方公布中繼節點狀態的資料服務，記錄全球有哪些中繼、位在哪個國家、頻寬多少，地球儀的資料就來自它。跟本頁後面提到的 OONI 是兩回事，OONI 量的是某個網站在某個地方連不連得上。
+
+[^prf]: WebAuthn 是瀏覽器內建的認證機制，PRF 是它的一個擴充。你的手機或電腦裡存著一串你看不到的秘密，每次要你用指紋、臉或 PIN 同意，才算得出一段固定的結果。這裡拿那段結果當加密金鑰，所以站上不需要保管任何東西。「驗證器」指的就是保管那串秘密的地方，可能是手機裡的安全晶片，也可能是你的密碼管理器。
+
+[^userid]: `user.id` 是 passkey 規格裡的一個基本欄位，本來用來放帳號的識別碼。這裡改放加密金鑰，理由是所有廠牌的密碼管理器都讀得回這個欄位，PRF 則有些組合拿不到。
+
+[^rpid]: RP ID 是 passkey 認的那個網域名稱。passkey 只在建立時登記的網域上有效，所以就算鏡像站與 onion 位址的內容一模一樣，瀏覽器仍然當成不同的地方，那把 passkey 在上面用不了。


### PR DESCRIPTION
接續 #455。這一頁專有名詞不少，用「站在走廊上用手機讀這頁的 Global Gathering 參加者」的視角跑了一次審讀再決定加在哪。那個角色懂審查、VPN、Tor 與 metadata，但沒有實作過任何協定。

加的是被標為「擋住理解」或「讀得過去但心虛」的六個，不是每個縮寫都加。

## 加了哪六個

| 腳註 | 位置 | 為什麼加 |
|---|---|---|
| `[^prf]` | passkey 段 | 全頁最難的一句，見下 |
| `[^onionoo]` | 3D 作品段 | 與 OONI 名字像雙胞胎 |
| `[^rpid]` | 摺疊區的限制清單 | 鏡像站與 onion 用不了的原因 |
| `[^userid]` | 摺疊區的實驗說明 | 開發者層級的 API 細節 |
| `[^bridge]` | 小工具表格 | 常聽到但講不出定義 |
| `[^exif]` | 小工具表格 | 一句白話裡唯一的裸縮寫 |

## 兩條特別值得說

**PRF 那條。** 「WebAuthn 的 PRF 擴充讓 passkey 內部多藏一把秘密，永遠不離開驗證器」被指為全頁最難讀的一句，三個沒解釋的東西塞在一句裡（協定名、擴充縮寫、沒定義的「驗證器」），而整段「資料留在自己手上」的說服力就架在它上面。原話是「會點頭繼續讀，兩小時後在下一個攤位講不出來這跟相信網站就好差在哪」。腳註把三個一起講完。

**Onionoo 那條防的是另一種錯。** 這一頁同時出現 Onionoo（畫地球儀的 Tor 中繼資料）與 OONI（量測連不連得上），名字像雙胞胎、功能完全不同。讀者不會當場卡住，會在下一場對話有把握地講錯。腳註直接點明差別。

## 刻意不加的

`X25519`、`Matrix`、`WEST`、`Cofacts`、`GPG 公鑰`。句子本身已經把讀者要做什麼講清楚，補上演算法名稱或縮寫全稱不會多給任何東西，只會讓這頁變得像教科書。這一頁的用途是現場快速參考。

## 驗證

- 三語系 strict 建置通過
- `docs_style_lint.py` 從 repo 根目錄跑，`0 error 0 warn`。第一版寫了「白話講」被 `colloquial-jiang` 抓到，已改
- 產物確認六個腳註都渲染得出來，特別檢查了兩個容易失效的位置：表格儲存格裡的 `bridge` 與摺疊 `??? note` 區塊裡的 `RP ID`
- 三語系的標記與定義各自成對，六對六
- frontmatter 三份都用 `yaml.safe_load` 驗過
- 390 px 截圖確認表格只多一個小上標、沒有撐開欄寬，頁尾腳註是編號清單

🤖 Generated with [Claude Code](https://claude.com/claude-code)