### PR TITLE
feat(threat-model): 答案可以用 passkey 存進暫存區，對手碰得到裝置時不提供

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -183,7 +183,8 @@ jobs:
       - name: 頁面裡的 script src
         run: node tools/test_script_src.mjs
 
-      # 威脅模型清單：建議的頁面存不存在，以及答案有沒有被存到裝置上
+      # 威脅模型清單：建議的頁面存不存在、這一支不直接碰儲存空間、存檔只經 passkey 暫存區，
+      # 對手碰得到裝置（親密關係、執法、國家級）時不提供存檔
       - name: 威脅模型清單
         run: node tools/test_threatmodel.mjs
 

--- a/docs/en/basics/threat-model.md
+++ b/docs/en/basics/threat-model.md
@@ -22,7 +22,7 @@ EFF frames threat modeling as five questions, worth keeping on a single sheet of
 - How bad are the consequences if I fail?
 - How much trouble am I willing to go through to prevent those?
 
-The [threat model checklist](../utils/threat-model.md) turns questions one, two and five into something you can click through, and flags the combinations that will not hold. It runs in your browser, saves nothing, and works offline. Questions three and four stay yours to judge, and the section below is why.
+The [threat model checklist](../utils/threat-model.md) turns questions one, two and five into something you can click through, and flags the combinations that will not hold. It runs in your browser, saves nothing unless you ask it to, and works offline. Questions three and four stay yours to judge, and the section below is why.
 
 <figure markdown="span">
     <img src="https://assets.anoni.net/diagrams/threat-model-quadrant.en.svg"

--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -28,7 +28,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 -   :material-clipboard-check-outline: **[Threat model checklist](threat-model.md)**
 
-    Turn your answers to the three questions (what you are protecting, who from, what you will spend) into a copyable checklist, with the mismatches flagged. Nothing is saved, and reloading clears it.
+    Turn your answers to the three questions (what you are protecting, who from, what you will spend) into a copyable checklist, with the mismatches flagged. Nothing is saved unless you choose to keep it, encrypted with a passkey on your device.
 
 -   :material-dice-multiple-outline: **[Passphrase and password generator](passphrase.md)**
 

--- a/docs/en/utils/threat-model.md
+++ b/docs/en/utils/threat-model.md
@@ -1,13 +1,84 @@
 ---
 title: Threat model checklist
-description: Turn your answers to the three questions (what you are protecting, who from, what you will spend) into a copyable checklist that also flags the mismatches. Nothing is saved, and reloading clears it.
+description: Turn your answers to the three questions (what you are protecting, who from, what you will spend) into a copyable checklist that also flags the mismatches. Nothing is saved unless you choose to keep it, encrypted with a passkey on your device.
 icon: material/clipboard-check-outline
+offline_assets:
+  # typage 與相依的 noble、scure 由 import map 接到 vendor/age/，hooks/offline_index.py 只認
+  # <script src>，所以逐一列在下面。清單由 tools/test_agecrypt.mjs 對照 vendor 目錄。
+  - utils/vendor/age/age-encryption/dist/armor.js
+  - utils/vendor/age/age-encryption/dist/cbor.js
+  - utils/vendor/age/age-encryption/dist/format.js
+  - utils/vendor/age/age-encryption/dist/index.js
+  - utils/vendor/age/age-encryption/dist/io.js
+  - utils/vendor/age/age-encryption/dist/recipients.js
+  - utils/vendor/age/age-encryption/dist/stream.js
+  - utils/vendor/age/age-encryption/dist/webauthn.js
+  - utils/vendor/age/age-encryption/dist/x25519.js
+  - utils/vendor/age/noble-ciphers/_arx.js
+  - utils/vendor/age/noble-ciphers/_poly1305.js
+  - utils/vendor/age/noble-ciphers/chacha.js
+  - utils/vendor/age/noble-ciphers/utils.js
+  - utils/vendor/age/noble-curves/abstract/curve.js
+  - utils/vendor/age/noble-curves/abstract/edwards.js
+  - utils/vendor/age/noble-curves/abstract/fft.js
+  - utils/vendor/age/noble-curves/abstract/hash-to-curve.js
+  - utils/vendor/age/noble-curves/abstract/modular.js
+  - utils/vendor/age/noble-curves/abstract/montgomery.js
+  - utils/vendor/age/noble-curves/abstract/oprf.js
+  - utils/vendor/age/noble-curves/abstract/weierstrass.js
+  - utils/vendor/age/noble-curves/ed25519.js
+  - utils/vendor/age/noble-curves/nist.js
+  - utils/vendor/age/noble-curves/utils.js
+  - utils/vendor/age/noble-hashes/_md.js
+  - utils/vendor/age/noble-hashes/_u64.js
+  - utils/vendor/age/noble-hashes/hkdf.js
+  - utils/vendor/age/noble-hashes/hmac.js
+  - utils/vendor/age/noble-hashes/pbkdf2.js
+  - utils/vendor/age/noble-hashes/scrypt.js
+  - utils/vendor/age/noble-hashes/sha2.js
+  - utils/vendor/age/noble-hashes/sha3.js
+  - utils/vendor/age/noble-hashes/utils.js
+  - utils/vendor/age/noble-post-quantum/_crystals.js
+  - utils/vendor/age/noble-post-quantum/hybrid.js
+  - utils/vendor/age/noble-post-quantum/ml-kem.js
+  - utils/vendor/age/noble-post-quantum/utils.js
+  - utils/vendor/age/scure-base/index.js
+  - js/vault.js
+  - js/threatmodel.js
 ---
 
 # :material-clipboard-check-outline: Threat model checklist
 
-<div id="threatmodel-tool"></div>
+<script type="importmap">
+{
+  "imports": {
+    "age-encryption": "../vendor/age/age-encryption/dist/index.js",
+    "@noble/ciphers/chacha.js": "../vendor/age/noble-ciphers/chacha.js",
+    "@noble/curves/abstract/edwards.js": "../vendor/age/noble-curves/abstract/edwards.js",
+    "@noble/curves/abstract/fft.js": "../vendor/age/noble-curves/abstract/fft.js",
+    "@noble/curves/abstract/montgomery.js": "../vendor/age/noble-curves/abstract/montgomery.js",
+    "@noble/curves/abstract/weierstrass.js": "../vendor/age/noble-curves/abstract/weierstrass.js",
+    "@noble/curves/ed25519.js": "../vendor/age/noble-curves/ed25519.js",
+    "@noble/curves/nist.js": "../vendor/age/noble-curves/nist.js",
+    "@noble/curves/utils.js": "../vendor/age/noble-curves/utils.js",
+    "@noble/hashes/hkdf": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hkdf.js": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hmac": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/hmac.js": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/scrypt.js": "../vendor/age/noble-hashes/scrypt.js",
+    "@noble/hashes/sha2": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha2.js": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha3.js": "../vendor/age/noble-hashes/sha3.js",
+    "@noble/hashes/utils": "../vendor/age/noble-hashes/utils.js",
+    "@noble/hashes/utils.js": "../vendor/age/noble-hashes/utils.js",
+    "@noble/post-quantum/hybrid.js": "../vendor/age/noble-post-quantum/hybrid.js",
+    "@scure/base": "../vendor/age/scure-base/index.js"
+  }
+}
+</script>
 
+<div id="threatmodel-tool"></div>
+<script src="../../js/vault.js"></script>
 <script src="../../js/threatmodel.js"></script>
 
 Two situations where this comes up:
@@ -33,13 +104,13 @@ Each answer looks reasonable on its own. Put together they often do not hold. Se
 
 These are hard to spot while filling in the form. Listed side by side, they stand out: an adversary set to state level against the lowest budget, for instance.
 
-## Nothing is saved
+## Nothing is saved by default
 
-What you enter stays in the browser tab. It is not written to any form of browser storage, and it is not sent anywhere. Reloading returns the page to blank.
+What you enter stays in the browser tab. It is not written to any form of browser storage and is not sent anywhere; reloading returns the page to blank. To keep a copy there are two routes: press "Copy summary" and paste it somewhere you chose, or press "Save to my stash" to keep it on this device encrypted with your [passkey](passkey.md), in the same ciphertext as [my preparation checklist](checklist.md). Both take a deliberate press; the page does not decide for you. Next time, the top of the page asks whether to fill in last time's answers.
 
-That is deliberate. An answer like "the person I am protecting against is someone close to me" is exactly the kind of thing that should not sit on the device, and that device may well be one the other person can reach. To keep a copy, press "Copy summary" and paste it somewhere you chose. That decision belongs to you. If you decide to keep it on the device, encrypt it first with [local file encryption](age.md) rather than leaving plain text behind. That page takes a passphrase, or a [passkey](passkey.md) as the key, which is one fingerprint touch.
+One case gets no save option: someone close to you, law enforcement or state intelligence as an adversary. They can reach your device and may be able to make you unlock it, and a passkey is no stronger than the screen lock. An answer like "the person I am protecting against is someone close to me" is exactly what should not sit on a device they can reach. Copy the summary instead, and paste it somewhere they cannot get to.
 
-A test covers this specifically, so that nobody later adds storage for the sake of convenience.
+A test covers three things: this page touches no storage itself, saving only goes through the passkey stash, and the save option disappears for those adversaries.
 
 ## This list is alive
 
@@ -61,5 +132,3 @@ The other tools in this section line up with the answers too:
 Like the rest of this section, the code is stored on your device and runs without a network. A blocked domain or a severed connection is exactly when you'll most want this list open.
 
 To take this page with you, see [offline reading](../offline.md).
-
-Answers here are not saved. The list that does keep a record is [my preparation checklist](checklist.md): it tracks how far you have got, encrypted with a passkey and kept on your device.

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -28,7 +28,7 @@ icon: material/tools
 
 -   :material-clipboard-check-outline: **[威胁模型清单](threat-model.md)**
 
-    把「要保护什么、要防谁、愿意付出多少」三题答成一份可复制的清单，并标出答案里的错配。答案不存起来，刷新就没了。
+    把「要保护什么、要防谁、愿意付出多少」三题答成一份可复制的清单，并标出答案里的错配。答案预设不存，要留的话用 passkey 加密存在你的设备上。
 
 -   :material-dice-multiple-outline: **[密语与密码生成器](passphrase.md)**
 

--- a/docs/zh-CN/utils/threat-model.md
+++ b/docs/zh-CN/utils/threat-model.md
@@ -1,13 +1,84 @@
 ---
 title: 威胁模型清单
-description: 把「要保护什么、要防谁、愿意付出多少」三题答成一份可复制的清单，并标出答案里的错配。答案不存起来，刷新就没了。
+description: 把「要保护什么、要防谁、愿意付出多少」三题答成一份可复制的清单，并标出答案里的错配。答案预设不存，要留的话用 passkey 加密存在你的设备上。
 icon: material/clipboard-check-outline
+offline_assets:
+  # typage 與相依的 noble、scure 由 import map 接到 vendor/age/，hooks/offline_index.py 只認
+  # <script src>，所以逐一列在下面。清單由 tools/test_agecrypt.mjs 對照 vendor 目錄。
+  - utils/vendor/age/age-encryption/dist/armor.js
+  - utils/vendor/age/age-encryption/dist/cbor.js
+  - utils/vendor/age/age-encryption/dist/format.js
+  - utils/vendor/age/age-encryption/dist/index.js
+  - utils/vendor/age/age-encryption/dist/io.js
+  - utils/vendor/age/age-encryption/dist/recipients.js
+  - utils/vendor/age/age-encryption/dist/stream.js
+  - utils/vendor/age/age-encryption/dist/webauthn.js
+  - utils/vendor/age/age-encryption/dist/x25519.js
+  - utils/vendor/age/noble-ciphers/_arx.js
+  - utils/vendor/age/noble-ciphers/_poly1305.js
+  - utils/vendor/age/noble-ciphers/chacha.js
+  - utils/vendor/age/noble-ciphers/utils.js
+  - utils/vendor/age/noble-curves/abstract/curve.js
+  - utils/vendor/age/noble-curves/abstract/edwards.js
+  - utils/vendor/age/noble-curves/abstract/fft.js
+  - utils/vendor/age/noble-curves/abstract/hash-to-curve.js
+  - utils/vendor/age/noble-curves/abstract/modular.js
+  - utils/vendor/age/noble-curves/abstract/montgomery.js
+  - utils/vendor/age/noble-curves/abstract/oprf.js
+  - utils/vendor/age/noble-curves/abstract/weierstrass.js
+  - utils/vendor/age/noble-curves/ed25519.js
+  - utils/vendor/age/noble-curves/nist.js
+  - utils/vendor/age/noble-curves/utils.js
+  - utils/vendor/age/noble-hashes/_md.js
+  - utils/vendor/age/noble-hashes/_u64.js
+  - utils/vendor/age/noble-hashes/hkdf.js
+  - utils/vendor/age/noble-hashes/hmac.js
+  - utils/vendor/age/noble-hashes/pbkdf2.js
+  - utils/vendor/age/noble-hashes/scrypt.js
+  - utils/vendor/age/noble-hashes/sha2.js
+  - utils/vendor/age/noble-hashes/sha3.js
+  - utils/vendor/age/noble-hashes/utils.js
+  - utils/vendor/age/noble-post-quantum/_crystals.js
+  - utils/vendor/age/noble-post-quantum/hybrid.js
+  - utils/vendor/age/noble-post-quantum/ml-kem.js
+  - utils/vendor/age/noble-post-quantum/utils.js
+  - utils/vendor/age/scure-base/index.js
+  - js/vault.js
+  - js/threatmodel.js
 ---
 
 # :material-clipboard-check-outline: 威胁模型清单
 
-<div id="threatmodel-tool"></div>
+<script type="importmap">
+{
+  "imports": {
+    "age-encryption": "../vendor/age/age-encryption/dist/index.js",
+    "@noble/ciphers/chacha.js": "../vendor/age/noble-ciphers/chacha.js",
+    "@noble/curves/abstract/edwards.js": "../vendor/age/noble-curves/abstract/edwards.js",
+    "@noble/curves/abstract/fft.js": "../vendor/age/noble-curves/abstract/fft.js",
+    "@noble/curves/abstract/montgomery.js": "../vendor/age/noble-curves/abstract/montgomery.js",
+    "@noble/curves/abstract/weierstrass.js": "../vendor/age/noble-curves/abstract/weierstrass.js",
+    "@noble/curves/ed25519.js": "../vendor/age/noble-curves/ed25519.js",
+    "@noble/curves/nist.js": "../vendor/age/noble-curves/nist.js",
+    "@noble/curves/utils.js": "../vendor/age/noble-curves/utils.js",
+    "@noble/hashes/hkdf": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hkdf.js": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hmac": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/hmac.js": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/scrypt.js": "../vendor/age/noble-hashes/scrypt.js",
+    "@noble/hashes/sha2": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha2.js": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha3.js": "../vendor/age/noble-hashes/sha3.js",
+    "@noble/hashes/utils": "../vendor/age/noble-hashes/utils.js",
+    "@noble/hashes/utils.js": "../vendor/age/noble-hashes/utils.js",
+    "@noble/post-quantum/hybrid.js": "../vendor/age/noble-post-quantum/hybrid.js",
+    "@scure/base": "../vendor/age/scure-base/index.js"
+  }
+}
+</script>
 
+<div id="threatmodel-tool"></div>
+<script src="../../js/vault.js"></script>
 <script src="../../js/threatmodel.js"></script>
 
 常见的两种处境：
@@ -33,13 +104,13 @@ icon: material/clipboard-check-outline
 
 一题一题答的时候不容易看出冲突，五种答案并排列出来，例如对手选到国家级却填最低成本，落差马上就跳出来。
 
-## 答案不会存起来
+## 答案预设不存
 
-填的内容只留在浏览器标签页里，不会写进任何一种浏览器存储空间，也不会送到任何地方。刷新就回到空白。要留纪录的是另一种清单，[我的准备清单](checklist.md)记的是做到哪一步，用 passkey 加密存在你的设备上。
+填的内容只留在浏览器标签页里，不写进任何一种浏览器存储空间，也不送到任何地方，刷新就回到空白。要留一份有两条路：按「复制摘要」贴到你自己选的地方，或按「存进我的暂存区」，用你的 [passkey](passkey.md) 加密存在这台设备上，跟[我的准备清单](checklist.md)同一份密文。两条都要你自己按，这一页不替你决定。下次进来，顶端会问要不要填回上次的答案。
 
-这是刻意的。「我要防的是亲密关系的人」这种答案留在设备上，正好是最不该留的东西，而那台设备很可能就是对方碰得到的一台。要留一份就按「复制摘要」，贴到你自己选的地方，决定权在你。决定要留在设备上的话，先用[本机文件加密](age.md)包成密文再存，不要留明文。那一页可以用密语，也可以用 [passkey](passkey.md) 当钥匙，按一次指纹就好。
+有一种情况不提供存档：对手选了亲密关系、一国执法或国家级。他们碰得到你的设备，也可能要求你解锁，passkey 没有比屏幕锁更强。「我要防的是亲密关系的人」这种答案留在对方碰得到的设备上，正好是最不该留的东西。那时只剩「复制摘要」，贴到对方碰不到的地方。
 
-有一项测试专门确保数据不落地，避免日后有人为了体验方便顺手加上存储。
+有一项测试守着三件事：这一页自己不碰任何存储空间，存档只经 passkey 暂存区，上面那几种对手选了就不提供存档。
 
 ## 这份清单是活的
 

--- a/docs/zh-TW/js/threatmodel.js
+++ b/docs/zh-TW/js/threatmodel.js
@@ -14,13 +14,18 @@
  * 要防親密關係卻沒把裝置列進資產、只防隨意路人卻打算大改工作流程。這些組合人自己
  * 填的時候看不出來，並排列出來就很明顯。
  *
- * === 為什麼不存 ===
+ * === 預設不存，存要讀者自己按 ===
  *
- * 答案不寫進 localStorage、sessionStorage 或 IndexedDB，重新整理就沒了。
+ * 這一支自己不碰 localStorage、sessionStorage 或 IndexedDB，重新整理就沒了。要留一份
+ * 有兩條路，都要讀者按：「複製摘要」貼到自己選的地方，或「存進我的暫存區」經
+ * window.anoniVault（docs/zh-TW/js/vault.js）用 passkey 加密寫進這台裝置，跟我的準備
+ * 清單同一份密文，這裡只動 threatModel 欄位。
  *
- * 這是刻意的。「我要防的是親密關係的人」這種答案留在裝置上，正好是家暴情境裡最不
- * 該留的東西，而那台裝置很可能就是對方碰得到的那一台。要留一份就按「複製摘要」，
- * 貼到自己選的地方，那個決定應該由讀者做而不是由這一頁替他做。
+ * 對手含親密關係、一國執法或國家級時不提供存檔，規則在 canStore()。這幾種對手碰得到
+ * 裝置，也可能要求解鎖，passkey 沒有比螢幕鎖更強。「我要防的是親密關係的人」這種
+ * 答案留在對方碰得到的裝置上，正好是家暴情境裡最不該留的東西。那時只剩複製摘要。
+ * tools/test_threatmodel.mjs 守這三件事：不直接碰儲存空間、只經 anoniVault、那幾種
+ * 對手選了就不提供。
  *
  * 三個語系共用這一份，docs/en/js/ 與 docs/zh-CN/js/ 底下是指向這裡的 symlink。
  * 純邏輯由 tools/test_threatmodel.mjs 原地抽出來測。
@@ -63,6 +68,13 @@
       if (has(adversaries, item.id) && item.power > top) top = item.power;
     }
     return top;
+  }
+
+  // 這幾種對手碰得到裝置、也可能要求解鎖，答案留在裝置上等於交給對方。選了就不提供存檔。
+  const NO_STORE = ["intimate", "police", "state"];
+  function canStore(adversaries) {
+    if (!adversaries.length) return false;
+    return !NO_STORE.some((id) => has(adversaries, id));
   }
 
   // 每一條規則看同一份答案，各自決定要不要出聲。kind 是 warn 的排在建議前面，
@@ -282,6 +294,15 @@
       word-break: break-word; user-select: all;
     }
     #threatmodel-tool .tm-empty { font-size: .76rem; opacity: .75; line-height: 1.7; }
+    #threatmodel-tool .tm-store {
+      border: .05rem dashed var(--md-default-fg-color--lighter);
+      border-radius: .2rem; padding: .6rem .8rem; margin: .8rem 0 1rem;
+    }
+    #threatmodel-tool .tm-store .tm-group { margin-top: 0; }
+    #threatmodel-tool .tm-store .tm-row { margin-bottom: 0; }
+    #threatmodel-tool .tm-store .tm-warn { margin-bottom: .6rem; }
+    #threatmodel-tool .tm-saved { font-size: .72rem; margin: 0 0 .5rem; }
+    #threatmodel-tool button[aria-busy="true"] { opacity: .7; }
     @media (pointer: coarse) {
       #threatmodel-tool button { min-height: 2.2rem; }
       #threatmodel-tool label { padding: .4rem 0; }
@@ -363,8 +384,31 @@
       copy: "複製摘要",
       copied: "已複製",
       reset: "全部清掉",
-      empty: "三題都答完再按「產生摘要」。答案不會存起來，重新整理就沒了。",
-      note: "答案只留在這個分頁裡，不寫進瀏覽器的任何儲存空間，也不送出去。要留一份就按「複製摘要」，貼到你自己選的地方。",
+      store: {
+        title: "留一份在這台裝置（選用）",
+        hint: "用你的 passkey 加密存進這台裝置的暫存區，跟我的準備清單同一份密文。站上什麼都不收。",
+        notOffered: "對手選了親密關係、一國執法或國家級，這裡不提供存檔。他們碰得到你的裝置，也可能要求你解鎖，passkey 沒有比螢幕鎖更強。要留一份就按「複製摘要」，貼到對方碰不到的地方。",
+        restore: "用 passkey 填回上次的答案",
+        restoreHint: "這台裝置的暫存區有東西。上次存過威脅模型的話，解開就填回來。",
+        restoreEmpty: "暫存區裡沒有存過威脅模型。",
+        save: "存進我的暫存區",
+        update: "更新存檔",
+        savedOn: "已存，{date}。",
+        remove: "刪掉存檔",
+        removed: "刪掉了。暫存區裡其他東西沒動。",
+        lock: "鎖上",
+        openExisting: "用我已有的鑰匙開",
+        createNew: "建一把新的鑰匙",
+        chooseHint: "這台裝置還沒有暫存區。已經在鑰匙頁建過 anoni.net 的 passkey 就用它開，還沒有的話建一把新的。",
+        waiting: "等你在瀏覽器的提示裡完成",
+        errors: {
+          cancelled: "你取消了，或瀏覽器沒有完成。再按一次。",
+          unsupported: "這個環境不允許用 passkey。要在正式站、https 網址，瀏覽器也沒有把功能關掉。",
+          failed: "沒有成功。換一個瀏覽器或密碼管理器試試。",
+        },
+      },
+      empty: "三題都答完再按「產生摘要」。答案預設不存，重新整理就沒了。",
+      note: "答案預設只留在這個分頁裡，不送出去。要留一份，按「複製摘要」貼到你自己選的地方，或用 passkey 加密存進這台裝置的暫存區。兩種都要你自己按。",
     },
     zh: {
       q1: "要保护什么",
@@ -437,8 +481,31 @@
       copy: "复制摘要",
       copied: "已复制",
       reset: "全部清掉",
-      empty: "三题都答完再按「生成摘要」。答案不会存起来，刷新就没了。",
-      note: "答案只留在这个标签页里，不写进浏览器的任何存储空间，也不送出去。要留一份就按「复制摘要」，贴到你自己选的地方。",
+      store: {
+        title: "留一份在这台设备（可选）",
+        hint: "用你的 passkey 加密存进这台设备的暂存区，跟我的准备清单同一份密文。站上什么都不收。",
+        notOffered: "对手选了亲密关系、一国执法或国家级，这里不提供存档。他们碰得到你的设备，也可能要求你解锁，passkey 没有比屏幕锁更强。要留一份就按「复制摘要」，贴到对方碰不到的地方。",
+        restore: "用 passkey 填回上次的答案",
+        restoreHint: "这台设备的暂存区有东西。上次存过威胁模型的话，解开就填回来。",
+        restoreEmpty: "暂存区里没有存过威胁模型。",
+        save: "存进我的暂存区",
+        update: "更新存档",
+        savedOn: "已存，{date}。",
+        remove: "删掉存档",
+        removed: "删掉了。暂存区里其他东西没动。",
+        lock: "锁上",
+        openExisting: "用我已有的钥匙开",
+        createNew: "创建一把新的钥匙",
+        chooseHint: "这台设备还没有暂存区。已经在钥匙页创建过 anoni.net 的 passkey 就用它开，还没有的话创建一把新的。",
+        waiting: "等你在浏览器的提示里完成",
+        errors: {
+          cancelled: "你取消了，或浏览器没有完成。再按一次。",
+          unsupported: "这个环境不允许用 passkey。要在正式站、https 网址，浏览器也没有把功能关掉。",
+          failed: "没有成功。换一个浏览器或密码管理器试试。",
+        },
+      },
+      empty: "三题都答完再按「生成摘要」。答案预设不存，刷新就没了。",
+      note: "答案预设只留在这个标签页里，不送出去。要留一份，按「复制摘要」贴到你自己选的地方，或用 passkey 加密存进这台设备的暂存区。两种都要你自己按。",
     },
     en: {
       q1: "What are you protecting",
@@ -511,8 +578,31 @@
       copy: "Copy summary",
       copied: "Copied",
       reset: "Clear everything",
-      empty: 'Answer all three questions, then press "Build summary". Nothing is saved: reloading clears it.',
-      note: 'Your answers stay in this tab. They are not written to any browser storage and are not sent anywhere. To keep a copy, press "Copy summary" and paste it somewhere you chose.',
+      store: {
+        title: "Keep a copy on this device (optional)",
+        hint: "Encrypted with your passkey into this device's stash, the same ciphertext as my preparation checklist. Nothing reaches the site.",
+        notOffered: "With someone close to you, law enforcement or state intelligence as an adversary, there is no save option here. They can reach your device and may be able to make you unlock it, and a passkey is no stronger than the screen lock. To keep a copy, press \"Copy summary\" and paste it somewhere they cannot reach.",
+        restore: "Fill in last time's answers with passkey",
+        restoreHint: "This device's stash has something in it. If you saved a threat model last time, unlocking fills it back in.",
+        restoreEmpty: "No threat model has been saved in the stash.",
+        save: "Save to my stash",
+        update: "Update the saved copy",
+        savedOn: "Saved, {date}.",
+        remove: "Delete the saved copy",
+        removed: "Deleted. Everything else in the stash is untouched.",
+        lock: "Lock",
+        openExisting: "Open with my existing key",
+        createNew: "Create a new key",
+        chooseHint: "There is no stash on this device yet. If you already created an anoni.net passkey on the key page, open with it; otherwise create a new one.",
+        waiting: "Finish the prompt in your browser",
+        errors: {
+          cancelled: "You cancelled, or the browser did not finish. Press again.",
+          unsupported: "This environment does not allow passkeys. It needs the production site, an https address, and a browser that has not turned the feature off.",
+          failed: "It did not work. Try another browser or password manager.",
+        },
+      },
+      empty: 'Answer all three questions, then press "Build summary". Nothing is saved by default: reloading clears it.',
+      note: 'By default your answers stay in this tab and are not sent anywhere. To keep a copy, press "Copy summary" and paste it somewhere you chose, or save it to the stash on this device, encrypted with a passkey. Both take a deliberate press.',
     },
   };
 
@@ -525,7 +615,7 @@
     return node;
   };
 
-  // 答案只在這裡。沒有 localStorage、沒有 IndexedDB，重新整理就回到空的。
+  // 答案只在這裡，預設不落地。要存得經下面暫存區那段，讀者自己按。
   const state = { assets: [], adversaries: [], budget: "", built: false, copied: false };
 
   const toggle = (list, id, on) => {
@@ -539,6 +629,181 @@
     const now = new Date();
     const pad = (n) => (n < 10 ? "0" + n : String(n));
     return now.getFullYear() + "-" + pad(now.getMonth() + 1) + "-" + pad(now.getDate());
+  }
+
+
+  // --- 存進暫存區（選用）---
+  //
+  // 預設什麼都不存。讀者按了才經 window.anoniVault 用 passkey 加密寫進這台裝置，
+  // 跟我的準備清單同一份密文，這裡只動 threatModel 欄位。對手含親密關係、一國執法
+  // 或國家級時 canStore() 是 false，整段不給存的按鈕。
+  const vault = () => window.anoniVault;
+  const vs = {
+    support: null,   // null 還在查
+    exists: false,   // 這台裝置有沒有暫存區
+    unlocked: false,
+    busy: null,      // "restore" | "save" | "remove"
+    saved: null,     // 存檔的日期
+    dirty: false,    // 存過之後答案有沒有改
+    choosing: false, // 沒有暫存區時，正在選用舊鑰匙還是建新的
+    error: null,
+    message: "",
+  };
+
+  function classifyError(err) {
+    const name = err && err.name;
+    if (name === "NotAllowedError" || name === "AbortError") return "cancelled";
+    if (name === "NotSupportedError" || name === "SecurityError") return "unsupported";
+    return "failed";
+  }
+  async function vaultRefresh() {
+    const v = vault();
+    vs.support = !!(window.PublicKeyCredential && navigator.credentials && v && v.available());
+    vs.exists = vs.support ? await v.exists() : false;
+  }
+  async function guarded(action, work) {
+    vs.error = null;
+    vs.message = "";
+    vs.busy = action;
+    render();
+    try {
+      await work();
+    } catch (err) {
+      vs.error = classifyError(err);
+    }
+    vs.busy = null;
+    render();
+  }
+  function snapshot() {
+    return { v: 1, assets: state.assets.slice(), adversaries: state.adversaries.slice(), budget: state.budget, savedAt: today() };
+  }
+  async function writeSnapshot() {
+    const data = (await vault().read()) || {};
+    data.threatModel = snapshot();
+    await vault().save(data);
+    vs.saved = data.threatModel.savedAt;
+    vs.dirty = false;
+    vs.exists = true;
+  }
+  // 讀回來的 id 只認現在有的，舊版存了已經拿掉的選項就略過
+  function applySnapshot(saved) {
+    const known = (list, ids) => (Array.isArray(ids) ? ids : []).filter((id) => list.some((x) => x.id === id));
+    state.assets = known(ASSETS, saved.assets);
+    state.adversaries = known(ADVERSARIES, saved.adversaries);
+    state.budget = BUDGETS.indexOf(saved.budget) >= 0 ? saved.budget : "";
+    state.built = !!(state.assets.length && state.adversaries.length && state.budget);
+    state.copied = false;
+    vs.saved = saved.savedAt || null;
+    vs.dirty = false;
+  }
+  const restore = () =>
+    guarded("restore", async () => {
+      await vault().unlock();
+      vs.unlocked = true;
+      const data = (await vault().read()) || {};
+      if (data.threatModel) applySnapshot(data.threatModel);
+      else vs.message = t.store.restoreEmpty;
+    });
+  const saveNow = () =>
+    guarded("save", async () => {
+      if (!vs.unlocked) {
+        await vault().unlock();
+        vs.unlocked = true;
+      }
+      await writeSnapshot();
+    });
+  const saveWithExisting = () =>
+    guarded("save", async () => {
+      await vault().openWithExisting(null);
+      vs.unlocked = true;
+      vs.choosing = false;
+      await writeSnapshot();
+    });
+  const saveWithNew = () =>
+    guarded("save", async () => {
+      await vault().create(null);
+      vs.unlocked = true;
+      vs.choosing = false;
+      await writeSnapshot();
+    });
+  const remove = () =>
+    guarded("remove", async () => {
+      const data = (await vault().read()) || {};
+      delete data.threatModel;
+      await vault().save(data);
+      vs.saved = null;
+      vs.dirty = true;
+      vs.message = t.store.removed;
+    });
+  function lock() {
+    vault().lock();
+    vs.unlocked = false;
+    vs.choosing = false;
+    vs.message = "";
+    vs.error = null;
+    render();
+  }
+
+  function tmButton(label, onClick) {
+    const node = el("button", null, label);
+    node.type = "button";
+    node.addEventListener("click", onClick);
+    return node;
+  }
+  function busyButton(label) {
+    const node = tmButton(label, () => {});
+    node.setAttribute("aria-busy", "true");
+    node.disabled = true;
+    return node;
+  }
+  // 頂部：有暫存區、還沒填任何答案時，先問要不要填回上次的。解開了卻沒有東西
+  // 可填（暫存區裡沒存過威脅模型）也要留在這裡說，不然讀者按下去像沒反應。
+  function restoreBox() {
+    if (!vs.support || !vs.exists) return null;
+    if (state.assets.length || state.adversaries.length || state.budget) return null;
+    const box = el("div", "tm-store");
+    const row = el("div", "tm-row");
+    if (!vs.unlocked) {
+      box.appendChild(el("p", "tm-hint", t.store.restoreHint));
+      row.appendChild(vs.busy === "restore" ? busyButton(t.store.waiting) : tmButton(t.store.restore, restore));
+    } else {
+      row.appendChild(tmButton(t.store.lock, lock));
+    }
+    box.appendChild(row);
+    if (vs.error) box.appendChild(el("p", "tm-warn", t.store.errors[vs.error] || t.store.errors.failed));
+    if (vs.message) box.appendChild(el("p", "tm-hint", vs.message));
+    return box;
+  }
+  // 摘要下方：存、更新、刪、鎖
+  function storeSection() {
+    if (!vs.support) return null;
+    const box = el("div", "tm-store");
+    box.appendChild(el("p", "tm-group", t.store.title));
+    const allowed = canStore(state.adversaries);
+    box.appendChild(allowed ? el("p", "tm-hint", t.store.hint) : el("p", "tm-warn", t.store.notOffered));
+    if (vs.unlocked && vs.saved) box.appendChild(el("p", "tm-saved", t.store.savedOn.replace("{date}", vs.saved)));
+    if (vs.choosing && !vs.busy) box.appendChild(el("p", "tm-hint", t.store.chooseHint));
+    const row = el("div", "tm-row");
+    if (vs.busy) row.appendChild(busyButton(t.store.waiting));
+    else if (vs.choosing) {
+      row.appendChild(tmButton(t.store.openExisting, saveWithExisting));
+      row.appendChild(tmButton(t.store.createNew, saveWithNew));
+    } else {
+      if (allowed) {
+        if (!vs.exists) row.appendChild(tmButton(t.store.save, () => { vs.choosing = true; render(); }));
+        else {
+          const b = tmButton(vs.saved ? t.store.update : t.store.save, saveNow);
+          b.disabled = !!(vs.saved && !vs.dirty);
+          row.appendChild(b);
+        }
+      }
+      if (vs.unlocked && vs.saved) row.appendChild(tmButton(t.store.remove, remove));
+      if (vs.unlocked) row.appendChild(tmButton(t.store.lock, lock));
+    }
+    box.appendChild(row);
+    if (vs.error) box.appendChild(el("p", "tm-warn", t.store.errors[vs.error] || t.store.errors.failed));
+    if (vs.message) box.appendChild(el("p", "tm-hint", vs.message));
+    return box;
   }
 
   function choiceGroup(question) {
@@ -559,6 +824,7 @@
       input.checked = question.checked(item.id);
       input.addEventListener("change", () => {
         question.onChange(item.id, input.checked);
+        vs.dirty = true;
         // 重畫整份輸出。答案改了，之前那份摘要就不再是這份答案的摘要。
         state.built = false;
         state.copied = false;
@@ -573,6 +839,9 @@
 
   function render() {
     root.textContent = "";
+
+    const top = restoreBox();
+    if (top) root.appendChild(top);
 
     root.appendChild(choiceGroup({
       key: "q1",
@@ -668,8 +937,12 @@
     copyRow.appendChild(copy);
     root.appendChild(copyRow);
 
+    const store = storeSection();
+    if (store) root.appendChild(store);
+
     root.appendChild(el("p", "tm-hint", t.note));
   }
 
   render();
+  vaultRefresh().then(render, render);
 })();

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -28,7 +28,7 @@ icon: material/tools
 
 -   :material-clipboard-check-outline: **[威脅模型清單](threat-model.md)**
 
-    把「要保護什麼、要防誰、願意付出多少」三題答成一份可複製的清單，並標出答案裡的錯配。答案不存起來，重新整理就沒了。
+    把「要保護什麼、要防誰、願意付出多少」三題答成一份可複製的清單，並標出答案裡的錯配。答案預設不存，要留的話用 passkey 加密存在你的裝置上。
 
 -   :material-dice-multiple-outline: **[密語與密碼產生器](passphrase.md)**
 

--- a/docs/zh-TW/utils/threat-model.md
+++ b/docs/zh-TW/utils/threat-model.md
@@ -1,13 +1,84 @@
 ---
 title: 威脅模型清單
-description: 把「要保護什麼、要防誰、願意付出多少」三題答成一份可複製的清單，並標出答案裡的錯配。答案不存起來，重新整理就沒了。
+description: 把「要保護什麼、要防誰、願意付出多少」三題答成一份可複製的清單，並標出答案裡的錯配。答案預設不存，要留的話用 passkey 加密存在你的裝置上。
 icon: material/clipboard-check-outline
+offline_assets:
+  # typage 與相依的 noble、scure 由 import map 接到 vendor/age/，hooks/offline_index.py 只認
+  # <script src>，所以逐一列在下面。清單由 tools/test_agecrypt.mjs 對照 vendor 目錄。
+  - utils/vendor/age/age-encryption/dist/armor.js
+  - utils/vendor/age/age-encryption/dist/cbor.js
+  - utils/vendor/age/age-encryption/dist/format.js
+  - utils/vendor/age/age-encryption/dist/index.js
+  - utils/vendor/age/age-encryption/dist/io.js
+  - utils/vendor/age/age-encryption/dist/recipients.js
+  - utils/vendor/age/age-encryption/dist/stream.js
+  - utils/vendor/age/age-encryption/dist/webauthn.js
+  - utils/vendor/age/age-encryption/dist/x25519.js
+  - utils/vendor/age/noble-ciphers/_arx.js
+  - utils/vendor/age/noble-ciphers/_poly1305.js
+  - utils/vendor/age/noble-ciphers/chacha.js
+  - utils/vendor/age/noble-ciphers/utils.js
+  - utils/vendor/age/noble-curves/abstract/curve.js
+  - utils/vendor/age/noble-curves/abstract/edwards.js
+  - utils/vendor/age/noble-curves/abstract/fft.js
+  - utils/vendor/age/noble-curves/abstract/hash-to-curve.js
+  - utils/vendor/age/noble-curves/abstract/modular.js
+  - utils/vendor/age/noble-curves/abstract/montgomery.js
+  - utils/vendor/age/noble-curves/abstract/oprf.js
+  - utils/vendor/age/noble-curves/abstract/weierstrass.js
+  - utils/vendor/age/noble-curves/ed25519.js
+  - utils/vendor/age/noble-curves/nist.js
+  - utils/vendor/age/noble-curves/utils.js
+  - utils/vendor/age/noble-hashes/_md.js
+  - utils/vendor/age/noble-hashes/_u64.js
+  - utils/vendor/age/noble-hashes/hkdf.js
+  - utils/vendor/age/noble-hashes/hmac.js
+  - utils/vendor/age/noble-hashes/pbkdf2.js
+  - utils/vendor/age/noble-hashes/scrypt.js
+  - utils/vendor/age/noble-hashes/sha2.js
+  - utils/vendor/age/noble-hashes/sha3.js
+  - utils/vendor/age/noble-hashes/utils.js
+  - utils/vendor/age/noble-post-quantum/_crystals.js
+  - utils/vendor/age/noble-post-quantum/hybrid.js
+  - utils/vendor/age/noble-post-quantum/ml-kem.js
+  - utils/vendor/age/noble-post-quantum/utils.js
+  - utils/vendor/age/scure-base/index.js
+  - js/vault.js
+  - js/threatmodel.js
 ---
 
 # :material-clipboard-check-outline: 威脅模型清單
 
-<div id="threatmodel-tool"></div>
+<script type="importmap">
+{
+  "imports": {
+    "age-encryption": "../vendor/age/age-encryption/dist/index.js",
+    "@noble/ciphers/chacha.js": "../vendor/age/noble-ciphers/chacha.js",
+    "@noble/curves/abstract/edwards.js": "../vendor/age/noble-curves/abstract/edwards.js",
+    "@noble/curves/abstract/fft.js": "../vendor/age/noble-curves/abstract/fft.js",
+    "@noble/curves/abstract/montgomery.js": "../vendor/age/noble-curves/abstract/montgomery.js",
+    "@noble/curves/abstract/weierstrass.js": "../vendor/age/noble-curves/abstract/weierstrass.js",
+    "@noble/curves/ed25519.js": "../vendor/age/noble-curves/ed25519.js",
+    "@noble/curves/nist.js": "../vendor/age/noble-curves/nist.js",
+    "@noble/curves/utils.js": "../vendor/age/noble-curves/utils.js",
+    "@noble/hashes/hkdf": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hkdf.js": "../vendor/age/noble-hashes/hkdf.js",
+    "@noble/hashes/hmac": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/hmac.js": "../vendor/age/noble-hashes/hmac.js",
+    "@noble/hashes/scrypt.js": "../vendor/age/noble-hashes/scrypt.js",
+    "@noble/hashes/sha2": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha2.js": "../vendor/age/noble-hashes/sha2.js",
+    "@noble/hashes/sha3.js": "../vendor/age/noble-hashes/sha3.js",
+    "@noble/hashes/utils": "../vendor/age/noble-hashes/utils.js",
+    "@noble/hashes/utils.js": "../vendor/age/noble-hashes/utils.js",
+    "@noble/post-quantum/hybrid.js": "../vendor/age/noble-post-quantum/hybrid.js",
+    "@scure/base": "../vendor/age/scure-base/index.js"
+  }
+}
+</script>
 
+<div id="threatmodel-tool"></div>
+<script src="../../js/vault.js"></script>
 <script src="../../js/threatmodel.js"></script>
 
 常見的兩種處境：
@@ -33,13 +104,13 @@ icon: material/clipboard-check-outline
 
 一題一題答的時候不容易看出衝突，五種答案並排列出來，例如對手選到國家級卻填最低成本，落差馬上就跳出來。
 
-## 答案不會存起來
+## 答案預設不存
 
-填的內容只留在瀏覽器分頁裡，不會寫進任何一種瀏覽器儲存空間，也不會送到任何地方。重新整理就回到空白。要留紀錄的是另一種清單，[我的準備清單](checklist.md)記的是做到哪一步，用 passkey 加密存在你的裝置上。
+填的內容只留在瀏覽器分頁裡，不寫進任何一種瀏覽器儲存空間，也不送到任何地方，重新整理就回到空白。要留一份有兩條路：按「複製摘要」貼到你自己選的地方，或按「存進我的暫存區」，用你的 [passkey](passkey.md) 加密存在這台裝置上，跟[我的準備清單](checklist.md)同一份密文。兩條都要你自己按，這一頁不替你決定。下次進來，頂端會問要不要填回上次的答案。
 
-這是刻意的。「我要防的是親密關係的人」這種答案留在裝置上，正好是最不該留的東西，而那台裝置很可能就是對方碰得到的一台。要留一份就按「複製摘要」，貼到你自己選的地方，決定權在你。決定要留在裝置上的話，先用[本機檔案加密](age.md)包成密文再存，不要留明文。那一頁可以用密語，也可以用 [passkey](passkey.md) 當鑰匙，按一次指紋就好。
+有一種情況不提供存檔：對手選了親密關係、一國執法或國家級。他們碰得到你的裝置，也可能要求你解鎖，passkey 沒有比螢幕鎖更強。「我要防的是親密關係的人」這種答案留在對方碰得到的裝置上，正好是最不該留的東西。那時只剩「複製摘要」，貼到對方碰不到的地方。
 
-有一項測試專門確保資料不落地，避免日後有人為了體驗方便順手加上儲存。
+有一項測試守著三件事：這一頁自己不碰任何儲存空間，存檔只經 passkey 暫存區，上面那幾種對手選了就不提供存檔。
 
 ## 這份清單是活的
 

--- a/tools/check_vault_browser.mjs
+++ b/tools/check_vault_browser.mjs
@@ -44,6 +44,7 @@ const BASE = process.env.VAULT_BASE || 'http://localhost:8011/docs/';
 const PASSKEY_URL = new URL('utils/passkey/', BASE).href;
 const VAULT_URL = new URL('community/vault-lab/', BASE).href;
 const CHECKLIST_URL = new URL('utils/checklist/', BASE).href;
+const THREAT_URL = new URL('utils/threat-model/', BASE).href;
 const SHOTS = process.argv.includes('--shots');
 const OUT = path.join(os.tmpdir(), 'vault-shots');
 
@@ -421,6 +422,75 @@ test('清單頁用鑰匙頁建的 passkey 開，勾兩項重新整理後還在',
     assert.equal(dates.length, 2, '勾的項目要顯示日期');
     for (const d of dates) assert.match(d, /^\d{4}-\d{2}-\d{2}$/, `日期格式不對：${d}`);
     assert.equal((await page.credentials()).length, 1, '解開不該多出 credential');
+  } finally {
+    await page.close();
+  }
+});
+
+test('威脅模型答案存進暫存區，重新整理後填回來，對手選親密關係就沒有存的按鈕', async () => {
+  const page = await openChrome();
+  try {
+    await page.goto(THREAT_URL);
+    await page.evaluate(HELPERS);
+    await page.waitFor("document.querySelectorAll('#threatmodel-tool input').length > 0", '工具畫出來');
+    // 頂端不該有「填回上次」：這台裝置還沒有暫存區
+    assert.equal(await page.evaluate("!!__vl.button('#threatmodel-tool', '用 passkey 填回上次的答案')"), false, '沒有暫存區卻出現填回按鈕');
+
+    const pick = async (name, index) => page.evaluate(`
+      (() => { const list = [...document.querySelectorAll('#threatmodel-tool fieldset')][${index}].querySelectorAll('input');
+        const i = [...list].find((x) => x.nextSibling && x.nextSibling.textContent.startsWith('${name}'));
+        if (!i) throw new Error('沒有選項 ${name}'); i.click(); return true; })()
+    `);
+    await pick('內容相關', 0);
+    await pick('隨意路人', 1);
+    await pick('低', 2);
+    await page.evaluate("__vl.click('#threatmodel-tool', '產生摘要')");
+    await page.waitFor("!!document.querySelector('#threatmodel-tool .tm-out')", '摘要出現');
+    assert.ok(await page.evaluate("!!__vl.button('#threatmodel-tool', '存進我的暫存區')"), '隨意路人為對手時要有存的按鈕');
+
+    await page.evaluate("__vl.click('#threatmodel-tool', '存進我的暫存區')");
+    await page.waitFor("!!__vl.button('#threatmodel-tool', '建一把新的鑰匙')", '沒有暫存區時給兩個選項');
+    await page.evaluate("__vl.click('#threatmodel-tool', '建一把新的鑰匙')");
+    await page.waitFor("/已存，\\d{4}-\\d{2}-\\d{2}/.test(__vl.text('#threatmodel-tool'))", '存好並顯示日期');
+    assert.equal((await page.credentials()).length, 1, '建鑰匙之後驗證器裡應該只有一筆');
+    assert.ok(await page.evaluate("__vl.button('#threatmodel-tool', '更新存檔').disabled"), '剛存完、沒改答案，更新要是灰的');
+    await page.evaluate("document.querySelector('#threatmodel-tool .tm-store').scrollIntoView(); true");
+    await page.shot('06-threat-model-saved');
+
+    // 改答案會讓摘要失效，暫存區那段跟摘要一起收起來，按「重新產生」才回來。
+    // 選親密關係 → 存的按鈕消失、只剩刪與鎖
+    await pick('親密關係', 1);
+    assert.ok(await page.evaluate("!document.querySelector('#threatmodel-tool .tm-out')"), '改答案之後舊摘要還在');
+    await page.evaluate("__vl.click('#threatmodel-tool', '產生摘要')");
+    await page.waitFor("!!document.querySelector('#threatmodel-tool .tm-out')", '重新產生');
+    assert.ok(await page.evaluate("!__vl.button('#threatmodel-tool', '更新存檔') && !__vl.button('#threatmodel-tool', '存進我的暫存區')"), '選了親密關係還有存的按鈕');
+    assert.ok(await page.evaluate("/不提供存檔/.test(__vl.text('#threatmodel-tool'))"), '選了親密關係要說明為什麼不提供');
+    assert.ok(await page.evaluate("!!__vl.button('#threatmodel-tool', '刪掉存檔')"), '解開狀態下要能刪掉舊存檔');
+    await pick('親密關係', 1); // 取消
+    await page.evaluate("__vl.click('#threatmodel-tool', '產生摘要')");
+    await page.waitFor("!!__vl.button('#threatmodel-tool', '更新存檔')", '取消親密關係之後更新回來');
+    assert.ok(await page.evaluate("!__vl.button('#threatmodel-tool', '更新存檔').disabled"), '改過答案，更新要能按');
+
+    // 重新整理 → 頂端問要不要填回 → 填回後三題與摘要都在
+    await page.send('Page.reload');
+    await page.waitFor("document.readyState === 'complete'", '重新整理');
+    await page.evaluate(HELPERS);
+    await page.waitFor("!!__vl.button('#threatmodel-tool', '用 passkey 填回上次的答案')", '重新整理後頂端問要不要填回');
+    await page.evaluate("__vl.click('#threatmodel-tool', '用 passkey 填回上次的答案')");
+    await page.waitFor("!!document.querySelector('#threatmodel-tool .tm-out')", '填回後摘要直接出現');
+    const checked = await page.evaluate("[...document.querySelectorAll('#threatmodel-tool input:checked')].map((i) => i.nextSibling.textContent.slice(0, 4))");
+    assert.deepEqual(checked, ['內容相關', '隨意路人', '低：不想'], `填回來的答案不對：${checked.join('、')}`);
+    assert.equal((await page.credentials()).length, 1, '填回不該多出 credential');
+
+    // 刪掉存檔 → 重新整理後頂端不再有填回（暫存區還在，但沒有威脅模型）
+    await page.evaluate("__vl.click('#threatmodel-tool', '刪掉存檔')");
+    await page.waitFor("/刪掉了/.test(__vl.text('#threatmodel-tool'))", '刪掉');
+    await page.send('Page.reload');
+    await page.waitFor("document.readyState === 'complete'", '再重新整理');
+    await page.evaluate(HELPERS);
+    await page.waitFor("!!__vl.button('#threatmodel-tool', '用 passkey 填回上次的答案')", '暫存區還在，頂端照樣問');
+    await page.evaluate("__vl.click('#threatmodel-tool', '用 passkey 填回上次的答案')");
+    await page.waitFor("/沒有存過威脅模型/.test(__vl.text('#threatmodel-tool'))", '刪掉之後填回要說沒有');
   } finally {
     await page.close();
   }

--- a/tools/test_threatmodel.mjs
+++ b/tools/test_threatmodel.mjs
@@ -40,7 +40,7 @@ const grab = (re) => {
 const harness = `
   ${grab(/^  const ASSETS = \[[\s\S]*?\n  function summarize\(state, strings, today\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  const STRINGS = \{[\s\S]*?\n  \};/m)}
-  return { ASSETS, ADVERSARIES, BUDGETS, RULES, evaluate, summarize, STRINGS, topPower };
+  return { ASSETS, ADVERSARIES, BUDGETS, RULES, evaluate, summarize, STRINGS, topPower, canStore, NO_STORE };
 `;
 const tool = new Function(harness)();
 
@@ -200,13 +200,32 @@ test('沒答的題目在摘要裡標成沒填，不是留空行', () => {
   assert.equal((text.match(/（沒有填）/g) || []).length, 3, '三題都沒填就該出現三次');
 });
 
-test('答案不寫進任何儲存空間', () => {
-  // 「我要防的是親密關係的人」這種答案留在裝置上，正好是最不該留的東西。
-  // 這是設計決定，不是還沒做，所以要有測試擋住日後順手加上去。
+test('這一支自己不碰任何儲存空間，存檔只經 anoniVault', () => {
+  // 預設不落地是設計決定。要存只能走 passkey 加密的暫存區（vault.js），這一支不能
+  // 自己開 localStorage 或 IndexedDB，也不能為了體驗方便偷偷加。
   for (const needle of ['localStorage', 'sessionStorage', 'indexedDB', 'document.cookie',
                         'caches.open', 'IDBDatabase']) {
     assert.ok(!code.includes(needle), `出現了 ${needle}`);
   }
+  assert.ok(code.includes('window.anoniVault'), '存檔沒有走 anoniVault');
+  // 寫入只在讀者按了之後：save 與 remove 都在 guarded 裡，沒有任何自動儲存的計時器
+  assert.ok(!/setTimeout\([^)]*save/i.test(code), '出現了自動儲存');
+});
+
+test('對手碰得到裝置就不提供存檔', () => {
+  // 「我要防的是親密關係的人」這種答案留在對方碰得到的裝置上，正好是最不該留的東西。
+  // 一國執法與國家級可以扣押裝置並要求解鎖，passkey 沒有比螢幕鎖更強。
+  assert.deepEqual(tool.NO_STORE.slice().sort(), ['intimate', 'police', 'state']);
+  assert.equal(tool.canStore([]), false, '沒選對手就沒有東西好存');
+  assert.equal(tool.canStore(['passerby']), true);
+  assert.equal(tool.canStore(['employer', 'platform']), true);
+  assert.equal(tool.canStore(['intimate']), false);
+  assert.equal(tool.canStore(['passerby', 'intimate']), false, '混進一個親密關係就整份不給存');
+  assert.equal(tool.canStore(['platform', 'police']), false);
+  assert.equal(tool.canStore(['state']), false);
+  // 畫面那一段要真的看 canStore，不能只在字串裡寫規則
+  const section = code.slice(code.indexOf('function storeSection'));
+  assert.ok(/canStore\(state\.adversaries\)/.test(section), 'storeSection 沒有問 canStore');
 });
 
 test('沒有任何網路請求', () => {


### PR DESCRIPTION
## 為什麼

威脅模型清單原本刻意不存答案，理由寫在原始碼的說明頭：「我要防的是親密關係的人」留在對方碰得到的裝置上，正好是家暴情境裡最不該留的東西。這次加存檔，把那個理由做成規則，沒有拿掉。

## 做了什麼

- **預設不存。** 讀者按「存進我的暫存區」才經 `window.anoniVault` 用 passkey 加密寫進這台裝置，跟我的準備清單同一份密文，只動 `threatModel` 欄位
- **`canStore()`：** 對手含親密關係、一國執法或國家級就不提供存的按鈕，畫面上說明為什麼（他們碰得到裝置、可能要求解鎖，passkey 沒有比螢幕鎖更強），只剩複製摘要
- **填回：** 下次進來頂端問要不要填回上次的答案，填回後摘要直接出現。解開了卻沒存過也要說一句，不然按下去像沒反應
- **沒有自動存。** 存過之後改答案，摘要照原本的設計失效，重新產生後「更新存檔」才能按。每一次寫入都是讀者按的
- **解開狀態下可以刪掉存檔、鎖上。** 選了親密關係的人也還能刪，那正是該刪的時候

三語系頁面加 import map 與 `vault.js`，「答案不會存起來」一節改寫成「答案預設不存」，家暴情境的段落留著並說明哪幾種對手不給存。索引卡片與 `basics/threat-model.md` en 的「saves nothing」跟著改。

## 測試

- `test_threatmodel.mjs` 原本那條「不寫進任何儲存空間」改成守三件事：這一支自己不碰儲存空間、存檔只經 `anoniVault` 且沒有自動儲存、`canStore` 的規則。21 通過
- `check_vault_browser.mjs` 加第六條，從建鑰匙、存、選親密關係看到按鈕消失、重新整理填回、刪掉再填回說沒有，整條走一遍。6 通過，截圖看過
- 三語系 `run*.sh` 建置零 WARNING，`check_precache.mjs` 通過，`test_script_src.mjs` 通過
- `docs_style_lint.py` 掃過 js 字串表與改到的頁面，0 error 0 warn

## 沒做的

- 沒有自動儲存，是刻意的。答案敏感，每一次落地都要讀者按
- 對手選了不給存的那幾種、又沒有解開暫存區時，看不到「刪掉存檔」。要刪得先在頂端填回再刪。這條路存在，只是多一步

🤖 Generated with [Claude Code](https://claude.com/claude-code)