### PR TITLE
feat(checklist): 登錄另一台裝置，A 限時顯示鑰匙的 QR code，B 拍照或貼上建同一份鑰匙的 passkey

### DIFF
--- a/docs/en/utils/checklist.md
+++ b/docs/en/utils/checklist.md
@@ -43,6 +43,8 @@ offline_assets:
   - utils/vendor/age/noble-post-quantum/ml-kem.js
   - utils/vendor/age/noble-post-quantum/utils.js
   - utils/vendor/age/scure-base/index.js
+  - utils/vendor/qrcode-generator.js
+  - utils/vendor/jsQR.js
   - js/vault.js
   - js/checklist.js
 ---
@@ -82,6 +84,8 @@ No passkey yet? Create one on [Passkey as your key](passkey.md) first, or create
 </script>
 
 <div id="checklist-tool"></div>
+<script src="../vendor/qrcode-generator.js"></script>
+<script src="../vendor/jsQR.js"></script>
 <script src="../../js/vault.js"></script>
 <script src="../../js/checklist.js"></script>
 
@@ -92,4 +96,5 @@ No passkey yet? Create one on [Passkey as your key](passkey.md) first, or create
 - The list only records what you ticked and on which day. If the passkey is lost and the list will not open, tick again; there is no backup key step here.
 - Renaming an article heading does not affect existing ticks. Ticks follow the item's internal id.
 - The yearly review group holds the nine questions from the baseline article. Anything untouched for over a year gets flagged, the filter narrows the list to those, and "Checked today" resets the date.
+- When the passkey did not sync to another device (a different ecosystem, a hardware key), unlock here and press Enrol another device: a QR code and a string appear for one minute. On the other device press Enrol this device with a key from another, photograph or paste it, and that device gets a passkey with the same key. The string is the data key itself, so use it only between your own two devices.
 - [Threat model checklist](threat-model.md) is the other list-shaped tool here. It asks what you protect and from whom, and stores nothing. This page records how far you have got.

--- a/docs/zh-CN/utils/checklist.md
+++ b/docs/zh-CN/utils/checklist.md
@@ -43,6 +43,8 @@ offline_assets:
   - utils/vendor/age/noble-post-quantum/ml-kem.js
   - utils/vendor/age/noble-post-quantum/utils.js
   - utils/vendor/age/scure-base/index.js
+  - utils/vendor/qrcode-generator.js
+  - utils/vendor/jsQR.js
   - js/vault.js
   - js/checklist.js
 ---
@@ -82,6 +84,8 @@ offline_assets:
 </script>
 
 <div id="checklist-tool"></div>
+<script src="../vendor/qrcode-generator.js"></script>
+<script src="../vendor/jsQR.js"></script>
 <script src="../../js/vault.js"></script>
 <script src="../../js/checklist.js"></script>
 
@@ -92,4 +96,5 @@ offline_assets:
 - 这份清单只记你勾了什么跟哪一天勾的。passkey 丢了、清单打不开，重勾一次就好，这里没有备援密钥那一步。
 - 文章改标题不影响已勾的项目，勾选跟着项目的内部编号走。
 - 「每年重看」那一组是文章里一年一次的检查那九题。任何项目超过一年没动会标出来，「只看超过一年没动的」把清单缩成该重看的那几项，按「今天确认过」把日期换成今天。
+- passkey 没有同步到另一台时（不同生态系、硬件密钥），这台解开后按「登录另一台设备」，会显示一个 QR code 与一串字，限时一分钟。另一台按「用另一台的钥匙登录这台」拍照或贴上，就创建出一把用同一份钥匙的 passkey。那串就是数据密钥本身，只在自己的两台设备之间用。
 - [威胁模型清单](threat-model.md)是另一个清单型工具，答的是要保护什么、防谁，答案不存起来。这一页记的是做到哪一步。

--- a/docs/zh-TW/js/checklist.js
+++ b/docs/zh-TW/js/checklist.js
@@ -81,6 +81,18 @@
     #checklist-tool .cl-filter { display: flex; gap: 0.5rem; align-items: center; font-size: 0.75rem; margin: 0.6rem 0; cursor: pointer; }
     #checklist-tool .cl-filter input { width: 1.1rem; height: 1.1rem; margin: 0; }
     #checklist-tool .cl-file { font-size: 0.72rem; }
+    #checklist-tool .cl-panel { border: 1px dashed var(--md-default-fg-color--lighter); border-radius: 0.4rem; padding: 0.6rem 0.8rem; margin: 0.8rem 0; }
+    #checklist-tool .cl-warn { font-weight: 600; border-left: 0.15rem solid #ef6c00; padding-left: 0.6rem; margin: 0.4rem 0; }
+    #checklist-tool .cl-secret {
+      font-family: var(--md-code-font-family, monospace); font-size: 0.72rem; word-break: break-all; user-select: all;
+      padding: 0.5rem; border-radius: 0.3rem; background: var(--md-code-bg-color);
+    }
+    #checklist-tool .cl-qr { display: block; width: 12rem; max-width: 100%; height: auto; image-rendering: pixelated; background: #fff; margin: 0.6rem 0; }
+    #checklist-tool .cl-label { display: block; margin: 0.6rem 0 0.3rem; font-size: 0.75rem; font-weight: 600; }
+    #checklist-tool .cl-key {
+      width: 100%; padding: 0.5rem; font-family: var(--md-code-font-family, monospace); font-size: 0.72rem;
+      border: 1px solid var(--md-default-fg-color--lighter); border-radius: 0.4rem; background: var(--md-default-bg-color); color: var(--md-default-fg-color);
+    }
     @media (pointer: coarse) { #checklist-tool .cl-item input { width: 1.5rem; height: 1.5rem; } }
   `;
 
@@ -166,6 +178,18 @@
       exportBlob: "匯出",
       importBlob: "匯入",
       exported: "匯出的是標準 age 檔，另一台裝置匯進去之後用同一把 passkey 解開。",
+      enrollShow: "登錄另一台裝置",
+      enrollWarn: "下面這串就是資料金鑰本身。拍到的人可以永遠打開你的暫存區，只在你自己的兩台裝置之間用。一分鐘後自動關掉，這一頁不留它。",
+      enrollSteps: "另一台打開我的準備清單，按「用另一台的鑰匙登錄這台」，拍下 QR code 或貼上字串。登錄完再用「傳到另一台」把資料搬過去。",
+      enrollCountdown: "還剩 {n} 秒",
+      enrollClose: "關掉",
+      enrollHere: "用另一台的鑰匙登錄這台",
+      enrollHereHint: "passkey 沒有同步到這台時用。另一台解開之後按「登錄另一台裝置」，把那邊顯示的字串貼進來，或拍那邊的 QR code。這台會建一把用同一份鑰匙的 passkey，資料再用那邊的「傳到另一台」搬。",
+      enrollInputLabel: "另一台顯示的字串（AGE-SECRET-KEY-1 開頭）",
+      enrollPhoto: "或拍另一台的 QR code",
+      enrollGo: "登錄這台裝置",
+      enrollBack: "返回",
+      enrollDone: "這台登錄好了，用的是跟另一台同一份鑰匙。資料還在另一台，用那邊的「傳到另一台」搬過來，或直接開始用。",
       imported: "匯進來了。用 passkey 解開。",
       transfer: "傳到另一台（QR）",
       transferHint: "開了一個新分頁在播 QR code。另一台打開 QR 影格串流的接收端對著掃，收齊之後按「匯入我的準備清單」，再用同一把 passkey 解開。兩台不需要共用網路。",
@@ -211,6 +235,8 @@
         failed: "沒有成功。換一個瀏覽器或密碼管理器試試。",
         badFile: "檔案格式不對，要的是從清單匯出的 age 檔。",
         badImport: "帶過來的內容不是暫存區的密文。",
+        badKey: "這串不是暫存區的鑰匙，要 AGE-SECRET-KEY-1 開頭的 74 個字元。",
+        noQr: "照片裡找不到 QR code，靠近一點、對正再拍一次。",
       },
     },
     zh: {
@@ -231,6 +257,18 @@
       exportBlob: "导出",
       importBlob: "导入",
       exported: "导出的是标准 age 文件，另一台设备导进去之后用同一把 passkey 解开。",
+      enrollShow: "登录另一台设备",
+      enrollWarn: "下面这串就是数据密钥本身。拍到的人可以永远打开你的暂存区，只在你自己的两台设备之间用。一分钟后自动关掉，这一页不留它。",
+      enrollSteps: "另一台打开我的准备清单，按「用另一台的钥匙登录这台」，拍下 QR code 或贴上字串。登录完再用「传到另一台」把数据搬过去。",
+      enrollCountdown: "还剩 {n} 秒",
+      enrollClose: "关掉",
+      enrollHere: "用另一台的钥匙登录这台",
+      enrollHereHint: "passkey 没有同步到这台时用。另一台解开之后按「登录另一台设备」，把那边显示的字串贴进来，或拍那边的 QR code。这台会创建一把用同一份钥匙的 passkey，数据再用那边的「传到另一台」搬。",
+      enrollInputLabel: "另一台显示的字串（AGE-SECRET-KEY-1 开头）",
+      enrollPhoto: "或拍另一台的 QR code",
+      enrollGo: "登录这台设备",
+      enrollBack: "返回",
+      enrollDone: "这台登录好了，用的是跟另一台同一份钥匙。数据还在另一台，用那边的「传到另一台」搬过来，或直接开始用。",
       imported: "导进来了。用 passkey 解开。",
       transfer: "传到另一台（QR）",
       transferHint: "开了一个新标签页在播 QR code。另一台打开 QR 影格串流的接收端对着扫，收齐之后按「导入我的准备清单」，再用同一把 passkey 解开。两台不需要共用网络。",
@@ -276,6 +314,8 @@
         failed: "没有成功。换一个浏览器或密码管理器试试。",
         badFile: "文件格式不对，要的是从清单导出的 age 文件。",
         badImport: "带过来的内容不是暂存区的密文。",
+        badKey: "这串不是暂存区的钥匙，要 AGE-SECRET-KEY-1 开头的 74 个字符。",
+        noQr: "照片里找不到 QR code，靠近一点、对正再拍一次。",
       },
     },
     en: {
@@ -296,6 +336,18 @@
       exportBlob: "Export",
       importBlob: "Import",
       exported: "The export is a standard age file. Import it on another device and unlock with the same passkey.",
+      enrollShow: "Enrol another device",
+      enrollWarn: "The string below is the data key itself. Anyone who photographs it can open your stash forever, so use it only between your own two devices. It closes by itself after a minute and this page keeps no copy.",
+      enrollSteps: "On the other device, open my preparation checklist, press Enrol this device with a key from another, then photograph this QR code or paste the string. Once enrolled, use Send to another device to move the data across.",
+      enrollCountdown: "{n} seconds left",
+      enrollClose: "Close",
+      enrollHere: "Enrol this device with a key from another",
+      enrollHereHint: "For when the passkey did not sync to this device. Unlock on the other device, press Enrol another device, then paste the string shown there or photograph its QR code. This device gets a passkey with the same key; move the data afterwards with Send to another device over there.",
+      enrollInputLabel: "The string shown on the other device (starts with AGE-SECRET-KEY-1)",
+      enrollPhoto: "or photograph the other device's QR code",
+      enrollGo: "Enrol this device",
+      enrollBack: "Back",
+      enrollDone: "This device is enrolled with the same key as the other one. The data is still over there: use Send to another device on that side, or just start here.",
       imported: "Imported. Unlock with your passkey.",
       transfer: "Send to another device (QR)",
       transferHint: "A new tab is playing QR codes. On the other device, open the QR frame stream receiver and point it at the screen. Once complete, press Import into my preparation checklist and unlock with the same passkey. The two devices do not need a shared network.",
@@ -341,6 +393,8 @@
         failed: "It did not work. Try another browser or password manager.",
         badFile: "That file is not an age file exported from here.",
         badImport: "What was handed over is not stash ciphertext.",
+        badKey: "That is not a stash key. It should be 74 characters starting with AGE-SECRET-KEY-1.",
+        noQr: "No QR code found in the photo. Get closer, line it up and try again.",
       },
     },
   };
@@ -408,6 +462,7 @@
     exists: false,
     unlocked: false,
     onlyStale: false, // 只看超過一年沒動的
+    enroll: { showing: false, identity: "", until: 0, timer: null, here: false, input: "" }, // 登錄另一台
     busy: null, // "unlock" | "open" | "create" | "import" | "export"
     data: null, // 解開後整份資料，checks 只是其中一欄
     error: null,
@@ -482,6 +537,7 @@
   const lock = () =>
     guard("lock", async () => {
       await saveNow();
+      closeEnrollSilently();
       vault().lock();
       state.unlocked = false;
       state.data = null;
@@ -558,6 +614,174 @@
     }
     return bytes;
   }
+
+
+  // --- 登錄另一台裝置 ---
+  //
+  // passkey 不會同步過去的第二台（不同生態系、硬體金鑰）要能開同一份暫存區，得把那
+  // 32 個位元組帶過去一次。A 解開後把鑰匙用 age 私鑰的編碼顯示成 QR code 與文字，限時
+  // 一分鐘；B 拍照或貼上，用同一個 user.id 建一把新的 passkey。那串就是資料金鑰本身，
+  // 顯示前先警告，關掉或鎖上就從記憶體拿掉，這一頁不留。
+  const ENROLL_MS = 60 * 1000;
+  const looksLikeKey = (text) => /^AGE-SECRET-KEY-1[02-9AC-HJ-NP-Z]{58}$/i.test(String(text || "").trim());
+  let countdownNode = null;
+  function stopEnrollTimer() {
+    if (state.enroll.timer) clearInterval(state.enroll.timer);
+    state.enroll.timer = null;
+  }
+  function closeEnrollSilently() {
+    stopEnrollTimer();
+    state.enroll.showing = false;
+    state.enroll.identity = "";
+    state.enroll.until = 0;
+  }
+  function closeEnroll() {
+    closeEnrollSilently();
+    render();
+  }
+  function tickEnroll() {
+    const left = Math.ceil((state.enroll.until - Date.now()) / 1000);
+    if (left <= 0) {
+      closeEnroll();
+      return;
+    }
+    if (countdownNode) countdownNode.textContent = fill(t.enrollCountdown, { n: left });
+  }
+  const showEnroll = () =>
+    guard("enroll", async () => {
+      state.enroll.identity = await vault().exportIdentity();
+      state.enroll.until = Date.now() + ENROLL_MS;
+      state.enroll.showing = true;
+      stopEnrollTimer();
+      state.enroll.timer = setInterval(tickEnroll, 1000);
+    });
+  // QR code 交給 vendor 的 qrcode-generator，畫在 canvas 上，沒有它就只顯示文字
+  function drawQr(text) {
+    if (typeof window.qrcode !== "function") return null;
+    const qr = window.qrcode(0, "M");
+    qr.addData(text);
+    qr.make();
+    const count = qr.getModuleCount();
+    const scale = 4;
+    const margin = 4 * scale;
+    const canvas = document.createElement("canvas");
+    canvas.className = "cl-qr";
+    canvas.width = count * scale + margin * 2;
+    canvas.height = canvas.width;
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#000";
+    for (let row = 0; row < count; row += 1) {
+      for (let col = 0; col < count; col += 1) {
+        if (qr.isDark(row, col)) ctx.fillRect(margin + col * scale, margin + row * scale, scale, scale);
+      }
+    }
+    return canvas;
+  }
+  function enrollShowPanel() {
+    const box = el("div", "cl-panel cl-enroll-show");
+    box.appendChild(el("p", "cl-warn", t.enrollWarn));
+    const canvas = drawQr(state.enroll.identity);
+    if (canvas) box.appendChild(canvas);
+    box.appendChild(el("p", "cl-secret", state.enroll.identity));
+    box.appendChild(el("p", "cl-hint", t.enrollSteps));
+    countdownNode = el("p", "cl-hint cl-countdown", fill(t.enrollCountdown, { n: Math.max(0, Math.ceil((state.enroll.until - Date.now()) / 1000)) }));
+    box.appendChild(countdownNode);
+    const row = el("div", "cl-row");
+    row.appendChild(button(t.enrollClose, "cl-primary", closeEnroll));
+    box.appendChild(row);
+    return box;
+  }
+  // B 這端：拍另一台螢幕的照片交給 vendor 的 jsQR 解，不開即時相機
+  async function decodeQrPhoto(file) {
+    if (typeof window.jsQR !== "function" || typeof createImageBitmap !== "function") throw new Error("noQr");
+    const bitmap = await createImageBitmap(file);
+    try {
+      const cap = 1400;
+      const ratio = Math.min(1, cap / Math.max(bitmap.width, bitmap.height));
+      const width = Math.max(1, Math.round(bitmap.width * ratio));
+      const height = Math.max(1, Math.round(bitmap.height * ratio));
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(bitmap, 0, 0, width, height);
+      const pixels = ctx.getImageData(0, 0, width, height);
+      const found = window.jsQR(pixels.data, width, height);
+      if (!found || !looksLikeKey(found.data)) throw new Error("noQr");
+      return found.data.trim();
+    } finally {
+      if (bitmap.close) bitmap.close();
+    }
+  }
+  function readQrPhoto(file) {
+    state.error = null;
+    decodeQrPhoto(file).then(
+      (text) => {
+        state.enroll.input = text;
+        render();
+      },
+      () => {
+        state.error = "noQr";
+        render();
+      }
+    );
+  }
+  function syncEnrollGo() {
+    const go = root.querySelector(".cl-enroll-go");
+    if (go) go.disabled = !looksLikeKey(state.enroll.input);
+  }
+  const enrollHere = () =>
+    guard("enroll", async () => {
+      const bytes = await vault().keyFromIdentity(state.enroll.input);
+      await vault().enrollDevice(bytes);
+      state.enroll.here = false;
+      state.enroll.input = "";
+      await opened();
+      state.message = t.enrollDone;
+    });
+  function enrollHerePanel() {
+    const box = el("div", "cl-panel cl-enroll-here");
+    box.appendChild(el("p", "cl-hint", t.enrollHereHint));
+    const label = el("label", "cl-label", t.enrollInputLabel);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.autocomplete = "off";
+    input.spellcheck = false;
+    input.className = "cl-key";
+    input.value = state.enroll.input;
+    input.addEventListener("input", () => {
+      state.enroll.input = input.value;
+      syncEnrollGo();
+    });
+    label.appendChild(input);
+    box.appendChild(label);
+    const photoRow = el("div", "cl-row");
+    photoRow.appendChild(el("span", "cl-hint", t.enrollPhoto));
+    const photo = document.createElement("input");
+    photo.type = "file";
+    photo.accept = "image/*";
+    photo.setAttribute("capture", "environment");
+    photo.className = "cl-file cl-photo";
+    photo.setAttribute("aria-label", t.enrollPhoto);
+    photo.addEventListener("change", () => {
+      if (photo.files && photo.files[0]) readQrPhoto(photo.files[0]);
+    });
+    photoRow.appendChild(photo);
+    box.appendChild(photoRow);
+    const row = el("div", "cl-row");
+    const go = button(t.enrollGo, "cl-primary cl-enroll-go", enrollHere);
+    go.disabled = !looksLikeKey(state.enroll.input);
+    row.appendChild(go);
+    row.appendChild(button(t.enrollBack, null, () => {
+      state.enroll.here = false;
+      render();
+    }));
+    box.appendChild(row);
+    return box;
+  }
+  window.addEventListener("pagehide", closeEnrollSilently);
 
   // --- 清單本體 ---
   function onToggle(id) {
@@ -693,8 +917,13 @@
       head.appendChild(hint);
       row.appendChild(button(t.openExisting, "cl-primary", openExisting));
       row.appendChild(button(t.createNew, null, createNew));
+      row.appendChild(button(t.enrollHere, null, () => {
+        state.enroll.here = !state.enroll.here;
+        render();
+      }));
     }
     head.appendChild(row);
+    if (!state.exists && state.enroll.here) head.appendChild(enrollHerePanel());
     const file = document.createElement("input");
     file.type = "file";
     file.accept = ".age,application/octet-stream";
@@ -728,13 +957,16 @@
       row.appendChild(button(t.lock, "cl-primary", lock));
       row.appendChild(button(t.exportBlob, null, exportBlob));
       row.appendChild(button(t.transfer, null, transfer));
+      row.appendChild(button(t.enrollShow, null, showEnroll));
     }
     head.appendChild(row);
+    if (state.enroll.showing && !state.busy) head.appendChild(enrollShowPanel());
   }
   function render() {
     head.textContent = "";
     progressNode = null;
     filterCountNode = null;
+    countdownNode = null;
     if (!state.support) head.appendChild(el("p", "cl-hint", t.checking));
     else if (state.unlocked) renderUnlocked();
     else renderLocked();

--- a/docs/zh-TW/js/vault.js
+++ b/docs/zh-TW/js/vault.js
@@ -173,6 +173,21 @@
     return bech32.encodeFromBytes("AGE-SECRET-KEY-", keyBytes).toUpperCase();
   }
 
+  // 另一台顯示的字串解回 32 個位元組。只認 AGE-SECRET-KEY-1 開頭、解出來剛好 32 位元組的。
+  async function keyFromIdentity(text) {
+    const { bech32 } = await import("@scure/base");
+    const clean = String(text || "").trim().toUpperCase();
+    if (!/^AGE-SECRET-KEY-1[02-9AC-HJ-NP-Z]{58}$/.test(clean)) throw new Error("badKey");
+    let res;
+    try {
+      res = bech32.decodeToBytes(clean); // 校驗碼錯會丟 scure 自己的錯誤，統一成 badKey
+    } catch (err) {
+      throw new Error("badKey");
+    }
+    if (String(res.prefix).toUpperCase() !== "AGE-SECRET-KEY-" || res.bytes.length !== KEY_BYTES) throw new Error("badKey");
+    return new Uint8Array(res.bytes);
+  }
+
   async function recipientOf(identity) {
     const age = await lib();
     return age.identityToRecipient(identity);
@@ -336,11 +351,21 @@
       return unlockedKey.slice();
     },
 
-    // 不同步的環境（Windows Hello）要加第二台裝置：帶著 exportKey 拿出來的金鑰，在那台
-    // 用同一個 user.id 建一把新的。還沒有介面。
+    // 給另一台登錄用的字串，跟 age 的私鑰同一種編碼。它就是資料金鑰本身，顯示的一方要限時、要警告。
+    async exportIdentity() {
+      if (!unlockedKey) throw new Error("locked");
+      return identityOf(unlockedKey);
+    },
+    keyFromIdentity: keyFromIdentity,
+
+    // passkey 不會同步過去的第二台：帶著另一台 exportIdentity 出來的鑰匙，在這台用同一個
+    // user.id 建一把新的。這台還沒有暫存區就先開一個空的，讀者重新整理之後「用我已有的
+    // 鑰匙開」才接得上。介面在我的準備清單。
     async enrollDevice(keyBytes) {
       const made = await createCredential(keyBytes);
       unlockedKey = keyBytes;
+      currentBackup = null;
+      if (!(await readBlob())) await api.save({});
       return made;
     },
 

--- a/docs/zh-TW/utils/checklist.md
+++ b/docs/zh-TW/utils/checklist.md
@@ -43,6 +43,8 @@ offline_assets:
   - utils/vendor/age/noble-post-quantum/ml-kem.js
   - utils/vendor/age/noble-post-quantum/utils.js
   - utils/vendor/age/scure-base/index.js
+  - utils/vendor/qrcode-generator.js
+  - utils/vendor/jsQR.js
   - js/vault.js
   - js/checklist.js
 ---
@@ -82,6 +84,8 @@ offline_assets:
 </script>
 
 <div id="checklist-tool"></div>
+<script src="../vendor/qrcode-generator.js"></script>
+<script src="../vendor/jsQR.js"></script>
 <script src="../../js/vault.js"></script>
 <script src="../../js/checklist.js"></script>
 
@@ -93,4 +97,5 @@ offline_assets:
 - 這份清單只記你勾了什麼跟哪一天勾的。passkey 丟了、清單打不開，重勾一次就好，這裡沒有備援金鑰那一步。
 - 文章改標題不影響已勾的項目，勾選跟著項目的內部編號走。
 - 「每年重看」那一組是文章裡一年一次的檢查那九題。任何項目超過一年沒動會標出來，「只看超過一年沒動的」把清單縮成該重看的那幾項，按「今天確認過」把日期換成今天。
+- passkey 沒有同步到另一台時（不同生態系、硬體金鑰），這台解開後按「登錄另一台裝置」，會顯示一個 QR code 與一串字，限時一分鐘。另一台按「用另一台的鑰匙登錄這台」拍照或貼上，就建出一把用同一份鑰匙的 passkey。那串就是資料金鑰本身，只在自己的兩台裝置之間用。
 - [威脅模型清單](threat-model.md)是另一個清單型工具，答的是要保護什麼、防誰，答案不存起來。這一頁記的是做到哪一步。

--- a/tools/check_vault_browser.mjs
+++ b/tools/check_vault_browser.mjs
@@ -176,6 +176,10 @@ async function openChrome() {
     const { result } = await send('WebAuthn.getCredentials', { authenticatorId });
     return result.credentials;
   };
+  // 模擬換到另一台：把驗證器裡的 credential 全部拿掉
+  const clearCredentials = async () => {
+    await send('WebAuthn.clearCredentials', { authenticatorId });
+  };
 
   const shot = async (name) => {
     if (!SHOTS) return;
@@ -194,6 +198,7 @@ async function openChrome() {
     goto,
     type,
     credentials,
+    clearCredentials,
     shot,
     // 收尾要吞掉錯誤。Chrome 關閉的時候還在寫 profile 目錄，rmSync 會撞上
     close: async () => {
@@ -739,6 +744,82 @@ test('清單傳到另一台：密文經 #send= 進 QR 串流頁載入，經 #imp
     await page.waitFor("/不是暫存區的密文/.test(__vl.text('#checklist-tool'))", '壞片段要說');
     assert.equal(await page.evaluate('location.hash'), '');
     assert.ok(await page.evaluate("!!__vl.button('#checklist-tool', '用 passkey 解開')"), '原本的暫存區要還在');
+  } finally {
+    await page.close();
+  }
+});
+
+test('登錄另一台：A 顯示鑰匙的 QR code，B 拍照登錄後用同一份鑰匙解開搬過來的資料', async () => {
+  const page = await openChrome();
+  try {
+    await page.goto(CHECKLIST_URL);
+    await page.evaluate(HELPERS);
+    await page.waitFor("!!__vl.button('#checklist-tool', '建一把新的鑰匙')", '清單頁畫出來');
+    await page.evaluate("__vl.click('#checklist-tool', '建一把新的鑰匙')");
+    await page.waitFor("document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]').length > 0", '清單畫出來');
+    await page.evaluate("document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]')[1].click(); true");
+    await page.evaluate("document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]')[2].click(); true");
+    await page.waitFor("/已存/.test(__vl.text('#checklist-tool'))", '自動存');
+    const exported = await page.evaluate("window.anoniVault.exportBlob().then((bytes) => Array.from(bytes))");
+    const blobPath = path.join(os.tmpdir(), `anoni-enroll-${process.pid}.age`);
+    fs.writeFileSync(blobPath, Buffer.from(exported));
+
+    // A：顯示鑰匙
+    await page.evaluate("__vl.click('#checklist-tool', '登錄另一台裝置')");
+    await page.waitFor("!!document.querySelector('#checklist-tool .cl-secret')", '鑰匙顯示出來');
+    const identity = await page.evaluate("document.querySelector('#checklist-tool .cl-secret').textContent");
+    assert.match(identity, /^AGE-SECRET-KEY-1[0-9A-Z]{58}$/, '顯示的要是 age 私鑰編碼');
+    assert.ok(await page.evaluate("!!document.querySelector('#checklist-tool canvas.cl-qr')"), '要有 QR code');
+    assert.ok(await page.evaluate("/資料金鑰本身/.test(__vl.text('#checklist-tool'))"), '要先警告');
+    assert.match(await page.evaluate("document.querySelector('#checklist-tool .cl-countdown').textContent"), /還剩 (60|59|58) 秒/, '倒數要從一分鐘開始');
+    await page.evaluate("document.querySelector('#checklist-tool .cl-enroll-show').scrollIntoView(); true");
+    await page.shot('11-enroll-show');
+    const png = await page.evaluate("document.querySelector('#checklist-tool canvas.cl-qr').toDataURL('image/png').split(',')[1]");
+    const photoPath = path.join(os.tmpdir(), `anoni-enroll-${process.pid}.png`);
+    fs.writeFileSync(photoPath, Buffer.from(png, 'base64'));
+
+    // 關掉之後畫面上不能再有鑰匙；鎖上也一樣
+    await page.evaluate("__vl.click('#checklist-tool', '關掉')");
+    assert.ok(!(await page.evaluate("__vl.text('#checklist-tool')")).includes(identity), '關掉之後鑰匙還在畫面上');
+    await page.evaluate("__vl.click('#checklist-tool', '登錄另一台裝置')");
+    await page.waitFor("!!document.querySelector('#checklist-tool .cl-secret')", '再顯示一次');
+    await page.evaluate("__vl.click('#checklist-tool', '鎖上')");
+    await page.waitFor("!!__vl.button('#checklist-tool', '用 passkey 解開')", '鎖上');
+    assert.ok(!(await page.evaluate("__vl.text('#checklist-tool')")).includes(identity), '鎖上之後鑰匙還在畫面上');
+
+    // B：這台沒有 passkey 也沒有暫存區，拍 A 的 QR code 登錄
+    await page.clearCredentials();
+    await page.evaluate('window.anoniVault.clear().then(() => true)');
+    await page.goto('about:blank');
+    await page.goto(CHECKLIST_URL);
+    await page.evaluate(HELPERS);
+    await page.waitFor("!!__vl.button('#checklist-tool', '用另一台的鑰匙登錄這台')", 'B 端給登錄的入口');
+    await page.evaluate("__vl.click('#checklist-tool', '用另一台的鑰匙登錄這台')");
+    await page.waitFor("!!document.querySelector('#checklist-tool input.cl-photo')", '登錄面板出現');
+    assert.ok(await page.evaluate("__vl.button('#checklist-tool', '登錄這台裝置').disabled"), '還沒有鑰匙不能登錄');
+    const { result: doc } = await page.send('DOM.getDocument', { depth: 1 });
+    const { result: node } = await page.send('DOM.querySelector', { nodeId: doc.root.nodeId, selector: '#checklist-tool input.cl-photo' });
+    await page.send('DOM.setFileInputFiles', { nodeId: node.nodeId, files: [photoPath] });
+    await page.waitFor(`document.querySelector('#checklist-tool input.cl-key') && document.querySelector('#checklist-tool input.cl-key').value === ${JSON.stringify(identity)}`, '照片解出鑰匙填進欄位');
+    await page.waitFor("!__vl.button('#checklist-tool', '登錄這台裝置').disabled", '有鑰匙了要能登錄');
+    await page.evaluate("__vl.click('#checklist-tool', '登錄這台裝置')");
+    await page.waitFor("/這台登錄好了/.test(__vl.text('#checklist-tool'))", '登錄完成');
+    assert.equal((await page.credentials()).length, 1, 'B 端要建出一筆新的 credential');
+    assert.ok(await page.evaluate("document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]').length > 0"), '登錄完直接是解開的');
+
+    // 把 A 匯出的密文用檔案匯進來，用 B 這把新的 passkey 解開
+    await page.evaluate("__vl.click('#checklist-tool', '鎖上')");
+    await page.waitFor("!!document.querySelector('#checklist-tool input.cl-file')", '鎖上後有匯入的選檔');
+    const { result: doc2 } = await page.send('DOM.getDocument', { depth: 1 });
+    const { result: fileNode } = await page.send('DOM.querySelector', { nodeId: doc2.root.nodeId, selector: '#checklist-tool input.cl-file' });
+    await page.send('DOM.setFileInputFiles', { nodeId: fileNode.nodeId, files: [blobPath] });
+    await page.waitFor("/匯進來了/.test(__vl.text('#checklist-tool'))", '搬過來');
+    await page.evaluate("__vl.click('#checklist-tool', '用 passkey 解開')");
+    await page.waitFor("document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]').length > 0", '用新的 passkey 解開');
+    const checked = await page.evaluate("[...document.querySelectorAll('#checklist-tool .cl-item input[type=checkbox]')].filter((i) => i.checked).length");
+    assert.equal(checked, 2, 'A 勾的兩項要在 B 解得出來');
+    fs.rmSync(photoPath, { force: true });
+    fs.rmSync(blobPath, { force: true });
   } finally {
     await page.close();
   }

--- a/tools/test_checklist.mjs
+++ b/tools/test_checklist.mjs
@@ -110,7 +110,9 @@ test('三語系頁面都掛了工具、兩支腳本與 import map，offline_asse
     assert.ok(text.includes('<script type="importmap">'), `${dir} 沒有 import map`);
     assert.ok(text.includes('  - js/vault.js'), `${dir} 的 offline_assets 沒列 js/vault.js`);
     assert.ok(text.includes('  - js/checklist.js'), `${dir} 的 offline_assets 沒列 js/checklist.js`);
-    assert.deepEqual(vendor(page), vendor(path.join(DOCS, dir, 'utils', 'passkey.md')), `${dir} 的 vendor 清單跟鑰匙頁不同`);
+    assert.deepEqual(vendor(page).filter((l) => l.includes('vendor/age/')), vendor(path.join(DOCS, dir, 'utils', 'passkey.md')), `${dir} 的 age vendor 清單跟鑰匙頁不同`);
+    for (const extra of ['utils/vendor/qrcode-generator.js', 'utils/vendor/jsQR.js']) assert.ok(text.includes(`  - ${extra}`), `${dir} 的 offline_assets 少了 ${extra}`);
+    assert.ok(text.includes('<script src="../vendor/qrcode-generator.js"></script>') && text.includes('<script src="../vendor/jsQR.js"></script>'), `${dir} 沒載 QR 的 vendor`);
   }
 });
 
@@ -154,6 +156,19 @@ test('傳到另一台：密文走網址片段到 QR 串流頁，回來就匯入�
   const incomingAt = src.indexOf('const incoming = takeIncoming()');
   assert.ok(incomingAt > 0 && incomingAt < src.indexOf('refresh().then'), '要在查暫存區之前就把片段拿走');
   assert.ok(/importBytes\(incoming, t\.importedFromQr, "badImport"\)/.test(src), '帶回來的密文沒有走匯入');
+});
+
+test('登錄另一台：鑰匙限時顯示、鎖上就收、B 端經 keyFromIdentity 與 enrollDevice', () => {
+  assert.ok(/const ENROLL_MS = 60 \* 1000;/.test(src), '顯示鑰匙要限時一分鐘');
+  assert.ok(/state\.enroll\.identity = await vault\(\)\.exportIdentity\(\)/.test(src), '顯示的字串要從 exportIdentity 來');
+  assert.ok(/if \(left <= 0\) \{\s*closeEnroll\(\);/.test(src), '時間到要自己關掉');
+  const lockAt = src.indexOf('const lock = () =>');
+  assert.ok(src.slice(lockAt, lockAt + 300).includes('closeEnrollSilently();'), '鎖上時沒有把顯示中的鑰匙收掉');
+  assert.ok(/window\.addEventListener\("pagehide", closeEnrollSilently\)/.test(src), '離開頁面沒有收掉');
+  assert.ok(/const bytes = await vault\(\)\.keyFromIdentity\(state\.enroll\.input\);\s*await vault\(\)\.enrollDevice\(bytes\);/.test(src), 'B 端沒有經 keyFromIdentity 再 enrollDevice');
+  assert.ok(/window\.qrcode\(0, "M"\)/.test(src) && /window\.jsQR\(pixels\.data, width, height\)/.test(src), 'QR 的產生與解碼要交給 vendor');
+  assert.ok(!/new Image\(/.test(src) && /createImageBitmap\(file\)/.test(src), '照片用 createImageBitmap 解，不走 Image 與 object URL');
+  assert.ok(!/setInterval\([^)]*save/i.test(src), '計時器不能拿來自動存');
 });
 
 test('原始碼沒有把勾選送出去或寫進 localStorage 的手段', () => {

--- a/tools/test_vault.mjs
+++ b/tools/test_vault.mjs
@@ -69,13 +69,15 @@ const harness = `
   const lib = async () => age;
   const importBase = async () => base;
   ${grab(/^  async function identityOf\(keyBytes\) \{[\s\S]*?\n  \}/m).replace('await import("@scure/base")', 'await importBase()')}
+  ${grab(/^  const KEY_BYTES = .*$/m)}
+  ${grab(/^  async function keyFromIdentity\(text\) \{[\s\S]*?\n  \}/m).replace('await import("@scure/base")', 'await importBase()')}
   ${grab(/^  async function recipientOf\(identity\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  async function encryptData\(data, keyBytes, backupRecipient\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  async function decryptData\(bytes, identity\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  const ENVELOPE_VERSION = .*$/m)}
   ${grab(/^  function wrapEnvelope\(data, backupRecipient\) \{[\s\S]*?\n  \}/m)}
   ${grab(/^  function unwrapEnvelope\(obj\) \{[\s\S]*?\n  \}/m)}
-  return { identityOf, recipientOf, encryptData, decryptData, wrapEnvelope, unwrapEnvelope, ENVELOPE_VERSION };
+  return { identityOf, keyFromIdentity, recipientOf, encryptData, decryptData, wrapEnvelope, unwrapEnvelope, ENVELOPE_VERSION };
 `;
 const vault = new Function('age', 'base', harness)(age, base);
 
@@ -83,6 +85,18 @@ let passed = 0;
 let failed = 0;
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
+
+test('另一台顯示的字串解回同一把金鑰，壞的、別種前綴、長度不對都拒絕', async () => {
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const identity = await vault.identityOf(key);
+  assert.deepEqual(await vault.keyFromIdentity(identity), key, '編碼再解碼要回到同一把');
+  assert.deepEqual(await vault.keyFromIdentity('  ' + identity.toLowerCase() + '\n'), key, '前後空白與小寫要容忍');
+  const theirs = await age.generateX25519Identity();
+  assert.equal((await vault.keyFromIdentity(theirs)).length, 32, 'typage 產的私鑰是同一種編碼');
+  for (const bad of ['', 'hello', identity.slice(0, -1), identity.slice(0, -1) + (identity.endsWith('Q') ? 'P' : 'Q'), await vault.recipientOf(identity), 'AGE-SECRET-KEY-PQ-1' + 'Q'.repeat(120)]) {
+    await assert.rejects(() => vault.keyFromIdentity(bad), /badKey/, `不該收：${bad.slice(0, 30)}`);
+  }
+});
 
 test('那 32 個位元組編出來的 identity 跟 typage 自己產的同一個形狀', async () => {
   const key = new Uint8Array(32).fill(7);


### PR DESCRIPTION
## 做了什麼

passkey 不會同步過去的第二台（不同生態系、硬體金鑰）開不了同一份暫存區。底層的 `enrollDevice()` 早就在，缺的是那 32 個位元組怎麼從 A 到 B 一次。這是先前討論選的第一個方案。

- **A 解開後按「登錄另一台裝置」**：鑰匙用 age 私鑰的編碼（`AGE-SECRET-KEY-1…`）顯示成 QR code 與文字。先警告那串就是資料金鑰本身、只在自己的兩台裝置之間用。一分鐘倒數到零自動關掉；關掉、鎖上、離開頁面都從記憶體拿掉
- **B 沒有暫存區時多一顆「用另一台的鑰匙登錄這台」**：貼上字串，或拍另一台螢幕的照片交給 vendor 的 jsQR 解（`createImageBitmap`，不開即時相機）。登錄就是用同一個 `user.id` 建一把新的 passkey，直接進解開狀態。資料再用匯入或「傳到另一台」搬
- `vault.js` 加 `exportIdentity()` 與 `keyFromIdentity()`：只認 `AGE-SECRET-KEY-1` 開頭、解出來剛好 32 位元組的，校驗碼錯統一丟 `badKey`。`enrollDevice()` 在這台沒有暫存區時先開一個空的，重新整理後「用我已有的鑰匙開」才接得上
- QR 產生交給 vendor 的 qrcode-generator 畫在 canvas 上。三語系 `checklist.md` 加兩個 vendor 的 script 與 `offline_assets`，「怎麼運作」補一條並寫明風險

## 測試

- `test_vault.mjs`：`keyFromIdentity` 的往返、容忍空白與小寫、typage 產的私鑰是同一種編碼、壞的與別種前綴與長度不對都拒絕。18 通過
- `test_checklist.mjs`：限時一分鐘、從 `exportIdentity` 來、時間到自動關、鎖上與離開頁面收掉、B 端經 `keyFromIdentity` 再 `enrollDevice`、QR 交給 vendor、照片走 `createImageBitmap`、計時器不能拿來自動存。10 通過
- `check_vault_browser.mjs` 加一條：A 顯示、關掉與鎖上後畫面上沒有鑰匙、`WebAuthn.clearCredentials` 加清掉暫存區模擬 B、把 canvas 存成 PNG 餵給照片欄位、jsQR 解出鑰匙填進欄位、登錄後多一筆 credential、匯入 A 的密文用新 passkey 解得開兩項勾選。8 通過，截圖看過
- 三語系 `run*.sh` 零 WARNING，`check_precache.mjs` 通過，`docs_style_lint.py` 0 error 0 warn

## 跟其他 PR 的關係

跟 #465 都動 `checklist.js` 的字串表、動作列與 `check_vault_browser.mjs`，相鄰行會衝突。先合哪個都行，合了一個告訴我，我 rebase 另一個。跟 #464、#466 沒有重疊。

## 沒做的

- 即時相機沒做，B 端是拍一張照片。清單頁不用多開 getUserMedia 那條路
- 後量子的私鑰編碼不在這裡，暫存區的鑰匙永遠是 32 位元組的 X25519 那種

🤖 Generated with [Claude Code](https://claude.com/claude-code)