### PR TITLE
場景層攤平撰寫中分組，三篇內文已無撰寫中提示

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,8 +67,7 @@ nav:
               - tools/email-alias.md
               - tools/crypto-privacy-spectrum.md
               - tools/ai-privacy.md
-      # 順序與分組跟著 scenarios/index.md 的「已上線」「撰寫中」兩節走。撰寫中的頁面
-      # 目前是大綱加可用段落，收進獨立分組讓讀者點進去之前就知道。寫完了就移上來。
+      # 順序跟著 scenarios/index.md 的清單走。
       - !ENV [NAV_SCENARIOS, "場景"]:
           - scenarios/index.md
           - scenarios/everyday-baseline.md
@@ -80,10 +79,9 @@ nav:
           - scenarios/singapore-malaysia-speech.md
           - scenarios/asia-travel.md
           - scenarios/travel-ai-briefing.md
-          - "撰寫中（2026 Q3）":
-              - scenarios/shutdown.md
-              - scenarios/domestic-violence.md
-              - scenarios/election-observer.md
+          - scenarios/domestic-violence.md
+          - scenarios/election-observer.md
+          - scenarios/shutdown.md
       - !ENV [NAV_ADVANCED, "進階"]:
           - advanced/index.md
           - advanced/e2ee.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -67,8 +67,7 @@ nav:
               - tools/email-alias.md
               - tools/crypto-privacy-spectrum.md
               - tools/ai-privacy.md
-      # 顺序与分组跟着 scenarios/index.md 的「已上线」「撰写中」两节走。撰写中的页面
-      # 目前是大纲加可用段落，收进独立分组让读者点进去之前就知道。写完了就移上来。
+      # 顺序跟着 scenarios/index.md 的清单走。
       - !ENV [NAV_SCENARIOS, "场景"]:
           - scenarios/index.md
           - scenarios/everyday-baseline.md
@@ -80,10 +79,9 @@ nav:
           - scenarios/singapore-malaysia-speech.md
           - scenarios/asia-travel.md
           - scenarios/travel-ai-briefing.md
-          - "撰写中（2026 Q3）":
-              - scenarios/shutdown.md
-              - scenarios/domestic-violence.md
-              - scenarios/election-observer.md
+          - scenarios/domestic-violence.md
+          - scenarios/election-observer.md
+          - scenarios/shutdown.md
       - !ENV [NAV_ADVANCED, "进阶"]:
           - advanced/index.md
           - advanced/e2ee.md


### PR DESCRIPTION
## 問題

`docs/mkdocs.yml` 與 `docs/mkdocs_cn.yml` 把 `scenarios/shutdown.md`、`scenarios/domestic-violence.md`、`scenarios/election-observer.md` 收在巢狀分組「撰寫中（2026 Q3）」底下，但三篇內文的撰寫中提示框都已經移除。`shutdown.md` 是在 #471 補齊「中斷當下的工作方式」時拿掉的，那次沒有跟著改 nav，結果讀者在側欄點進去之前會先被告知是半成品。

## 改動

- 三篇攤平回場景層主清單，順序對齊 `scenarios/index.md` 的清單（domestic-violence、election-observer、shutdown 接在 travel-ai-briefing 之後）
- 分組上方的註解說順序跟著 `index.md` 的「已上線」「撰寫中」兩節走，但 `index.md` 現在只有單一的「目前的場景文章」清單，註解一併改掉
- `mkdocs_en.yml` 本來就是攤平寫法，這次不動

## 驗證

- `bash run.sh` 與 `bash run_zh-cn.sh` 皆 exit 0，0 個 ERROR
- 建置產物的 `scenarios/shutdown/index.html` 側欄已無「撰寫中（2026 Q3）」字樣

內容缺口的補強另開 PR 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)