### PR TITLE
fix(utils): 手機上的輸入欄位撐到 16px、觸控目標撐到 44px

### DIFF
--- a/docs/zh-TW/community/passkey-lab.md
+++ b/docs/zh-TW/community/passkey-lab.md
@@ -17,6 +17,51 @@ hide:
 
 `user.id` 是 WebAuthn 的核心欄位而不是擴充，規格上每次驗證都會原樣回傳。如果實作真的照規格走，它就是那條繞得過去的路。規格說可以跟實作真的給是兩回事，所以先在真機上量。
 
+<style>
+/*
+  這一頁原本一條樣式都沒寫。兩個按鈕靠 appendChild 接在一起，中間連空白字元都沒有，
+  在手機上就是兩個緊貼的目標。按鈕之間留間距，觸控目標給到 2.75rem（約 44 px，
+  觸控介面的建議下限），跟 vault-lab 那一頁同一個處理。
+  貼字串的欄位也沒有字級，落在瀏覽器給 input 的預設 13 px。iOS Safari 在輸入框字級
+  小於 16px 時一聚焦就放大整頁，而且不會縮回去，處理同 qrcode.js。
+*/
+#passkey-lab .pl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.1rem 0;
+  align-items: center;
+}
+#passkey-lab .pl-btn {
+  min-height: 2.75rem;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  cursor: pointer;
+}
+#passkey-lab .pl-label {
+  display: block;
+  margin: 1.2rem 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+#passkey-lab .pl-expect {
+  width: 100%;
+  margin-top: 0.4rem;
+  padding: 0.5rem;
+  font-family: var(--md-code-font-family, monospace);
+  font-size: max(16px, 0.78rem);
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+</style>
+
 <div id="passkey-lab"></div>
 <script src="../../js/passkey-lab.js"></script>
 

--- a/docs/zh-TW/community/vault-lab.md
+++ b/docs/zh-TW/community/vault-lab.md
@@ -127,7 +127,8 @@ offline_assets:
   margin-top: 0.4rem;
   padding: 0.6rem;
   font-family: var(--md-code-font-family, monospace);
-  font-size: 0.78rem;
+  /* iOS Safari 在輸入框字級小於 16px 時一聚焦就放大整頁，處理同 qrcode.js */
+  font-size: max(16px, 0.78rem);
   border: 1px solid var(--md-default-fg-color--lighter);
   border-radius: 0.4rem;
   background: var(--md-default-bg-color);
@@ -138,7 +139,8 @@ offline_assets:
 #vault-lab .vl-label input {
   width: 100%;
   padding: 0.5rem;
-  font-size: 0.78rem;
+  /* 同上，備援私鑰與密語欄位也要撐到 16px */
+  font-size: max(16px, 0.78rem);
   border: 1px solid var(--md-default-fg-color--lighter);
   border-radius: 0.4rem;
   background: var(--md-default-bg-color);

--- a/docs/zh-TW/js/agecrypt.js
+++ b/docs/zh-TW/js/agecrypt.js
@@ -370,7 +370,8 @@
     #age-tool label.ag-label { display: block; font-size: .74rem; margin: .8rem 0 .2rem; }
     #age-tool .ag-row { display: flex; flex-wrap: wrap; gap: .4rem; align-items: center; }
     #age-tool input[type="password"], #age-tool input[type="text"] {
-      font: inherit; font-size: .8rem; flex: 1; min-width: 12rem;
+      /* iOS Safari 在輸入框字級小於 16px 時一聚焦就放大整頁，處理同 qrcode.js */
+      font: inherit; font-size: max(16px, .8rem); flex: 1; min-width: 12rem;
       padding: .4rem .6rem; border: .05rem solid var(--md-default-fg-color--lighter);
       border-radius: .1rem; background: var(--md-default-bg-color); color: inherit;
     }
@@ -403,7 +404,8 @@
       margin: .8rem 0; font-size: .74rem; line-height: 1.7;
     }
     #age-tool textarea.ag-paste, #age-tool textarea.ag-out {
-      width: 100%; box-sizing: border-box; font-size: .74rem; line-height: 1.6;
+      /* iOS Safari 在輸入框字級小於 16px 時一聚焦就放大整頁，處理同 qrcode.js */
+      width: 100%; box-sizing: border-box; font-size: max(16px, .74rem); line-height: 1.6;
       font-family: var(--md-code-font-family, monospace); padding: .5rem .6rem;
       border: .05rem solid var(--md-default-fg-color--lighter); border-radius: .1rem;
       background: var(--md-code-bg-color); color: inherit; resize: vertical;

--- a/docs/zh-TW/js/checklist.js
+++ b/docs/zh-TW/js/checklist.js
@@ -90,10 +90,15 @@
     #checklist-tool .cl-qr { display: block; width: 12rem; max-width: 100%; height: auto; image-rendering: pixelated; background: #fff; margin: 0.6rem 0; }
     #checklist-tool .cl-label { display: block; margin: 0.6rem 0 0.3rem; font-size: 0.75rem; font-weight: 600; }
     #checklist-tool .cl-key {
-      width: 100%; padding: 0.5rem; font-family: var(--md-code-font-family, monospace); font-size: 0.72rem;
+      /* iOS Safari 在輸入框字級小於 16px 時一聚焦就放大整頁，處理同 qrcode.js */
+      width: 100%; padding: 0.5rem; font-family: var(--md-code-font-family, monospace); font-size: max(16px, 0.72rem);
       border: 1px solid var(--md-default-fg-color--lighter); border-radius: 0.4rem; background: var(--md-default-bg-color); color: var(--md-default-fg-color);
     }
-    @media (pointer: coarse) { #checklist-tool .cl-item input { width: 1.5rem; height: 1.5rem; } }
+    @media (pointer: coarse) {
+      #checklist-tool .cl-item input { width: 1.5rem; height: 1.5rem; }
+      /* 原生的檔案選擇器只有 22px 高，其他工具把它藏起來走拖放區，這裡是露在外面的 */
+      #checklist-tool .cl-file { min-height: 2.2rem; }
+    }
   `;
 
   // 清單的骨架。id 進了讀者的密文就不能改，改標籤與連結去 STRINGS。

--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -177,6 +177,11 @@
     #offline-library .ol-path__done { margin: 0; opacity: .7; }
     #offline-library .ol-path .ol-hint { margin: .3rem 0 0; }
     #offline-library .ol-paths ~ .ol-hint { margin-left: 0; }
+    /* 觸控裝置上把按鈕與整行的勾選標籤撐到約 44px，站上其他工具都有這一條，這一頁漏了 */
+    @media (pointer: coarse) {
+      #offline-library button { min-height: 2.2rem; }
+      #offline-library .ol-auto, #offline-library .ol-filter { padding: .5rem 0; }
+    }
   `;
   const style = document.createElement("style");
   // 規則寫的是 #offline-library，起步索引頁的根節點是 #start-offline，注入時換掉

--- a/docs/zh-TW/js/qrstream.js
+++ b/docs/zh-TW/js/qrstream.js
@@ -1486,6 +1486,11 @@
         font-family: monospace; font-size: 9pt; margin: 1mm 0 0; color: #000;
       }
     }
+    /* 觸控裝置上把按鈕撐到約 44px，站上其他工具都有這一條，這一頁漏了。
+       .qs-seg 與 .qs-tabs 的按鈕連在一起是分段控制的畫法，間距刻意留 0，只撐高度。 */
+    @media (pointer: coarse) {
+      #qr-stream-tool button { min-height: 2.2rem; }
+    }
   `;
 
   const dom = {};

--- a/docs/zh-TW/js/threatmodel.js
+++ b/docs/zh-TW/js/threatmodel.js
@@ -305,7 +305,8 @@
     #threatmodel-tool button[aria-busy="true"] { opacity: .7; }
     @media (pointer: coarse) {
       #threatmodel-tool button { min-height: 2.2rem; }
-      #threatmodel-tool label { padding: .4rem 0; }
+      /* .4rem 只撐到 42px，差 44px 的建議值兩格 */
+      #threatmodel-tool label { padding: .5rem 0; }
     }
   `;
   const style = document.createElement("style");


### PR DESCRIPTION
## 起因

在 iOS 上點小工具的輸入欄位，畫面會突然放大，之後版面就跟著亂掉。iOS Safari 的規則是輸入框字級小於 16px 時一聚焦就把整頁放大，而且不會縮回去。Material 的 rem 基準是 20px，站上工具寫的 `.74rem` 到 `.78rem` 換算成 14.8 到 15.6px，全部踩在門檻底下。cleanurl、hash、invisible、qrcode 四個工具在 #291 已經用 `max(16px, …)` 處理過，這次補完剩下的，順便把同一批頁面的觸控目標一起量了。

## 字級

用 headless Chrome 模擬 390×844，逐一讀每個 input、textarea、select 的 computed font-size。動態產生、要點按才出現的欄位用注入同 class 探針的方式量。

| 位置 | 欄位 | 原本 |
|---|---|---|
| `js/agecrypt.js` | `textarea.ag-paste`、`.ag-out`、`.ag-recipients` | 14.8px |
| `js/agecrypt.js` | 密語欄位 `input[type=password/text]` | 16px，壓在線上 |
| `js/checklist.js` | `.cl-key`，貼另一台裝置鑰匙字串的欄位 | 14.4px |
| `community/vault-lab.md` | `.vl-note`、`.vl-label input`（備援公鑰與備援私鑰） | 15.6px |
| `community/passkey-lab.md` | `.pl-expect` | 一條樣式都沒有，13.3px |

一律改成 `max(16px, 原值)`，桌機的視覺差在 1 到 2px 之間。不動 viewport 的 `user-scalable`，需要放大的讀者仍然放得大。

## 觸控目標

同一套模擬加上 `Emulation.setTouchEmulationEnabled`，讓 `@media (pointer: coarse)` 真的生效之後再量。判準用站上既有的 2.2rem 與 2.75rem 慣例，也就是約 44px。

| 位置 | 問題 |
|---|---|
| `js/qrstream.js` | 整份沒有 coarse 規則，13 顆按鈕停在 40 到 42px |
| `js/offline-library.js` | 整份沒有 coarse 規則，3 顆按鈕 40px，3 個整行勾選標籤 26px |
| `js/threatmodel.js` | 有規則，label 的 `.4rem` 只撐到 42px |
| `js/checklist.js` | 露在外面的原生檔案選擇器 `.cl-file` 只有 22px |
| `community/passkey-lab.md` | 兩顆按鈕靠 appendChild 接在一起，中間連空白字元都沒有 |

qr-stream 的 `.qs-tabs` 與 `.qs-seg` 按鈕彼此間距 0 沒有動。連在一起是分段控制的標準畫法，程式碼註解寫過理由，這次只撐高度。

`offline-library.js` 的樣式會被 `CSS.split("#offline-library").join("#" + root.id)` 換成起步索引頁的根節點，新規則跟著換，`/start/` 那頁一併複查過。

## 語系

zh-CN 與 en 的 js 是指向 zh-TW 的 symlink，改一份三語系都套用。vault-lab 與 passkey-lab 只有 zh-TW 版。

## 驗證

- 17 個工具頁面重掃，工具容器內可觸控元素的高度全部 44px 以上，字級小於 16px 的輸入欄位 0 個
- qr-stream、offline、passkey-lab、vault-lab、age 五頁在 390×844 截圖確認版面沒有被撐壞
- `run.sh` 建置 exit 0
- `docs_style_lint.py` 對兩份 md 都是 0 error

量測時站台的 service worker 會回舊版 js，`Network.setCacheDisabled` 擋不住，要另外送 `Network.setBypassServiceWorker` 才量得到改完的結果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)