### PR TITLE
fix(build): 移除誤 commit 的 docs/.cache symlink，部署建置因此失敗

### DIFF
--- a/docs/.cache
+++ b/docs/.cache
@@ -1,1 +1,0 @@
-/home/toomore/app/anoni-net-ws/anoni-net-docs/docs/.cache

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 output
 .cache/
+.cache
 anoni-net-docs-ipfs
 .python-version
 .DS_Store


### PR DESCRIPTION
## 症狀

推 `docs` 分支之後 `build_docs.yml` 的兩個 job 都失敗（[run 34164537065](https://github.com/anoni-net/docs/actions/runs/34164537065)）：

```
FileNotFoundError: [Errno 2] No such file or directory:
  /home/runner/work/docs/docs/docs/.cache/plugin
```

## 原因

#479 裡有一個 commit 用了 `git add docs tools`，把本機開發用的 `docs/.cache` symlink 一起收了進去。那個連結指向開發機上的絕對路徑，runner 上不存在，privacy 外掛開始寫快取時就中止。

`docs/.gitignore` 原本只有 `.cache/`，帶斜線的樣式只比對目錄，比不到 symlink，所以當時 `git status` 把它列成未追蹤（`?? docs/.cache`）而不是忽略，才會被 `git add docs` 收走。

PR 的 `lint`、`scan`、`tests` 三個 job 不跑完整的 mkdocs build，攔不到這個問題，只有推 `docs` 分支的部署建置會踩到。

## 改了什麼

- `git rm --cached docs/.cache`，把 symlink 從版本庫移除
- `docs/.gitignore` 補一行不帶斜線的 `.cache`，目錄與 symlink 兩種形式都擋掉

## 之後

合併後重推 `docs` 分支，站上內容目前還停在 `731fa9cd`，#479 與 #480 的內容尚未上線。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
