### PR TITLE
fix(nav): 窄螢幕抽屜不再顯示 GitHub repo 那一排

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -581,3 +581,24 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     font-size: 0.58rem;
   }
 }
+
+/* ==========================================================================
+   窄螢幕抽屜：隱藏 GitHub repo 那一排
+   套用範圍：抽屜裡的 .md-nav__source，桌面 header 與頁尾社群列不受影響
+
+   設了 repo_url 之後，partials/nav.html 會在抽屜標題底下放一個
+   .md-nav__source，內容是 repo 名稱與 star、fork 數，位置排在導覽清單之前。
+   讀者打開抽屜第一眼看到的就是那一排，而站上多數讀者沒有技術背景，
+   GitHub 的星數對他們沒有意義，還把「開始」、「指南」往下擠了一行。
+
+   Material 給這個元素的規則是單一 class 的 .md-nav__source，只在
+   max-width 那組媒體查詢裡開成 display:block。底下用兩個 class 的選擇器
+   把權重蓋過去，不跟著 theme 的斷點走，升級改了斷點也不會失效。
+
+   repo 連結沒有消失。桌面 header 從 60em 起照樣顯示，頁尾社群列的 GitHub
+   圖示在所有寬度都在。
+   ========================================================================== */
+
+.md-nav--primary .md-nav__source {
+  display: none;
+}

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -573,3 +573,24 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     font-size: 0.58rem;
   }
 }
+
+/* ==========================================================================
+   窄螢幕抽屜：隱藏 GitHub repo 那一排
+   套用範圍：抽屜裡的 .md-nav__source，桌面 header 與頁尾社群列不受影響
+
+   設了 repo_url 之後，partials/nav.html 會在抽屜標題底下放一個
+   .md-nav__source，內容是 repo 名稱與 star、fork 數，位置排在導覽清單之前。
+   讀者打開抽屜第一眼看到的就是那一排，而站上多數讀者沒有技術背景，
+   GitHub 的星數對他們沒有意義，還把「開始」、「指南」往下擠了一行。
+
+   Material 給這個元素的規則是單一 class 的 .md-nav__source，只在
+   max-width 那組媒體查詢裡開成 display:block。底下用兩個 class 的選擇器
+   把權重蓋過去，不跟著 theme 的斷點走，升級改了斷點也不會失效。
+
+   repo 連結沒有消失。桌面 header 從 60em 起照樣顯示，頁尾社群列的 GitHub
+   圖示在所有寬度都在。
+   ========================================================================== */
+
+.md-nav--primary .md-nav__source {
+  display: none;
+}

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -574,3 +574,24 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     font-size: 0.58rem;
   }
 }
+
+/* ==========================================================================
+   窄螢幕抽屜：隱藏 GitHub repo 那一排
+   套用範圍：抽屜裡的 .md-nav__source，桌面 header 與頁尾社群列不受影響
+
+   設了 repo_url 之後，partials/nav.html 會在抽屜標題底下放一個
+   .md-nav__source，內容是 repo 名稱與 star、fork 數，位置排在導覽清單之前。
+   讀者打開抽屜第一眼看到的就是那一排，而站上多數讀者沒有技術背景，
+   GitHub 的星數對他們沒有意義，還把「開始」、「指南」往下擠了一行。
+
+   Material 給這個元素的規則是單一 class 的 .md-nav__source，只在
+   max-width 那組媒體查詢裡開成 display:block。底下用兩個 class 的選擇器
+   把權重蓋過去，不跟著 theme 的斷點走，升級改了斷點也不會失效。
+
+   repo 連結沒有消失。桌面 header 從 60em 起照樣顯示，頁尾社群列的 GitHub
+   圖示在所有寬度都在。
+   ========================================================================== */
+
+.md-nav--primary .md-nav__source {
+  display: none;
+}


### PR DESCRIPTION
## 問題

設了 `repo_url` 之後，mkdocs-material 的 `partials/nav.html` 會在抽屜標題底下放一個 `.md-nav__source`，內容是 repo 名稱與 star、fork 數，位置排在導覽清單之前。

窄螢幕的讀者打開抽屜，第一眼看到的就是那一排（`匿名網路社群文件　26.09.02　★49　⑂7`），而站上多數讀者沒有技術背景，GitHub 的星數對他們沒有意義，還把「開始」、「指南」往下擠了一行。

## 做法

三份 `docs/<lang>/stylesheets/extra.css` 各補一條規則：

```css
.md-nav--primary .md-nav__source {
  display: none;
}
```

Material 給這個元素的規則是單一 class 的 `.md-nav__source`，預設 `display:none`，只在 `max-width: 76.234375em` 那組媒體查詢裡開成 `display:block`。上面用兩個 class 的選擇器把權重蓋過去，所以不必複製 theme 的斷點數字，升級改了斷點也不會失效。

沒有動 `overrides/`，theme 的 partial 維持原樣，升級時不用回頭對版本。

## repo 連結沒有消失

| 寬度 | 抽屜 `.md-nav__source` | header `.md-header__source` | 頁尾社群列 GitHub 圖示 |
|---|---|---|---|
| 390px | none | none（Material 預設） | 在 |
| 1100px | none | block | 在 |
| 1440px | none | block | 在 |

手機上仍然從頁尾社群列連得到 repo，桌面右上角照舊。

## 驗證

- Chrome CDP headless 量三個寬度的 computed style，結果如上表
- 390px 抽屜改前改後截圖比對，第一排從 GitHub 那一排換成「首頁」，沒有留下空隙
- 三語系都用 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 以 `-s` 嚴格模式建置，0 warning，產物的 `extra.css` 都含這條規則

🤖 Generated with [Claude Code](https://claude.com/claude-code)