### PR TITLE
feat(header): 窄螢幕把亮暗與語言收進右側設定抽屜

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -602,3 +602,255 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-nav--primary .md-nav__source {
   display: none;
 }
+
+/* ==========================================================================
+   窄螢幕的設定抽屜
+   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+
+   窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
+   40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
+   收進抽屜，header 只留一顆設定圖示與搜尋。搜尋留著，那是文件站最高頻的
+   動作，收進第二層等於每次多一次點擊。
+
+   收進抽屜還有一個空間以外的好處。那兩顆在 header 上都只有圖示沒有文字，
+   抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
+   並列，目前選的是哪一個直接看得到。
+
+   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
+   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
+   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
+   bundle.js 的 palette 都照常運作。
+
+   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
+   寬度夠，三顆並排不擠。
+   ========================================================================== */
+
+/* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
+.anoni-settings {
+  display: contents;
+}
+
+.anoni-settings__overlay,
+.anoni-settings__head,
+.anoni-settings__group,
+.anoni-settings__choice {
+  display: none;
+}
+
+/* Material 的 .md-header__button:not([hidden]) 是兩個 class 的權重，單靠
+   .anoni-settings__button 蓋不掉，桌面版會多出一顆設定圖示。 */
+.anoni-settings__button.md-header__button {
+  display: none;
+}
+
+/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
+   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+.anoni-site-name--short {
+  display: none;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
+  }
+
+  .anoni-site-name {
+    display: none;
+  }
+
+  .anoni-site-name--short {
+    display: inline;
+  }
+
+  /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊
+     環境，抽屜放到 header 外面會被 Material 的 .md-overlay（z-index 5）蓋住。
+     放在裡面之後，整個 header 開啟時提到 6，overlay 才遮得到 header 這一條，
+     讀者不會在抽屜開著的時候還按得到漢堡與搜尋。 */
+  #__settings:checked ~ .md-header {
+    z-index: 6;
+  }
+
+  .anoni-settings__overlay {
+    background-color: #0000008a;
+    display: block;
+    inset: 0;
+    opacity: 0;
+    position: fixed;
+    transition: opacity 0.25s, visibility 0ms 0.25s;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings__overlay {
+    opacity: 1;
+    transition: opacity 0.25s, visibility 0ms;
+    visibility: visible;
+  }
+
+  /* 關閉時用 visibility:hidden 把整個抽屜移出 tab 順序。留在畫面外但還可以
+     tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
+  .anoni-settings {
+    background-color: var(--md-default-bg-color);
+    bottom: 0;
+    display: block;
+    overflow-y: auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: translateX(100%);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms 0.25s;
+    visibility: hidden;
+    width: 12.1rem;
+    z-index: 2;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings {
+    transform: translateX(0);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms;
+    visibility: visible;
+  }
+
+  .anoni-settings__head {
+    align-items: center;
+    background-color: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color);
+    display: flex;
+    height: 2.4rem;
+    padding: 0 0.4rem 0 0.8rem;
+  }
+
+  .anoni-settings__title {
+    flex-grow: 1;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  .anoni-settings__close {
+    cursor: pointer;
+    padding: 0.4rem;
+  }
+
+  .anoni-settings__close svg {
+    display: block;
+    fill: currentcolor;
+    height: 1.2rem;
+    width: 1.2rem;
+  }
+
+  .anoni-settings__group {
+    color: var(--md-default-fg-color--light);
+    display: block;
+    font-size: 0.64rem;
+    font-weight: 700;
+    margin: 0;
+    padding: 0.8rem 0.8rem 0.2rem;
+  }
+
+  /* .md-header__option 在 header 裡是橫排，抽屜裡要直排。搜尋展開時 Material
+     會把它壓成 max-width:0，那條規則在抽屜裡也要擋掉，否則抽屜內容會消失。 */
+  .anoni-settings .md-header__option,
+  [data-md-toggle="search"]:checked ~ .md-header .anoni-settings .md-header__option {
+    display: block;
+    max-width: none;
+    opacity: 1;
+    transition: none;
+    white-space: normal;
+  }
+
+  /* header 上那顆循環切換的圖示按鈕在抽屜裡沒有用處，三個選項已經並列 */
+  .anoni-settings .md-header__option > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings__choice {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
+  }
+
+  .anoni-settings__choice-text {
+    flex-grow: 1;
+  }
+
+  .anoni-settings__choice-mark {
+    display: block;
+    opacity: 0;
+  }
+
+  .anoni-settings__choice-mark svg {
+    display: block;
+    fill: var(--md-accent-fg-color);
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  /* 目前選的是哪一個，看上游那顆循環 label 的 hidden。bundle.js 每次換配色都會
+     把 index 對應的那一顆解除 hidden，其餘關掉，所以它一定跟著現況走。
+
+     不綁 input 的 :checked，因為第一次進站三顆 radio 都還沒被勾選（配色是從
+     localStorage 或 prefers-color-scheme 算出來的），綁 :checked 會整排沒有勾號。
+
+     順序是 input、循環 label、抽屜選項，由 palette.html 固定，中間不能插東西。 */
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice {
+    color: var(--md-accent-fg-color);
+  }
+
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice .anoni-settings__choice-mark {
+    opacity: 1;
+  }
+
+  /* 語言切換在 header 是滑過才展開的下拉，抽屜裡直接把清單攤開 */
+  /* .md-select__inner 在 header 是 position:absolute 的浮層，靠 hover 才展開。
+     抽屜裡要它回到文件流，位置與動畫那一整組都得歸零，只留清單本身。 */
+  .anoni-settings .md-select__inner {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    left: auto;
+    margin-top: 0;
+    max-height: none;
+    opacity: 1;
+    position: static;
+    top: auto;
+    transform: none;
+    transition: none;
+    z-index: auto;
+  }
+
+  .anoni-settings .md-select__inner::after {
+    display: none;
+  }
+
+  .anoni-settings .md-select {
+    display: block;
+  }
+
+  .anoni-settings .md-select > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings .md-select__list {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    max-height: none;
+    overflow: visible;
+  }
+
+  /* .md-select__item 帶 1.8rem 的 line-height，加上連結自己的 padding，兩個
+     語言之間會空出比外觀那三項多一倍的距離。 */
+  .anoni-settings .md-select__item {
+    line-height: 1.4;
+  }
+
+  .anoni-settings .md-select__link {
+    color: var(--md-default-fg-color);
+    font-size: 0.7rem;
+    padding: 0.5rem 0.8rem;
+    width: 100%;
+  }
+}

--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -630,6 +630,11 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: contents;
 }
 
+/* 語言名稱前面的字形圖示只在抽屜出現，桌面的下拉選單維持純文字 */
+.anoni-lang__icon {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -776,6 +781,18 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     flex-grow: 1;
   }
 
+  .anoni-settings__choice-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__choice-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
   .anoni-settings__choice-mark {
     display: block;
     opacity: 0;
@@ -847,10 +864,26 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     line-height: 1.4;
   }
 
+  /* 跟外觀那三項共用一組左側圖示欄，兩組並排時對得起來 */
   .anoni-settings .md-select__link {
+    align-items: center;
     color: var(--md-default-fg-color);
+    display: flex;
     font-size: 0.7rem;
+    gap: 0.4rem;
     padding: 0.5rem 0.8rem;
     width: 100%;
+  }
+
+  .anoni-settings .anoni-lang__icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings .anoni-lang__icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
   }
 }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -284,6 +284,13 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "亮色"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "暗色"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "閱讀語言"]
+  # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
+  # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。
+  # 圖示不分語系，三份設定填一樣的值，也就不需要 !ENV。
+  settings_appearance_icons:
+    - material/brightness-auto
+    - material/white-balance-sunny
+    - material/weather-night
   # 窄螢幕的短站名，理由見 partials/header.html。留空就照舊顯示完整 site_name。
   site_name_short: !ENV [SITE_NAME_SHORT, "匿名網路社群"]
   # 建在根路徑、網址上沒有語系區段的那一個語系。三份設定填的是同一個值，因為講的是
@@ -301,12 +308,15 @@ extra:
     - name: 臺灣正體（zh-TW）
       link: /docs/
       lang: zh-TW
+      icon: material/ideogram-cjk
     - name: 簡體中文（zh-CN）
       link: /docs/zh-cn/
       lang: zh-CN
+      icon: material/ideogram-cjk
     - name: English (en-US)
       link: /docs/en/
       lang: en
+      icon: material/alphabet-latin
   social:
     - icon: material/home
       link: https://anoni.net/docs/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -272,6 +272,20 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 窄螢幕設定抽屜的文案。partials/header.html 與 partials/palette.html 是三個
+  # 語系共用的符號連結，文字只能走設定，跟上面 variant_label_* 是同一個理由。
+  # settings_appearance_options 的順序要跟 theme.palette 一致，目前是跟隨系統、
+  # 亮色、暗色三個。多一個或少一個選項，partial 會退回上游的 toggle.name。
+  settings_label: !ENV [SETTINGS_LABEL, "設定"]
+  settings_close: !ENV [SETTINGS_CLOSE, "關閉"]
+  settings_appearance: !ENV [SETTINGS_APPEARANCE, "外觀"]
+  settings_appearance_options:
+    - !ENV [SETTINGS_APPEARANCE_AUTO, "跟隨系統"]
+    - !ENV [SETTINGS_APPEARANCE_LIGHT, "亮色"]
+    - !ENV [SETTINGS_APPEARANCE_DARK, "暗色"]
+  settings_language: !ENV [SETTINGS_LANGUAGE, "閱讀語言"]
+  # 窄螢幕的短站名，理由見 partials/header.html。留空就照舊顯示完整 site_name。
+  site_name_short: !ENV [SITE_NAME_SHORT, "匿名網路社群"]
   # 建在根路徑、網址上沒有語系區段的那一個語系。三份設定填的是同一個值，因為講的是
   # 這個部署長什麼樣，跟正在建哪一份無關。base.html 的偏好轉址只在這個語系的首頁動手，
   # /docs/en/ 那種網址上已經指定過語系的入口不受偏好影響。

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -263,6 +263,13 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "浅色"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "深色"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "阅读语言"]
+  # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
+  # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。
+  # 圖示不分語系，三份設定填一樣的值，也就不需要 !ENV。
+  settings_appearance_icons:
+    - material/brightness-auto
+    - material/white-balance-sunny
+    - material/weather-night
   # 窄屏幕的短站名，理由见 partials/header.html。留空就照旧显示完整 site_name。
   site_name_short: !ENV [SITE_NAME_SHORT, "匿名网络社群"]
   # 建在根路徑、網址上沒有語系區段的那一個語系，三份設定同一個值，理由見 mkdocs.yml。
@@ -275,12 +282,15 @@ extra:
     - name: 臺灣正體（zh-TW）
       link: /docs/
       lang: zh-TW
+      icon: material/ideogram-cjk
     - name: 简体中文（zh-CN）
       link: /docs/zh-cn/
       lang: zh-CN
+      icon: material/ideogram-cjk
     - name: English (en-US)
       link: /docs/en/
       lang: en
+      icon: material/alphabet-latin
   social:
     - icon: material/home
       link: https://anoni.net/docs/

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -251,6 +251,20 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # 窄屏幕设置抽屉的文案。partials/header.html 与 partials/palette.html 是三个
+  # 语系共用的符号链接，文字只能走设置，跟上面 variant_label_* 是同一个理由。
+  # settings_appearance_options 的顺序要跟 theme.palette 一致，目前是跟随系统、
+  # 浅色、深色三个。多一个或少一个选项，partial 会退回上游的 toggle.name。
+  settings_label: !ENV [SETTINGS_LABEL, "设置"]
+  settings_close: !ENV [SETTINGS_CLOSE, "关闭"]
+  settings_appearance: !ENV [SETTINGS_APPEARANCE, "外观"]
+  settings_appearance_options:
+    - !ENV [SETTINGS_APPEARANCE_AUTO, "跟随系统"]
+    - !ENV [SETTINGS_APPEARANCE_LIGHT, "浅色"]
+    - !ENV [SETTINGS_APPEARANCE_DARK, "深色"]
+  settings_language: !ENV [SETTINGS_LANGUAGE, "阅读语言"]
+  # 窄屏幕的短站名，理由见 partials/header.html。留空就照旧显示完整 site_name。
+  site_name_short: !ENV [SITE_NAME_SHORT, "匿名网络社群"]
   # 建在根路徑、網址上沒有語系區段的那一個語系，三份設定同一個值，理由見 mkdocs.yml。
   default_lang: zh-TW
   # 這份產物是哪一個語系，語言切換器拿它把「目前語系」那一項藏起來。值對齊底下

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -267,6 +267,14 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "Light"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "Dark"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "Reading language"]
+  # Icons for the three appearance options in the drawer, same order as theme.palette.
+  # The upstream toggle.icon says "what this switches to", the drawer needs "what this
+  # option is", so they are listed separately. Icons are not localised, all three
+  # configs carry the same values, hence no !ENV.
+  settings_appearance_icons:
+    - material/brightness-auto
+    - material/white-balance-sunny
+    - material/weather-night
   # Short site name for narrow screens, see partials/header.html. Leave empty
   # to keep the full site_name.
   site_name_short: !ENV [SITE_NAME_SHORT, "anoni.net Docs"]
@@ -280,13 +288,16 @@ extra:
     - name: English (en-US)
       link: /docs/en/
       lang: en
+      icon: material/alphabet-latin
     # zh-TW 是網站預設語系，建在根路徑，沒有獨立語系區段。理由見 mkdocs.yml 的註解。
     - name: 臺灣正體（zh-TW）
       link: /docs/
       lang: zh-TW
+      icon: material/ideogram-cjk
     - name: 簡體中文（zh-CN）
       link: /docs/zh-cn/
       lang: zh-CN
+      icon: material/ideogram-cjk
   social:
     - icon: material/home
       link: https://anoni.net/docs/en/

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -254,6 +254,22 @@ extra:
   # 跟 NAV_* 那組是同一套做法。header.html 是三個語系共用的符號連結，文案只能走設定。
   variant_label_onion: !ENV [VARIANT_LABEL_ONION, "Onion 版本"]
   variant_label_ipfs: !ENV [VARIANT_LABEL_IPFS, "IPFS 鏡像"]
+  # Copy for the narrow-screen settings drawer. partials/header.html and
+  # partials/palette.html are symlinks shared by all three languages, so the
+  # strings have to come from config, same reason as variant_label_* above.
+  # Keep settings_appearance_options in the same order as theme.palette:
+  # follow system, light, dark. A mismatched length falls back to toggle.name.
+  settings_label: !ENV [SETTINGS_LABEL, "Settings"]
+  settings_close: !ENV [SETTINGS_CLOSE, "Close"]
+  settings_appearance: !ENV [SETTINGS_APPEARANCE, "Appearance"]
+  settings_appearance_options:
+    - !ENV [SETTINGS_APPEARANCE_AUTO, "Follow system"]
+    - !ENV [SETTINGS_APPEARANCE_LIGHT, "Light"]
+    - !ENV [SETTINGS_APPEARANCE_DARK, "Dark"]
+  settings_language: !ENV [SETTINGS_LANGUAGE, "Reading language"]
+  # Short site name for narrow screens, see partials/header.html. Leave empty
+  # to keep the full site_name.
+  site_name_short: !ENV [SITE_NAME_SHORT, "anoni.net Docs"]
   # 建在根路徑、網址上沒有語系區段的那一個語系，三份設定同一個值，理由見 mkdocs.yml。
   # 底下 alternate 把 English 排第一是選單的版面安排，跟這裡無關。
   default_lang: zh-TW

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -249,6 +249,12 @@
     {% set features = config.theme.features or [] %}
     <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    {#-
+      窄螢幕設定抽屜的開關。抽屜本體與它的 overlay 在 partials/header.html，
+      理由寫在那裡。放在這裡是因為 extra.css 要用 #__settings:checked ~ .md-header
+      這種同層選擇器抓到 header，跟上面兩個 toggle 是同一套做法。
+    -#}
+    <input class="md-toggle" data-md-toggle="settings" type="checkbox" id="__settings" autocomplete="off">
     <label class="md-overlay" for="__drawer"></label>
     <div data-md-component="skip">
       {% if page.toc | first is defined %}
@@ -790,6 +796,20 @@
           banner.appendChild(line);
           banner.appendChild(actions);
           dismiss = window.__anoniToast(banner);
+        })();
+      </script>
+      <script>
+        // 設定抽屜按 Esc 關掉。開合本身是 #__settings 這顆 checkbox，關掉 JS 也
+        // 能用 header 的圖示與 overlay 操作，這一段只是把鍵盤的習慣補上，跟
+        // Material 給左側抽屜與搜尋的 Esc 行為對齊。
+        (function () {
+          var toggle = document.getElementById("__settings");
+          if (!toggle) return;
+          document.addEventListener("keydown", function (event) {
+            if (event.key === "Escape" && toggle.checked) {
+              toggle.checked = false;
+            }
+          });
         })();
       </script>
     {% endblock %}

--- a/docs/overrides/partials/alternate.html
+++ b/docs/overrides/partials/alternate.html
@@ -16,14 +16,25 @@
       <ul class="md-select__list">
         {% for alt in config.extra.alternate %}
           <li class="md-select__item"{% if alt.lang == config.extra.current_lang %} hidden{% endif %}>
+            {#-
+              語言名稱外面包一層 span，前面多一個字形圖示，給窄螢幕的設定抽屜用。
+              圖示走 extra.alternate 的 icon，沒填就退回切換器自己那顆。桌面的下拉
+              選單維持純文字，圖示由 extra.css 在抽屜的斷點裡才顯示。
+
+              圖示放在連結裡面不影響 base.html 讀語系清單。它取的是
+              a.textContent.trim()，SVG 不帶文字節點，剩下的空白 trim 掉就是名稱。
+            -#}
+            {% set alt_icon = alt.icon or icon %}
             {% if page is defined and page %}
               {% set base = alt.link.rstrip('/') %}
               <a href="{{ (base ~ '/' ~ page.url) | url }}" hreflang="{{ alt.lang }}" class="md-select__link">
-                {{ alt.name }}
+                <span class="anoni-lang__icon">{% include ".icons/" ~ alt_icon ~ ".svg" %}</span>
+                <span class="anoni-lang__name">{{ alt.name }}</span>
               </a>
             {% else %}
               <a href="{{ alt.link }}" hreflang="{{ alt.lang }}" class="md-select__link">
-                {{ alt.name }}
+                <span class="anoni-lang__icon">{% include ".icons/" ~ alt_icon ~ ".svg" %}</span>
+                <span class="anoni-lang__name">{{ alt.name }}</span>
               </a>
             {% endif %}
           </li>

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -21,9 +21,20 @@
     </label>
     <div class="md-header__title" data-md-component="header-title">
       <div class="md-header__ellipsis">
+        {#-
+          窄螢幕換一個短站名。完整站名在 390px 上要 236px，標題那一格收掉亮暗與
+          語言兩顆圖示之後有 178px，還是會截成「匿名網路社群 …」。短站名走
+          config.extra，沒設就照舊用 site_name。捲動之後 Material 換成下面那個
+          頁面標題，這一段只影響停在頂端的時候。
+        -#}
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            {{ config.site_name }}
+            {% if config.extra.site_name_short %}
+              <span class="anoni-site-name">{{ config.site_name }}</span>
+              <span class="anoni-site-name--short">{{ config.extra.site_name_short }}</span>
+            {% else %}
+              {{ config.site_name }}
+            {% endif %}
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -62,17 +73,49 @@
         <span class="anoni-variant__label">{{ variant_label }}</span>
       </a>
     {% endif %}
-    {% if config.theme.palette %}
-      {% if not config.theme.palette is mapping %}
-        {% include "partials/palette.html" %}
+    {#-
+      窄螢幕的設定抽屜。亮暗切換與語言切換在窄螢幕上是兩顆沒有文字的圖示，讀者
+      不見得認得，而且它們常駐在右側，390px 上標題只剩 130px。兩者都收進從右側
+      滑出的抽屜，header 上只留一顆設定圖示與搜尋。搜尋留在 header，那是文件站
+      最高頻的動作，多一層就是每次多一次點擊。
+
+      .anoni-settings 在桌面是 display:contents，palette 與語言切換照樣直接排進
+      header 的 flex，DOM 只有一份。窄螢幕才變成 position:fixed 的抽屜。斷點取
+      Material 自己的 mobile 上限 44.9375em。
+
+      開合靠 base.html 的 #__settings checkbox，純 HTML 加 CSS，Tor Browser 把
+      JS 關到最嚴也開得起來，跟底下 anoni-variant 那段是同一個理由。
+
+      overlay 與抽屜都放在 .md-header__inner 裡面。.md-header 是 z-index 4 的
+      堆疊環境，抽屜放到 header 外面就一定被 .md-overlay（z-index 5）蓋住，放在
+      裡面才有辦法讓 overlay 連 header 這一條也遮起來。開啟時 extra.css 把
+      .md-header 提到 z-index 6。
+    -#}
+    <label class="anoni-settings__overlay" for="__settings"></label>
+    <div class="anoni-settings">
+      <div class="anoni-settings__head">
+        <span class="anoni-settings__title">{{ config.extra.settings_label }}</span>
+        <label class="anoni-settings__close md-icon" for="__settings" title="{{ config.extra.settings_close }}" aria-label="{{ config.extra.settings_close }}">
+          {% include ".icons/material/close.svg" %}
+        </label>
+      </div>
+      {% if config.theme.palette %}
+        {% if not config.theme.palette is mapping %}
+          <p class="anoni-settings__group">{{ config.extra.settings_appearance }}</p>
+          {% include "partials/palette.html" %}
+        {% endif %}
       {% endif %}
-    {% endif %}
+      {% if config.extra.alternate %}
+        <p class="anoni-settings__group">{{ config.extra.settings_language }}</p>
+        {% include "partials/alternate.html" %}
+      {% endif %}
+    </div>
     {% if not config.theme.palette is mapping %}
       {% include "partials/javascripts/palette.html" %}
     {% endif %}
-    {% if config.extra.alternate %}
-      {% include "partials/alternate.html" %}
-    {% endif %}
+    <label class="anoni-settings__button md-header__button md-icon" for="__settings" title="{{ config.extra.settings_label }}" aria-label="{{ config.extra.settings_label }}">
+      {% include ".icons/material/tune-variant.svg" %}
+    </label>
     {% if "material/search" in config.plugins %}
       {% set search = config.plugins["material/search"] | attr("config") %}
       {% if search.enabled %}

--- a/docs/overrides/partials/palette.html
+++ b/docs/overrides/partials/palette.html
@@ -26,7 +26,15 @@
         {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
       </label>
       {% set choices = config.extra.settings_appearance_options %}
+      {% set icons = config.extra.settings_appearance_icons %}
       <label class="anoni-settings__choice" for="__palette_{{ loop.index0 }}">
+        <span class="anoni-settings__choice-icon">
+          {%- if icons and icons | length > loop.index0 -%}
+            {% include ".icons/" ~ icons[loop.index0] ~ ".svg" %}
+          {%- else -%}
+            {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+          {%- endif -%}
+        </span>
         <span class="anoni-settings__choice-text">
           {%- if choices and choices | length > loop.index0 -%}
             {{ choices[loop.index0] }}

--- a/docs/overrides/partials/palette.html
+++ b/docs/overrides/partials/palette.html
@@ -1,0 +1,43 @@
+{#-
+  Fork of mkdocs-material partials/palette.html: 每個選項多一顆直接指定的 label，
+  給窄螢幕的設定抽屜用。
+
+  上游那顆 label 的 for 指向下一個選項，點一下換下一個，讀者要從圖示反推目前是
+  哪個狀態。抽屜裡要的是三個並列，點哪個就是哪個，所以另外加一顆 for 指向自己的
+  label。桌面版把新加的那顆藏起來，維持原本的循環按鈕。
+
+  新加的 label 一定要排在上游那顆後面。bundle.js 用 input.nextElementSibling
+  找上游那顆來切 hidden（palette 的 index 一變就重算），插到前面會被它當成圖示
+  按鈕關掉。extra.css 的勾號規則也靠 input + label + label 這個順序。
+
+  選項名稱走 config.extra.settings_appearance_options，因為這支 partial 是三個
+  語系共用的符號連結。順序跟 theme.palette 一致，沒設就退回上游的 toggle.name。
+
+  theme-partial-from: mkdocs-material 9.7.7
+-#}
+<form class="md-header__option" data-md-component="palette">
+  {% for option in config.theme.palette %}
+    {% set scheme  = option.scheme  | d("default", true) %}
+    {% set primary = option.primary | d("indigo", true) %}
+    {% set accent  = option.accent  | d("indigo", true) %}
+    <input class="md-option" data-md-color-media="{{ option.media }}" data-md-color-scheme="{{ scheme | replace(' ', '-') }}" data-md-color-primary="{{ primary | replace(' ', '-') }}" data-md-color-accent="{{ accent | replace(' ', '-') }}" {% if option.toggle %} aria-label="{{ option.toggle.name }}" {% else %} aria-hidden="true" {% endif %} type="radio" name="__palette" id="__palette_{{ loop.index0 }}">
+    {% if option.toggle %}
+      <label class="md-header__button md-icon" title="{{ option.toggle.name }}" for="__palette_{{ loop.index % loop.length }}" hidden>
+        {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+      </label>
+      {% set choices = config.extra.settings_appearance_options %}
+      <label class="anoni-settings__choice" for="__palette_{{ loop.index0 }}">
+        <span class="anoni-settings__choice-text">
+          {%- if choices and choices | length > loop.index0 -%}
+            {{ choices[loop.index0] }}
+          {%- else -%}
+            {{ option.toggle.name }}
+          {%- endif -%}
+        </span>
+        <span class="anoni-settings__choice-mark">
+          {% include ".icons/material/check.svg" %}
+        </span>
+      </label>
+    {% endif %}
+  {% endfor %}
+</form>

--- a/docs/overrides_cn/partials/palette.html
+++ b/docs/overrides_cn/partials/palette.html
@@ -1,0 +1,1 @@
+../../overrides/partials/palette.html

--- a/docs/overrides_en/partials/palette.html
+++ b/docs/overrides_en/partials/palette.html
@@ -1,0 +1,1 @@
+../../overrides/partials/palette.html

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -622,6 +622,11 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: contents;
 }
 
+/* 語言名稱前面的字形圖示只在抽屜出現，桌面的下拉選單維持純文字 */
+.anoni-lang__icon {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -768,6 +773,18 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     flex-grow: 1;
   }
 
+  .anoni-settings__choice-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__choice-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
   .anoni-settings__choice-mark {
     display: block;
     opacity: 0;
@@ -839,10 +856,26 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     line-height: 1.4;
   }
 
+  /* 跟外觀那三項共用一組左側圖示欄，兩組並排時對得起來 */
   .anoni-settings .md-select__link {
+    align-items: center;
     color: var(--md-default-fg-color);
+    display: flex;
     font-size: 0.7rem;
+    gap: 0.4rem;
     padding: 0.5rem 0.8rem;
     width: 100%;
+  }
+
+  .anoni-settings .anoni-lang__icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings .anoni-lang__icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
   }
 }

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -594,3 +594,255 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-nav--primary .md-nav__source {
   display: none;
 }
+
+/* ==========================================================================
+   窄螢幕的設定抽屜
+   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+
+   窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
+   40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
+   收進抽屜，header 只留一顆設定圖示與搜尋。搜尋留著，那是文件站最高頻的
+   動作，收進第二層等於每次多一次點擊。
+
+   收進抽屜還有一個空間以外的好處。那兩顆在 header 上都只有圖示沒有文字，
+   抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
+   並列，目前選的是哪一個直接看得到。
+
+   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
+   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
+   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
+   bundle.js 的 palette 都照常運作。
+
+   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
+   寬度夠，三顆並排不擠。
+   ========================================================================== */
+
+/* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
+.anoni-settings {
+  display: contents;
+}
+
+.anoni-settings__overlay,
+.anoni-settings__head,
+.anoni-settings__group,
+.anoni-settings__choice {
+  display: none;
+}
+
+/* Material 的 .md-header__button:not([hidden]) 是兩個 class 的權重，單靠
+   .anoni-settings__button 蓋不掉，桌面版會多出一顆設定圖示。 */
+.anoni-settings__button.md-header__button {
+  display: none;
+}
+
+/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
+   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+.anoni-site-name--short {
+  display: none;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
+  }
+
+  .anoni-site-name {
+    display: none;
+  }
+
+  .anoni-site-name--short {
+    display: inline;
+  }
+
+  /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊
+     環境，抽屜放到 header 外面會被 Material 的 .md-overlay（z-index 5）蓋住。
+     放在裡面之後，整個 header 開啟時提到 6，overlay 才遮得到 header 這一條，
+     讀者不會在抽屜開著的時候還按得到漢堡與搜尋。 */
+  #__settings:checked ~ .md-header {
+    z-index: 6;
+  }
+
+  .anoni-settings__overlay {
+    background-color: #0000008a;
+    display: block;
+    inset: 0;
+    opacity: 0;
+    position: fixed;
+    transition: opacity 0.25s, visibility 0ms 0.25s;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings__overlay {
+    opacity: 1;
+    transition: opacity 0.25s, visibility 0ms;
+    visibility: visible;
+  }
+
+  /* 關閉時用 visibility:hidden 把整個抽屜移出 tab 順序。留在畫面外但還可以
+     tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
+  .anoni-settings {
+    background-color: var(--md-default-bg-color);
+    bottom: 0;
+    display: block;
+    overflow-y: auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: translateX(100%);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms 0.25s;
+    visibility: hidden;
+    width: 12.1rem;
+    z-index: 2;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings {
+    transform: translateX(0);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms;
+    visibility: visible;
+  }
+
+  .anoni-settings__head {
+    align-items: center;
+    background-color: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color);
+    display: flex;
+    height: 2.4rem;
+    padding: 0 0.4rem 0 0.8rem;
+  }
+
+  .anoni-settings__title {
+    flex-grow: 1;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  .anoni-settings__close {
+    cursor: pointer;
+    padding: 0.4rem;
+  }
+
+  .anoni-settings__close svg {
+    display: block;
+    fill: currentcolor;
+    height: 1.2rem;
+    width: 1.2rem;
+  }
+
+  .anoni-settings__group {
+    color: var(--md-default-fg-color--light);
+    display: block;
+    font-size: 0.64rem;
+    font-weight: 700;
+    margin: 0;
+    padding: 0.8rem 0.8rem 0.2rem;
+  }
+
+  /* .md-header__option 在 header 裡是橫排，抽屜裡要直排。搜尋展開時 Material
+     會把它壓成 max-width:0，那條規則在抽屜裡也要擋掉，否則抽屜內容會消失。 */
+  .anoni-settings .md-header__option,
+  [data-md-toggle="search"]:checked ~ .md-header .anoni-settings .md-header__option {
+    display: block;
+    max-width: none;
+    opacity: 1;
+    transition: none;
+    white-space: normal;
+  }
+
+  /* header 上那顆循環切換的圖示按鈕在抽屜裡沒有用處，三個選項已經並列 */
+  .anoni-settings .md-header__option > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings__choice {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
+  }
+
+  .anoni-settings__choice-text {
+    flex-grow: 1;
+  }
+
+  .anoni-settings__choice-mark {
+    display: block;
+    opacity: 0;
+  }
+
+  .anoni-settings__choice-mark svg {
+    display: block;
+    fill: var(--md-accent-fg-color);
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  /* 目前選的是哪一個，看上游那顆循環 label 的 hidden。bundle.js 每次換配色都會
+     把 index 對應的那一顆解除 hidden，其餘關掉，所以它一定跟著現況走。
+
+     不綁 input 的 :checked，因為第一次進站三顆 radio 都還沒被勾選（配色是從
+     localStorage 或 prefers-color-scheme 算出來的），綁 :checked 會整排沒有勾號。
+
+     順序是 input、循環 label、抽屜選項，由 palette.html 固定，中間不能插東西。 */
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice {
+    color: var(--md-accent-fg-color);
+  }
+
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice .anoni-settings__choice-mark {
+    opacity: 1;
+  }
+
+  /* 語言切換在 header 是滑過才展開的下拉，抽屜裡直接把清單攤開 */
+  /* .md-select__inner 在 header 是 position:absolute 的浮層，靠 hover 才展開。
+     抽屜裡要它回到文件流，位置與動畫那一整組都得歸零，只留清單本身。 */
+  .anoni-settings .md-select__inner {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    left: auto;
+    margin-top: 0;
+    max-height: none;
+    opacity: 1;
+    position: static;
+    top: auto;
+    transform: none;
+    transition: none;
+    z-index: auto;
+  }
+
+  .anoni-settings .md-select__inner::after {
+    display: none;
+  }
+
+  .anoni-settings .md-select {
+    display: block;
+  }
+
+  .anoni-settings .md-select > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings .md-select__list {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    max-height: none;
+    overflow: visible;
+  }
+
+  /* .md-select__item 帶 1.8rem 的 line-height，加上連結自己的 padding，兩個
+     語言之間會空出比外觀那三項多一倍的距離。 */
+  .anoni-settings .md-select__item {
+    line-height: 1.4;
+  }
+
+  .anoni-settings .md-select__link {
+    color: var(--md-default-fg-color);
+    font-size: 0.7rem;
+    padding: 0.5rem 0.8rem;
+    width: 100%;
+  }
+}

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -623,6 +623,11 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: contents;
 }
 
+/* 語言名稱前面的字形圖示只在抽屜出現，桌面的下拉選單維持純文字 */
+.anoni-lang__icon {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -769,6 +774,18 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     flex-grow: 1;
   }
 
+  .anoni-settings__choice-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__choice-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
   .anoni-settings__choice-mark {
     display: block;
     opacity: 0;
@@ -840,10 +857,26 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     line-height: 1.4;
   }
 
+  /* 跟外觀那三項共用一組左側圖示欄，兩組並排時對得起來 */
   .anoni-settings .md-select__link {
+    align-items: center;
     color: var(--md-default-fg-color);
+    display: flex;
     font-size: 0.7rem;
+    gap: 0.4rem;
     padding: 0.5rem 0.8rem;
     width: 100%;
+  }
+
+  .anoni-settings .anoni-lang__icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings .anoni-lang__icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
   }
 }

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -595,3 +595,255 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .md-nav--primary .md-nav__source {
   display: none;
 }
+
+/* ==========================================================================
+   窄螢幕的設定抽屜
+   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+
+   窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
+   40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
+   收進抽屜，header 只留一顆設定圖示與搜尋。搜尋留著，那是文件站最高頻的
+   動作，收進第二層等於每次多一次點擊。
+
+   收進抽屜還有一個空間以外的好處。那兩顆在 header 上都只有圖示沒有文字，
+   抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
+   並列，目前選的是哪一個直接看得到。
+
+   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
+   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
+   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
+   bundle.js 的 palette 都照常運作。
+
+   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
+   寬度夠，三顆並排不擠。
+   ========================================================================== */
+
+/* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
+.anoni-settings {
+  display: contents;
+}
+
+.anoni-settings__overlay,
+.anoni-settings__head,
+.anoni-settings__group,
+.anoni-settings__choice {
+  display: none;
+}
+
+/* Material 的 .md-header__button:not([hidden]) 是兩個 class 的權重，單靠
+   .anoni-settings__button 蓋不掉，桌面版會多出一顆設定圖示。 */
+.anoni-settings__button.md-header__button {
+  display: none;
+}
+
+/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
+   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+.anoni-site-name--short {
+  display: none;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
+  }
+
+  .anoni-site-name {
+    display: none;
+  }
+
+  .anoni-site-name--short {
+    display: inline;
+  }
+
+  /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊
+     環境，抽屜放到 header 外面會被 Material 的 .md-overlay（z-index 5）蓋住。
+     放在裡面之後，整個 header 開啟時提到 6，overlay 才遮得到 header 這一條，
+     讀者不會在抽屜開著的時候還按得到漢堡與搜尋。 */
+  #__settings:checked ~ .md-header {
+    z-index: 6;
+  }
+
+  .anoni-settings__overlay {
+    background-color: #0000008a;
+    display: block;
+    inset: 0;
+    opacity: 0;
+    position: fixed;
+    transition: opacity 0.25s, visibility 0ms 0.25s;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings__overlay {
+    opacity: 1;
+    transition: opacity 0.25s, visibility 0ms;
+    visibility: visible;
+  }
+
+  /* 關閉時用 visibility:hidden 把整個抽屜移出 tab 順序。留在畫面外但還可以
+     tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
+  .anoni-settings {
+    background-color: var(--md-default-bg-color);
+    bottom: 0;
+    display: block;
+    overflow-y: auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: translateX(100%);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms 0.25s;
+    visibility: hidden;
+    width: 12.1rem;
+    z-index: 2;
+  }
+
+  #__settings:checked ~ .md-header .anoni-settings {
+    transform: translateX(0);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0ms;
+    visibility: visible;
+  }
+
+  .anoni-settings__head {
+    align-items: center;
+    background-color: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color);
+    display: flex;
+    height: 2.4rem;
+    padding: 0 0.4rem 0 0.8rem;
+  }
+
+  .anoni-settings__title {
+    flex-grow: 1;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  .anoni-settings__close {
+    cursor: pointer;
+    padding: 0.4rem;
+  }
+
+  .anoni-settings__close svg {
+    display: block;
+    fill: currentcolor;
+    height: 1.2rem;
+    width: 1.2rem;
+  }
+
+  .anoni-settings__group {
+    color: var(--md-default-fg-color--light);
+    display: block;
+    font-size: 0.64rem;
+    font-weight: 700;
+    margin: 0;
+    padding: 0.8rem 0.8rem 0.2rem;
+  }
+
+  /* .md-header__option 在 header 裡是橫排，抽屜裡要直排。搜尋展開時 Material
+     會把它壓成 max-width:0，那條規則在抽屜裡也要擋掉，否則抽屜內容會消失。 */
+  .anoni-settings .md-header__option,
+  [data-md-toggle="search"]:checked ~ .md-header .anoni-settings .md-header__option {
+    display: block;
+    max-width: none;
+    opacity: 1;
+    transition: none;
+    white-space: normal;
+  }
+
+  /* header 上那顆循環切換的圖示按鈕在抽屜裡沒有用處，三個選項已經並列 */
+  .anoni-settings .md-header__option > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings__choice {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
+  }
+
+  .anoni-settings__choice-text {
+    flex-grow: 1;
+  }
+
+  .anoni-settings__choice-mark {
+    display: block;
+    opacity: 0;
+  }
+
+  .anoni-settings__choice-mark svg {
+    display: block;
+    fill: var(--md-accent-fg-color);
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  /* 目前選的是哪一個，看上游那顆循環 label 的 hidden。bundle.js 每次換配色都會
+     把 index 對應的那一顆解除 hidden，其餘關掉，所以它一定跟著現況走。
+
+     不綁 input 的 :checked，因為第一次進站三顆 radio 都還沒被勾選（配色是從
+     localStorage 或 prefers-color-scheme 算出來的），綁 :checked 會整排沒有勾號。
+
+     順序是 input、循環 label、抽屜選項，由 palette.html 固定，中間不能插東西。 */
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice {
+    color: var(--md-accent-fg-color);
+  }
+
+  .anoni-settings .md-header__button:not([hidden]) + .anoni-settings__choice .anoni-settings__choice-mark {
+    opacity: 1;
+  }
+
+  /* 語言切換在 header 是滑過才展開的下拉，抽屜裡直接把清單攤開 */
+  /* .md-select__inner 在 header 是 position:absolute 的浮層，靠 hover 才展開。
+     抽屜裡要它回到文件流，位置與動畫那一整組都得歸零，只留清單本身。 */
+  .anoni-settings .md-select__inner {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    left: auto;
+    margin-top: 0;
+    max-height: none;
+    opacity: 1;
+    position: static;
+    top: auto;
+    transform: none;
+    transition: none;
+    z-index: auto;
+  }
+
+  .anoni-settings .md-select__inner::after {
+    display: none;
+  }
+
+  .anoni-settings .md-select {
+    display: block;
+  }
+
+  .anoni-settings .md-select > .md-header__button {
+    display: none;
+  }
+
+  .anoni-settings .md-select__list {
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    max-height: none;
+    overflow: visible;
+  }
+
+  /* .md-select__item 帶 1.8rem 的 line-height，加上連結自己的 padding，兩個
+     語言之間會空出比外觀那三項多一倍的距離。 */
+  .anoni-settings .md-select__item {
+    line-height: 1.4;
+  }
+
+  .anoni-settings .md-select__link {
+    color: var(--md-default-fg-color);
+    font-size: 0.7rem;
+    padding: 0.5rem 0.8rem;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## 問題

窄螢幕的 header 右側常駐三顆圖示。390px 上量到亮暗 48px、語言 48px、搜尋 40px，共 140px，標題只剩 130px，而完整站名要 236px，一律截成「匿名網路社群 …」。

| 寬度 | 標題可用 | 標題需要 | 右側圖示 |
|---|---|---|---|
| 360px | 100px | 236px | 140px |
| 390px | 130px | 236px | 140px |
| 430px | 170px | 236px | 140px |

右側的常駐控制項比標題本身還寬。

## 做法

亮暗與語言收進從右側滑出的抽屜，header 留一顆設定圖示與搜尋。標題因此拿到 178px。

搜尋不收。那是文件站最高頻的動作，收進第二層等於每次多一次點擊，而它在 header 只佔一顆 40px 的常駐位置。

窄螢幕另外換一個短站名。收掉兩顆圖示之後標題有 178px，完整站名 236px 還是會截斷。zh-TW 與 zh-CN 用「匿名網路社群」，en 用 `anoni.net Docs`，320px 以上都完整顯示。桌面版維持完整站名。

## 收進抽屜還解決了什麼

那兩顆在 header 上都只有圖示沒有文字，非技術背景的讀者不見得認得。抽屜裡放得下「外觀」與「閱讀語言」的標題。

亮暗原本是點一下換下一個，讀者要從圖示反推目前是哪個狀態。抽屜裡三個選項並列，目前選的是哪一個直接看得到。

## 實作重點

**桌面版完全不變。** `.anoni-settings` 在 44.9375em 以上是 `display: contents`，palette 與語言切換照樣直接排進 header 的 flex。DOM 只有一份，所以 `base.html` 讀 `.md-header__option .md-select__link` 的語言偏好與 `bundle.js` 的 palette 都照常運作。

**overlay 與抽屜放在 `.md-header__inner` 裡面。** `.md-header` 是 z-index 4 的堆疊環境，抽屜放到 header 外面一定被 Material 的 `.md-overlay`（z-index 5）蓋住。放在裡面之後，開啟時把 `.md-header` 提到 6，overlay 才遮得到 header 那一條。

**開合是純 HTML 加 CSS。** `base.html` 多一顆 `#__settings` checkbox，關掉 JS 也開得起來，跟 `anoni-variant` 那段是同一個理由。Esc 關閉另外補一小段 JS。

**`partials/palette.html` 新 fork。** 每個選項多一顆 `for` 指向自己的 label。新 label 一定要排在上游那顆循環 label 後面，`bundle.js` 用 `input.nextElementSibling` 找上游那顆來切 `hidden`。

**勾號綁上游那顆 label 的 `:not([hidden])`，不綁 input 的 `:checked`。** 第一次進站三顆 radio 都還沒被勾選（配色是從 localStorage 或 `prefers-color-scheme` 算出來的），綁 `:checked` 會整排沒有勾號。

**文案走 `config.extra`。** `header.html` 與 `palette.html` 是三個語系共用的符號連結。

## 驗證

Chrome CDP headless：

- 360、390、719 顯示抽屜，720、960、1440 維持原本三顆並排，斷點乾淨
- 設定鈕、X、overlay、Esc 四條關閉路徑都把 checkbox 切回 `false`
- 開啟時 overlay 遮得到漢堡的位置，關閉時抽屜內連結不進 tab 順序
- 勾號在首次載入（亮色與暗色系統設定）都指向「跟隨系統」，選暗色後跟著移動
- 搜尋與設定同時開時，抽屜內容不會被 Material 的 `max-width: 0` 壓掉
- 320 到 412 五個寬度短站名都不截斷
- 三語系抽屜文案都在地化，桌面 1440px 的 header 與改之前一致

建置與測試：

- `run.sh`、`run_zh-cn.sh`、`run_en.sh` 三支都以 `-s` 嚴格模式建置通過
- `tools/` 十支相關測試全過：`test_lang_switcher.py`、`test_theme_assets.py`、`check_start_parity.py`、`test_offline_index.py`、`test_lang_preference.mjs`、`test_before_send.mjs`、`test_update_banner.mjs`、`test_busy_feedback.mjs`、`test_analytics_events.mjs`、`test_offline_library.mjs`

## 已知限制

外觀那一組本來就依賴 JS，Material 的 palette 切換沒有 JS 就不會動。閱讀語言那一組是純連結，關掉 JS 照樣可用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)