### PR TITLE
fix(header): 設定抽屜的按鈕拿掉 title，觸控後的 tooltip 不再賴著

### DIFF
--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -95,7 +95,14 @@
     <div class="anoni-settings">
       <div class="anoni-settings__head">
         <span class="anoni-settings__title">{{ config.extra.settings_label }}</span>
-        <label class="anoni-settings__close md-icon" for="__settings" title="{{ config.extra.settings_close }}" aria-label="{{ config.extra.settings_close }}">
+        {#-
+          只給 aria-label，不給 title。theme 開了 content.tooltips，bundle.js 會把
+          header 裡每一個帶 title 的元素接管成自訂 tooltip。桌面滑鼠移開就收掉，
+          觸控沒有 mouseleave，點一下之後那顆白色小框會一直蓋在抽屜上，要再點畫面
+          其他地方才消失。這兩顆按鈕在桌面是 display:none，只有觸控看得到，title
+          帶不來好處。無障礙名稱由 aria-label 提供，沒有損失。
+        -#}
+        <label class="anoni-settings__close md-icon" for="__settings" aria-label="{{ config.extra.settings_close }}">
           {% include ".icons/material/close.svg" %}
         </label>
       </div>
@@ -113,7 +120,8 @@
     {% if not config.theme.palette is mapping %}
       {% include "partials/javascripts/palette.html" %}
     {% endif %}
-    <label class="anoni-settings__button md-header__button md-icon" for="__settings" title="{{ config.extra.settings_label }}" aria-label="{{ config.extra.settings_label }}">
+    {#- 不給 title，理由同上面關閉鈕那一段 -#}
+    <label class="anoni-settings__button md-header__button md-icon" for="__settings" aria-label="{{ config.extra.settings_label }}">
       {% include ".icons/material/tune-variant.svg" %}
     </label>
     {% if "material/search" in config.plugins %}


### PR DESCRIPTION
## 問題

在手機上點設定圖示打開抽屜之後，一個白色的「設定」小框會蓋在抽屜內容上，而且不會自己消失，要再點畫面其他地方才收掉。

原因是 theme 開了 `content.tooltips`。`bundle.js` 在 header 的初始化裡對 `[title]` 全數接管：

```js
fe(M("[title]", e)).pipe(g(() => V("content.tooltips")), J(s => ii(s)))
```

桌面滑鼠移開就收掉，觸控沒有 mouseleave，所以那顆 tooltip 一直維持 `md-tooltip--active`。

## 做法

設定鈕與抽屜的關閉鈕都拿掉 `title`，只留 `aria-label`。

這兩顆在桌面是 `display: none`，只有觸控看得到，`title` 帶不來好處。無障礙名稱由 `aria-label` 提供，沒有損失。

header 裡另外兩個帶 `title` 的是站台 logo 與 onion/IPFS 的版本標記，兩個都是連結，點下去就換頁，tooltip 跟著頁面一起消失，維持原樣。

## 驗證

用 CDP 的 `Input.dispatchTouchEvent` 打真的觸控事件，量 `.md-tooltip` 與 `.md-tooltip2`：

改之前

| 動作 | tooltip |
|---|---|
| 載入後 | 無 |
| 點設定鈕 | `md-tooltip md-tooltip--inline md-tooltip--active`，文字「設定」，opacity 1，高 24px |
| 再點畫面別處 | 消失 |

改之後

| 動作 | 抽屜 | 配色 | tooltip |
|---|---|---|---|
| 載入後 | 關 | default | 無 |
| 點設定鈕 | 開 | default | 無 |
| 點關閉鈕 | 關 | default | 無 |
| 再點設定鈕 | 開 | default | 無 |
| 點左側遮罩 | 關 | default | 無 |
| 第三次開啟 | 開 | default | 無 |
| 點暗色 | 開 | slate | 無 |

`aria-label` 仍在（`設定`、`關閉`），`title` 為 `null`。

三語系用 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 建置通過，`tools/` 七支相關測試全過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)