### PR TITLE
fix(header): 設定抽屜的斷點對齊左側導覽抽屜

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -604,8 +604,8 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 }
 
 /* ==========================================================================
-   窄螢幕的設定抽屜
-   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+   設定抽屜
+   套用範圍：76.234375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
 
    窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
    40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
@@ -616,13 +616,17 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
    抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
    並列，目前選的是哪一個直接看得到。
 
-   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
-   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
-   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
-   bundle.js 的 palette 都照常運作。
+   斷點跟左側導覽抽屜取同一個值。Material 在 max-width 76.234375em 把
+   .md-nav--primary 收成抽屜，並在 min-width 76.25em 把漢堡藏起來。兩側用同一
+   條線，讀者在平板上不會看到一邊收起、另一邊還攤在 header 的半套狀態。
 
-   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
-   寬度夠，三顆並排不擠。
+   這裡原本填 44.9375em（Material 的 mobile 上限，719px），只顧到手機。平板
+   直立與手機橫放都落在 720 到 1219 之間，左邊已經是抽屜，右邊還是三顆並排。
+
+   .anoni-settings 在 76.25em 以上是 display:contents，palette 與語言切換直接
+   排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只有一份，所以 base.html
+   讀 .md-header__option .md-select__link 的語言偏好與 bundle.js 的 palette 都
+   照常運作。
    ========================================================================== */
 
 /* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
@@ -648,23 +652,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
-/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
-   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+/* 短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，還是會
+   截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。
+
+   這一項的斷點跟抽屜不同，維持 44.9375em。720px 起標題那一格已經有四百多 px，
+   完整站名放得下，沒有理由換掉。 */
 .anoni-site-name--short {
   display: none;
 }
 
 @media screen and (max-width: 44.9375em) {
-  .anoni-settings__button.md-header__button {
-    display: inline-block;
-  }
-
   .anoni-site-name {
     display: none;
   }
 
   .anoni-site-name--short {
     display: inline;
+  }
+}
+
+@media screen and (max-width: 76.234375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
   }
 
   /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -596,8 +596,8 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 }
 
 /* ==========================================================================
-   窄螢幕的設定抽屜
-   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+   設定抽屜
+   套用範圍：76.234375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
 
    窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
    40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
@@ -608,13 +608,17 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
    抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
    並列，目前選的是哪一個直接看得到。
 
-   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
-   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
-   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
-   bundle.js 的 palette 都照常運作。
+   斷點跟左側導覽抽屜取同一個值。Material 在 max-width 76.234375em 把
+   .md-nav--primary 收成抽屜，並在 min-width 76.25em 把漢堡藏起來。兩側用同一
+   條線，讀者在平板上不會看到一邊收起、另一邊還攤在 header 的半套狀態。
 
-   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
-   寬度夠，三顆並排不擠。
+   這裡原本填 44.9375em（Material 的 mobile 上限，719px），只顧到手機。平板
+   直立與手機橫放都落在 720 到 1219 之間，左邊已經是抽屜，右邊還是三顆並排。
+
+   .anoni-settings 在 76.25em 以上是 display:contents，palette 與語言切換直接
+   排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只有一份，所以 base.html
+   讀 .md-header__option .md-select__link 的語言偏好與 bundle.js 的 palette 都
+   照常運作。
    ========================================================================== */
 
 /* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
@@ -640,23 +644,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
-/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
-   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+/* 短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，還是會
+   截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。
+
+   這一項的斷點跟抽屜不同，維持 44.9375em。720px 起標題那一格已經有四百多 px，
+   完整站名放得下，沒有理由換掉。 */
 .anoni-site-name--short {
   display: none;
 }
 
 @media screen and (max-width: 44.9375em) {
-  .anoni-settings__button.md-header__button {
-    display: inline-block;
-  }
-
   .anoni-site-name {
     display: none;
   }
 
   .anoni-site-name--short {
     display: inline;
+  }
+}
+
+@media screen and (max-width: 76.234375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
   }
 
   /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -597,8 +597,8 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 }
 
 /* ==========================================================================
-   窄螢幕的設定抽屜
-   套用範圍：44.9375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
+   設定抽屜
+   套用範圍：76.234375em 以下，亮暗切換與語言切換收進從右側滑出的抽屜
 
    窄螢幕的 header 右側常駐三顆圖示，390px 上量到亮暗 48px、語言 48px、搜尋
    40px，共 140px，標題只剩 130px，而站名要 236px 才放得下。亮暗與語言兩顆
@@ -609,13 +609,17 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
    抽屜裡放得下「外觀」與「閱讀語言」的標題，亮暗也從點一下換下一個改成三個
    並列，目前選的是哪一個直接看得到。
 
-   桌面版完全不受影響。.anoni-settings 在 44.9375em 以上是 display:contents，
-   palette 與語言切換直接排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只
-   有一份，所以 base.html 讀 .md-header__option .md-select__link 的語言偏好與
-   bundle.js 的 palette 都照常運作。
+   斷點跟左側導覽抽屜取同一個值。Material 在 max-width 76.234375em 把
+   .md-nav--primary 收成抽屜，並在 min-width 76.25em 把漢堡藏起來。兩側用同一
+   條線，讀者在平板上不會看到一邊收起、另一邊還攤在 header 的半套狀態。
 
-   斷點取 Material 自己的 mobile 上限 44.9375em（719px）。再往上 header 的
-   寬度夠，三顆並排不擠。
+   這裡原本填 44.9375em（Material 的 mobile 上限，719px），只顧到手機。平板
+   直立與手機橫放都落在 720 到 1219 之間，左邊已經是抽屜，右邊還是三顆並排。
+
+   .anoni-settings 在 76.25em 以上是 display:contents，palette 與語言切換直接
+   排進 .md-header__inner 的 flex，跟改之前一樣。DOM 只有一份，所以 base.html
+   讀 .md-header__option .md-select__link 的語言偏好與 bundle.js 的 palette 都
+   照常運作。
    ========================================================================== */
 
 /* 桌面：抽屜的外框與裝飾全部退場，只留原本那兩組控制項排進 header */
@@ -641,23 +645,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
-/* 窄螢幕改用短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，
-   還是會截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。 */
+/* 短站名。標題在 390px 上收掉兩顆圖示之後有 178px，完整站名要 236px，還是會
+   截斷。短站名走 config，因為 header.html 是三個語系共用的符號連結。
+
+   這一項的斷點跟抽屜不同，維持 44.9375em。720px 起標題那一格已經有四百多 px，
+   完整站名放得下，沒有理由換掉。 */
 .anoni-site-name--short {
   display: none;
 }
 
 @media screen and (max-width: 44.9375em) {
-  .anoni-settings__button.md-header__button {
-    display: inline-block;
-  }
-
   .anoni-site-name {
     display: none;
   }
 
   .anoni-site-name--short {
     display: inline;
+  }
+}
+
+@media screen and (max-width: 76.234375em) {
+  .anoni-settings__button.md-header__button {
+    display: inline-block;
   }
 
   /* overlay 與抽屜都在 .md-header__inner 裡面。.md-header 是 z-index 4 的堆疊


### PR DESCRIPTION
## 問題

右側設定抽屜原本設在 `44.9375em`（Material 的 mobile 上限，719px），只顧到手機。平板直立與手機橫放落在 720 到 1219 之間，左邊導覽已經收成抽屜，右邊的亮暗與語言還攤在 header，兩側各走各的。

## 做法

改成跟左側同一條線。Material 的數字：

- `max-width: 76.234375em` 把 `.md-nav--primary` 收成抽屜
- `min-width: 76.25em` 把漢堡藏起來

右側抽屜與設定圖示改用同一組。

短站名不跟著改，維持 `44.9375em`。720px 起標題那一格已經有四百多 px，完整站名放得下，沒有理由換掉。原本兩件事寫在同一個媒體查詢裡，這次拆成兩段。

## 驗證

**斷點一致**

| 寬度 | 漢堡 | 設定圖示 | 站名 | 標題截斷 |
|---|---|---|---|---|
| 390 | block | block | 短 | 否 |
| 719 | block | block | 短 | 否 |
| 720 | block | block | 完整 | 否 |
| 1024 | block | block | 完整 | 否 |
| 1219 | block | block | 完整 | 否 |
| 1220 | none | none | 完整 | 否 |
| 1440 | none | none | 完整 | 否 |

兩側翻轉的位置完全一致。

**觸控操作**：390、768、1024、1219 四個寬度各跑一輪，開啟、關閉鈕、遮罩關閉、選暗色的行為一致，全程量不到任何 `.md-tooltip`。1024 上抽屜的 x 是 782（1024 減 242），遮罩正確。

**建置與測試**：三語系用 `run_*.sh` 以 `-s` 建置通過，`tools/` 八支相關測試全過。

## 一併查清楚的既有行為（不在這次修改範圍）

768px 上開搜尋時，Chrome 的行動裝置模擬會把 `innerWidth` 撐到 2224，關掉之後停在 855 不回到 768。

把 `.anoni-settings` 與它的遮罩整個從 DOM 移除再跑同一段，數字一模一樣（2224 → 855），所以那是 Material 自己的版面行為，不是這次或上次改動造成的。抽屜是 `position: fixed` 貼右緣，只是跟著被撐開的視窗一起位移。`document.documentElement.clientWidth` 全程維持 768。

🤖 Generated with [Claude Code](https://claude.com/claude-code)