### PR TITLE
fix(header): 設定圖示移到搜尋後面

### DIFF
--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -120,10 +120,6 @@
     {% if not config.theme.palette is mapping %}
       {% include "partials/javascripts/palette.html" %}
     {% endif %}
-    {#- 不給 title，理由同上面關閉鈕那一段 -#}
-    <label class="anoni-settings__button md-header__button md-icon" for="__settings" aria-label="{{ config.extra.settings_label }}">
-      {% include ".icons/material/tune-variant.svg" %}
-    </label>
     {% if "material/search" in config.plugins %}
       {% set search = config.plugins["material/search"] | attr("config") %}
       {% if search.enabled %}
@@ -134,6 +130,18 @@
         {% include "partials/search.html" %}
       {% endif %}
     {% endif %}
+    {#-
+      設定圖示排在搜尋後面，窄螢幕上由左到右是漢堡、標題、搜尋、設定。設定是
+      最少用的那一顆，放在最外側。
+
+      桌面不受影響，這顆在 76.25em 以上是 display:none。上面 .anoni-settings 的
+      display:contents 仍排在搜尋之前，所以桌面的 palette、語言、搜尋順序沒有變。
+
+      不給 title，理由同上面關閉鈕那一段。
+    -#}
+    <label class="anoni-settings__button md-header__button md-icon" for="__settings" aria-label="{{ config.extra.settings_label }}">
+      {% include ".icons/material/tune-variant.svg" %}
+    </label>
     {% if config.repo_url %}
       <div class="md-header__source">
         {% include "partials/source.html" %}


### PR DESCRIPTION
## 做法

窄螢幕由左到右改成漢堡、標題、搜尋、設定。設定是這四個裡最少用的一顆，放在最外側。

只是把 `.anoni-settings__button` 這個 `<label>` 搬到 `partials/search.html` 之後。

桌面不受影響。這顆在 76.25em 以上是 `display: none`，而 `.anoni-settings` 的 `display: contents` 仍排在搜尋之前，palette、語言、搜尋的順序沒有變。

## 驗證

依實際 x 座標排序 header 上看得到的元素：

| 寬度 | 順序 |
|---|---|
| 390 | 漢堡@24、標題@88、搜尋圖示@278、設定@326 |
| 768 | 漢堡@24、標題@88、搜尋圖示@656、設定@704 |
| 1024 | 漢堡@24、標題@88、搜尋框@468、設定@706、repo@770 |
| 1440 | 標題@208、亮暗@708、語言@756、搜尋框@804、repo@1066 |

1440 那一列跟改之前一致。

390 與 1024 各跑一輪觸控：開啟、關閉鈕、遮罩關閉、選暗色都正常，全程量不到 `.md-tooltip`。

三語系用 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 以 `-s` 建置通過，`tools/` 七支相關測試全過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)