### PR TITLE
ci(tools-tests): 觸發路徑改成整個 overrides/partials 目錄

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -45,9 +45,14 @@ on:
       # overrides 的 main.html 是 test_before_send.mjs 的來源，送出前的白名單寫在裡面
       - "docs/overrides/base.html"
       - "docs/overrides/main.html"
-      # 語言切換器的樣板。改壞的方式是「目前語系整筆跳過」，畫面照樣好看，
-      # 壞掉的是首頁的偏好轉址與底部的語言選擇卡片
-      - "docs/overrides/partials/alternate.html"
+      # partials 整個目錄。原本只列 alternate.html，因為語言切換器改壞的方式是
+      # 「目前語系整筆跳過」，畫面照樣好看，壞掉的是首頁的偏好轉址與底部的語言
+      # 選擇卡片。
+      #
+      # 2026-09-09 的 #492 與 #494 只動 header.html，這一支一次都沒觸發。當下沒有
+      # 測試讀 header.html，所以那兩次即使跑了也抓不到東西，但下一支測試補進來的
+      # 時候不會有人記得回來加路徑，跟上面 js 那段是同一種漏法。改成整個目錄。
+      - "docs/overrides/partials/**"
       - "docs/overrides_cn/main.html"
       - "docs/overrides_en/main.html"
       - "docs/hooks/**"


### PR DESCRIPTION
## 做法

`docs/overrides/partials/alternate.html` 改成 `docs/overrides/partials/**`。

## 先更正一件事

我原本說「改 partials 不會觸發 `test_lang_switcher.py`」，那是錯的。`alternate.html` 一直都在 paths 裡，而 `test_lang_switcher.py` 讀的正是那一支，所以它一直有被守著。

實際的情況是：2026-09-09 的 #492 與 #494 只動 `header.html`，這支 workflow 一次都沒觸發。但當下沒有任何測試讀 `header.html` 或 `palette.html`（`grep -ln "header\.html\|palette\.html" tools/*` 沒有結果），所以那兩次即使跑了也抓不到東西。

## 那為什麼還要改

為了下一支測試。等有人替 `header.html` 或 `palette.html` 寫檢查時，不會有人記得回來加路徑，跟這個檔案上面那段 js 的教訓是同一種漏法（原文：「漏一支的代價上面第 10 行已經寫過一次」）。

整套跑完不到二十秒，多觸發幾次的成本可以忽略。

## 順帶記一個目前沒人守的東西

`header.html` 與 `palette.html` 的檔頭都寫了 `theme-partial-from: mkdocs-material 9.7.7`，但整個 repo 沒有任何地方讀這個標記：

```
$ grep -rn "theme-partial-from" tools/ .github/ docs/overrides/
docs/overrides/partials/header.html:5:  theme-partial-from: mkdocs-material 9.7.7
docs/overrides/partials/palette.html:16:  theme-partial-from: mkdocs-material 9.7.7
```

`base.html` 的 `theme-assets-from` 有 `check_theme_assets.py` 守著，partial 的 fork 版本沒有對應的檢查。升級 mkdocs-material 時上游改了那兩支 partial，這裡不會有人提醒。這次不處理，先記著。

🤖 Generated with [Claude Code](https://claude.com/claude-code)