### PR TITLE
feat(header): 設定抽屜加一顆檢查更新

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -639,6 +639,13 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
+/* 離線內容那一組只在抽屜出現。樣板先給 hidden，base.html 註冊 service worker
+   成功才拿掉，所以底下開啟的規則要避開 [hidden]，否則作者樣式會蓋掉瀏覽器
+   預設的 [hidden]{display:none}，沒有 SW 的環境也會看到一顆按不動的按鈕。 */
+.anoni-settings__update {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -705,6 +712,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
      tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
   .anoni-settings {
     background-color: var(--md-default-bg-color);
+    /* 抽屜長在 .md-header 裡面，文字色從 header 繼承下來是 --md-primary-bg-color
+       （白的）。底下每一列都各自指定過顏色所以看不出問題，直到放進一顆用
+       color:inherit 的 .anoni-banner-action，白字落在白底上整顆變空白。
+       在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
+       primary 那組。 */
+    color: var(--md-default-fg-color);
     bottom: 0;
     display: block;
     overflow-y: auto;
@@ -749,6 +762,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     fill: currentcolor;
     height: 1.2rem;
     width: 1.2rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+  }
+
+  .anoni-settings__update-body {
+    padding: 0 0.8rem 0.8rem;
+  }
+
+  /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
+  .anoni-settings__update-body .anoni-banner-action {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .anoni-settings__status {
+    color: var(--md-default-fg-color--light);
+    font-size: 0.62rem;
+    line-height: 1.35;
+    margin: 0.4rem 0 0;
+    text-wrap: pretty;
   }
 
   .anoni-settings__group {

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -284,6 +284,9 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "亮色"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "暗色"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "閱讀語言"]
+  # 抽屜裡「離線內容」那一組的文案，理由同上面 settings_*。
+  settings_offline: !ENV [SETTINGS_OFFLINE, "離線內容"]
+  settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "檢查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。
   # 圖示不分語系，三份設定填一樣的值，也就不需要 !ENV。

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -263,6 +263,9 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "浅色"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "深色"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "阅读语言"]
+  # 抽屉里「离线内容」那一组的文案，理由同上面 settings_*。
+  settings_offline: !ENV [SETTINGS_OFFLINE, "离线内容"]
+  settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "检查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。
   # 圖示不分語系，三份設定填一樣的值，也就不需要 !ENV。

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -267,6 +267,9 @@ extra:
     - !ENV [SETTINGS_APPEARANCE_LIGHT, "Light"]
     - !ENV [SETTINGS_APPEARANCE_DARK, "Dark"]
   settings_language: !ENV [SETTINGS_LANGUAGE, "Reading language"]
+  # Copy for the "offline content" group in the drawer, same reason as settings_* above.
+  settings_offline: !ENV [SETTINGS_OFFLINE, "Offline content"]
+  settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "Check for updates"]
   # Icons for the three appearance options in the drawer, same order as theme.palette.
   # The upstream toggle.icon says "what this switches to", the drawer needs "what this
   # option is", so they are listed separately. Icons are not localised, all three

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -470,15 +470,21 @@
           var STRINGS = {
             "zh-TW": {
               text: "離線存的內容有新版本。更新會重新載入這一頁。",
-              update: "更新", later: "稍後", updating: "更新中"
+              update: "更新", later: "稍後", updating: "更新中",
+              checking: "檢查中", latest: "已是最新版本",
+              failed: "連不上，稍後再試"
             },
             "zh": {
               text: "离线存的内容有新版本。更新会重新加载这一页。",
-              update: "更新", later: "稍后", updating: "更新中"
+              update: "更新", later: "稍后", updating: "更新中",
+              checking: "检查中", latest: "已是最新版本",
+              failed: "连不上，稍后再试"
             },
             "en": {
               text: "A newer version is available for offline reading. Updating reloads this page.",
-              update: "Update", later: "Later", updating: "Updating"
+              update: "Update", later: "Later", updating: "Updating",
+              checking: "Checking", latest: "Already up to date",
+              failed: "Could not check, try again later"
             }
           };
           var t = STRINGS[document.documentElement.lang] || STRINGS["zh-TW"];
@@ -500,6 +506,11 @@
             button.addEventListener("click", onClick);
             return button;
           }
+
+          // 抽屜裡那顆按鈕的「有新版等著」入口。setupUpdateCheck 會把它接上去，
+          // 沒有那塊 DOM 的話維持空函式。被動的換版提示與主動的檢查更新看的是
+          // 同一個 registration，兩邊要顯示同一件事。
+          var onUpdateReady = function () {};
 
           function showUpdateBanner(waiting) {
             if (document.getElementById("__sw-update")) return;
@@ -557,6 +568,91 @@
             dismiss = window.__anoniToast(banner);
           }
 
+          // 抽屜裡的檢查更新。換版提示是被動的，要等 service worker 自己裝好新版
+          // 才浮出來，讀者按過稍後就得等下一次導覽，而 standalone 的 PWA 常常好幾天
+          // 不產生新的導覽。這裡給一個隨時問得到的入口。
+          //
+          // 兩種狀態共用同一顆按鈕。mode 是 "check" 時按下去問伺服器，是 "apply"
+          // 時按下去換版，跟換版提示上那顆做的是同一件事，送同一則 SKIP_WAITING。
+          function setupUpdateCheck(registration) {
+            var box = document.getElementById("__anoni-update");
+            var button = document.getElementById("__anoni-update-check");
+            var status = document.getElementById("__anoni-update-status");
+            if (!box || !button || !status) return;
+
+            // 樣板把整塊藏起來，註冊成功才顯示。沒有 service worker 的環境按了
+            // 什麼都不會發生，那種按鈕不如不要出現。
+            box.hidden = false;
+
+            // 按鈕原本的字取自樣板，那串走 config.extra，三個語系各自不同。
+            // 在這裡讀一次就不必再往 STRINGS 塞第四份。
+            var checkLabel = button.textContent.trim();
+            var mode = "check";
+
+            function setBusy(label) {
+              button.disabled = true;
+              button.textContent = "";
+              var spinner = document.createElement("span");
+              spinner.className = "anoni-spinner";
+              button.appendChild(spinner);
+              button.appendChild(document.createTextNode(label));
+              button.setAttribute("aria-busy", "true");
+            }
+
+            function setIdle(label, primary) {
+              button.disabled = false;
+              button.textContent = label;
+              button.removeAttribute("aria-busy");
+              button.className =
+                "anoni-banner-action" + (primary ? " anoni-banner-action--primary" : "");
+            }
+
+            function toApply() {
+              mode = "apply";
+              status.textContent = t.text;
+              setIdle(t.update, true);
+            }
+
+            function toCheck(message) {
+              mode = "check";
+              status.textContent = message || "";
+              setIdle(checkLabel, false);
+            }
+
+            // 讀者上次按了稍後，新版還停在 waiting。抽屜一打開就該看得到可以直接換，
+            // 不必再問一次伺服器。
+            if (registration.waiting && navigator.serviceWorker.controller) toApply();
+            onUpdateReady = toApply;
+
+            button.addEventListener("click", function () {
+              if (mode === "apply") {
+                var waiting = registration.waiting;
+                // 等的那個不見了（別的分頁先換掉了），退回檢查狀態，不要送空訊息
+                if (!waiting) { toCheck(t.latest); return; }
+                setBusy(t.updating);
+                status.textContent = "";
+                reloadOnTakeover = true;
+                waiting.postMessage({ type: "SKIP_WAITING" });
+                return;
+              }
+              setBusy(t.checking);
+              status.textContent = "";
+              registration.update().then(function () {
+                // update() 只保證檢查做完，裝新版可能還在跑，所以三種都要看
+                if (registration.waiting) { toApply(); return; }
+                var installing = registration.installing;
+                if (!installing) { toCheck(t.latest); return; }
+                installing.addEventListener("statechange", function () {
+                  if (installing.state === "installed") toApply();
+                  else if (installing.state === "redundant") toCheck(t.failed);
+                });
+              }).catch(function () {
+                // 離線或抓不到 sw.js
+                toCheck(t.failed);
+              });
+            });
+          }
+
           navigator.serviceWorker.register(script, options).then(function (registration) {
             // 告訴 SW 這頁是哪個語系，它據此補齊該語系的預快取。送的是網址不是語系
             // 代碼，判斷邏輯只留在 sw.js 的 langPrefixOf 一處，也繞開 zh-CN 版的
@@ -581,6 +677,8 @@
               }
             });
 
+            setupUpdateCheck(registration);
+
             // 上一次沒按更新，新版還停在 waiting
             if (registration.waiting && navigator.serviceWorker.controller) {
               showUpdateBanner(registration.waiting);
@@ -593,6 +691,9 @@
                 // 有 controller 才代表這是換版。沒有的話是首次安裝，沒什麼好提示的。
                 if (installing.state === "installed" && navigator.serviceWorker.controller) {
                   showUpdateBanner(installing);
+                  // 抽屜那顆也要跟上。讀者關掉卡片之後打開抽屜，看到的要是
+                  // 「有新版本」而不是「檢查更新」。
+                  onUpdateReady();
                 }
               });
             });

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -116,6 +116,28 @@
         <p class="anoni-settings__group">{{ config.extra.settings_language }}</p>
         {% include "partials/alternate.html" %}
       {% endif %}
+      {#-
+        離線內容的更新入口。換版提示是被動的，它要等 service worker 裝好新版才
+        浮出來，讀者按過稍後就得等下一次導覽，而 standalone 的 PWA 常常好幾天不
+        產生新的導覽。這顆給的是主動的入口，隨時問得到。
+
+        整塊預設帶 hidden，由 base.html 註冊 service worker 成功之後才拿掉。
+        關掉 JS、瀏覽器不支援、或者在不註冊 SW 的主機上（本機以外的非 anoni.net）
+        按了什麼都不會發生，那種按鈕不如不要出現。
+
+        按鈕用全站共用的 .anoni-banner-action，樣式與觸控尺寸跟換版提示那兩顆
+        同一份，定義在 base.html 的 styles block。狀態那一行的文字由 JS 填，
+        role 與 aria-live 讓讀螢幕的人也拿得到結果。
+      -#}
+      <div class="anoni-settings__update" id="__anoni-update" hidden>
+        <p class="anoni-settings__group">{{ config.extra.settings_offline }}</p>
+        <div class="anoni-settings__update-body">
+          <button type="button" class="anoni-banner-action" id="__anoni-update-check">
+            {{ config.extra.settings_update_check }}
+          </button>
+          <p class="anoni-settings__status" id="__anoni-update-status" role="status" aria-live="polite"></p>
+        </div>
+      </div>
     </div>
     {% if not config.theme.palette is mapping %}
       {% include "partials/javascripts/palette.html" %}

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -631,6 +631,13 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
+/* 離線內容那一組只在抽屜出現。樣板先給 hidden，base.html 註冊 service worker
+   成功才拿掉，所以底下開啟的規則要避開 [hidden]，否則作者樣式會蓋掉瀏覽器
+   預設的 [hidden]{display:none}，沒有 SW 的環境也會看到一顆按不動的按鈕。 */
+.anoni-settings__update {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -697,6 +704,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
      tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
   .anoni-settings {
     background-color: var(--md-default-bg-color);
+    /* 抽屜長在 .md-header 裡面，文字色從 header 繼承下來是 --md-primary-bg-color
+       （白的）。底下每一列都各自指定過顏色所以看不出問題，直到放進一顆用
+       color:inherit 的 .anoni-banner-action，白字落在白底上整顆變空白。
+       在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
+       primary 那組。 */
+    color: var(--md-default-fg-color);
     bottom: 0;
     display: block;
     overflow-y: auto;
@@ -741,6 +754,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     fill: currentcolor;
     height: 1.2rem;
     width: 1.2rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+  }
+
+  .anoni-settings__update-body {
+    padding: 0 0.8rem 0.8rem;
+  }
+
+  /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
+  .anoni-settings__update-body .anoni-banner-action {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .anoni-settings__status {
+    color: var(--md-default-fg-color--light);
+    font-size: 0.62rem;
+    line-height: 1.35;
+    margin: 0.4rem 0 0;
+    text-wrap: pretty;
   }
 
   .anoni-settings__group {

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -632,6 +632,13 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   display: none;
 }
 
+/* 離線內容那一組只在抽屜出現。樣板先給 hidden，base.html 註冊 service worker
+   成功才拿掉，所以底下開啟的規則要避開 [hidden]，否則作者樣式會蓋掉瀏覽器
+   預設的 [hidden]{display:none}，沒有 SW 的環境也會看到一顆按不動的按鈕。 */
+.anoni-settings__update {
+  display: none;
+}
+
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
@@ -698,6 +705,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
      tab 進去的話，讀者會在看不到東西的狀態下走進一串連結。 */
   .anoni-settings {
     background-color: var(--md-default-bg-color);
+    /* 抽屜長在 .md-header 裡面，文字色從 header 繼承下來是 --md-primary-bg-color
+       （白的）。底下每一列都各自指定過顏色所以看不出問題，直到放進一顆用
+       color:inherit 的 .anoni-banner-action，白字落在白底上整顆變空白。
+       在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
+       primary 那組。 */
+    color: var(--md-default-fg-color);
     bottom: 0;
     display: block;
     overflow-y: auto;
@@ -742,6 +755,28 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     fill: currentcolor;
     height: 1.2rem;
     width: 1.2rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+  }
+
+  .anoni-settings__update-body {
+    padding: 0 0.8rem 0.8rem;
+  }
+
+  /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
+  .anoni-settings__update-body .anoni-banner-action {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .anoni-settings__status {
+    color: var(--md-default-fg-color--light);
+    font-size: 0.62rem;
+    line-height: 1.35;
+    margin: 0.4rem 0 0;
+    text-wrap: pretty;
   }
 
   .anoni-settings__group {

--- a/tools/test_update_banner.mjs
+++ b/tools/test_update_banner.mjs
@@ -17,6 +17,13 @@
  * 從 overrides/base.html 原地抽出來執行，不重寫一份。DOM 用最小替身，只實作這段
  * 真正用到的那幾個方法。
  *
+ * === 抽屜裡那顆檢查更新 ===
+ *
+ * 換版提示是被動的，要等 service worker 自己裝好新版才浮出來。抽屜裡那顆是主動
+ * 的入口，同一顆按鈕身兼兩種狀態：問伺服器，以及套用已經等在那裡的新版。狀態
+ * 弄反的後果是讀者按了「更新」卻只是又問了一次，或者按「檢查更新」卻直接把頁面
+ * 換掉，兩種都只在真的有新版時才看得到，本機開發碰不到。
+ *
  * 用法：
  *   node tools/test_update_banner.mjs
  * 不需要建置產物，也沒有外部相依。
@@ -43,6 +50,7 @@ class FakeElement {
     this.attributes = {};
     this.className = '';
     this.disabled = false;
+    this.hidden = false;
     this._text = '';
     this._handlers = {};
   }
@@ -63,6 +71,9 @@ class FakeElement {
   }
   getAttribute(name) {
     return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+  }
+  removeAttribute(name) {
+    delete this.attributes[name];
   }
   addEventListener(type, fn) {
     this._handlers[type] = fn;
@@ -170,9 +181,158 @@ test('沒按更新之前兩顆都是可以按的', () => {
   assert.equal(buttonBy('稍後').disabled, false);
 });
 
+// ---------------------------------------------------------------------------
+// 抽屜裡的檢查更新
+// ---------------------------------------------------------------------------
+
+const loadCheck = ({ waiting = null, installing = null, updateFails = false, hasDom = true } = {}) => {
+  const box = new FakeElement('div');
+  // 樣板給的初始狀態就是 hidden，假替身要照著來，不然「有沒有拿掉」驗不到東西
+  box.hidden = true;
+  const button = new FakeElement('button');
+  const status = new FakeElement('p');
+  button.className = 'anoni-banner-action';
+  button.textContent = '檢查更新';
+  const byId = {
+    '__anoni-update': box,
+    '__anoni-update-check': button,
+    '__anoni-update-status': status,
+  };
+  const document = {
+    createElement: (tag) => new FakeElement(tag),
+    createTextNode: (text) => {
+      const node = new FakeElement('#text');
+      node.textContent = text;
+      return node;
+    },
+    getElementById: (id) => (hasDom ? byId[id] || null : null),
+  };
+  const sent = [];
+  const registration = {
+    waiting: waiting === null ? null : { postMessage: (m) => sent.push(m) },
+    installing,
+    update: () => (updateFails ? Promise.reject(new Error('offline')) : Promise.resolve()),
+  };
+  const navigator = { serviceWorker: { controller: {} } };
+
+  const harness = `
+    ${grab(/var STRINGS = \{[\s\S]*?\n          \};/)}
+    var t = STRINGS["zh-TW"];
+    var reloadOnTakeover = false;
+    var onUpdateReady = function () {};
+    ${grab(/function setupUpdateCheck\(registration\) \{[\s\S]*?\n          \}/)}
+    return {
+      setup: setupUpdateCheck,
+      reloaded: function () { return reloadOnTakeover; },
+      ready: function () { return onUpdateReady; }
+    };
+  `;
+  const api = new Function('document', 'navigator', harness)(document, navigator);
+  api.setup(registration);
+  return { api, box, button, status, sent, registration };
+};
+
+// 讓 registration.update() 那條 promise 鏈跑完
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test('沒有那塊 DOM 就什麼都不做', () => {
+  // onion 與 IPFS 版一樣走這支 base.html，樣板哪天沒渲那塊也不該整段爆掉
+  const { box } = loadCheck({ hasDom: false });
+  assert.equal(box.hidden, true, '找不到按鈕卻還是把整塊顯示出來了');
+});
+
+test('註冊成功之後那塊才顯示', () => {
+  // 樣板給的是 hidden，沒有 service worker 的環境不該看到按不動的按鈕
+  const { box } = loadCheck();
+  assert.equal(box.hidden, false, '註冊成功卻沒有把 hidden 拿掉');
+});
+
+test('上次按了稍後，抽屜一開就是可以直接更新', () => {
+  const { button, status } = loadCheck({ waiting: true });
+  assert.equal(button.textContent, '更新');
+  assert.ok(button.className.includes('--primary'), button.className);
+  assert.ok(status.textContent.includes('重新載入'), status.textContent);
+});
+
+test('沒有等待中的新版時是檢查狀態', () => {
+  const { button, status } = loadCheck();
+  assert.equal(button.textContent, '檢查更新');
+  assert.equal(button.className, 'anoni-banner-action');
+  assert.equal(status.textContent, '');
+});
+
+test('按下檢查會停用並顯示檢查中與轉圈', async () => {
+  // 慢網路上 update() 要好幾秒，按鈕沒有變化讀者只會以為沒按到
+  const { button } = loadCheck();
+  button.click();
+  assert.equal(button.disabled, true);
+  assert.ok(button.textContent.includes('檢查中'), button.textContent);
+  assert.ok(button.children.some((c) => c.className === 'anoni-spinner'), '按鈕上沒有轉圈');
+  assert.equal(button.getAttribute('aria-busy'), 'true');
+  await flush();
+});
+
+test('檢查完沒有新版就說已是最新版本', async () => {
+  const { button, status } = loadCheck();
+  button.click();
+  await flush();
+  assert.equal(status.textContent, '已是最新版本');
+  assert.equal(button.textContent, '檢查更新', '按鈕沒有還原成原本那串');
+  assert.equal(button.disabled, false);
+  assert.equal(button.getAttribute('aria-busy'), null);
+});
+
+test('檢查完抓不到 sw.js 就說連不上', async () => {
+  const { button, status } = loadCheck({ updateFails: true });
+  button.click();
+  await flush();
+  assert.ok(status.textContent.includes('連不上'), status.textContent);
+  assert.equal(button.disabled, false, '失敗之後按鈕沒有解開，讀者再也試不了');
+});
+
+test('檢查完發現新版就換成更新', async () => {
+  const { button, status, registration } = loadCheck();
+  registration.update = () => {
+    registration.waiting = { postMessage: () => {} };
+    return Promise.resolve();
+  };
+  button.click();
+  await flush();
+  assert.equal(button.textContent, '更新');
+  assert.ok(button.className.includes('--primary'), button.className);
+  assert.ok(status.textContent.includes('重新載入'), status.textContent);
+});
+
+test('更新狀態按下去送 SKIP_WAITING 並標記重新載入', () => {
+  const { api, button, sent } = loadCheck({ waiting: true });
+  button.click();
+  assert.deepEqual(sent, [{ type: 'SKIP_WAITING' }]);
+  assert.equal(api.reloaded(), true, '沒有標記接管後要重新載入');
+  assert.equal(button.disabled, true);
+  assert.ok(button.textContent.includes('更新中'), button.textContent);
+});
+
+test('等待中的新版不見了就退回檢查，不送空訊息', () => {
+  // 另一個分頁先按了更新，這邊的 registration.waiting 會變成 null
+  const { button, status, sent, registration } = loadCheck({ waiting: true });
+  registration.waiting = null;
+  button.click();
+  assert.deepEqual(sent, [], '對著不存在的 worker 送了訊息');
+  assert.equal(button.textContent, '檢查更新');
+  assert.equal(status.textContent, '已是最新版本');
+});
+
+test('換版提示那條路也接得到抽屜這顆', () => {
+  // 讀者關掉卡片再打開抽屜，看到的要是「更新」而不是「檢查更新」
+  const { api, button } = loadCheck();
+  assert.equal(button.textContent, '檢查更新');
+  api.ready()();
+  assert.equal(button.textContent, '更新');
+});
+
 for (const [name, fn] of tests) {
   try {
-    fn();
+    await fn();
     passed++;
     console.log('  ✓ ' + name);
   } catch (err) {


### PR DESCRIPTION
## 為什麼

換版提示是被動的，要等 service worker 自己裝好新版才浮出來。讀者按過稍後就得等下一次導覽，而 standalone 的 PWA 常常好幾天不產生新的導覽，那條提示等不到，讀者連按鈕都看不到。

抽屜裡這顆是主動的入口，隨時問得到。

## 行為

同一顆按鈕兩種狀態。`mode` 是 `check` 時按下去問伺服器，是 `apply` 時按下去換版，送的是跟換版提示那顆一樣的 `SKIP_WAITING`。

| 情況 | 按鈕 | 狀態文字 |
|---|---|---|
| 檢查中 | 停用、轉圈、`aria-busy` | 檢查中 |
| 沒有新版 | 檢查更新 | 已是最新版本 |
| 有新版 | 更新（primary） | 離線存的內容有新版本。更新會重新載入這一頁。 |
| 抓不到 sw.js | 檢查更新 | 連不上，稍後再試 |
| 套用中 | 停用、轉圈 | （清空） |

兩條路互通：

- 讀者上次按了稍後、新版還停在 `waiting`，抽屜一打開就直接是「更新」，不必再問一次伺服器
- 被動那條路裝好新版時也會通知抽屜這顆，關掉卡片再打開抽屜看到的是「更新」而不是「檢查更新」

整塊在樣板上帶 `hidden`，`base.html` 註冊成功才拿掉。關掉 JS、瀏覽器不支援、或在不註冊 SW 的主機上都不會看到一顆按不動的按鈕。

按鈕重用全站共用的 `.anoni-banner-action` 與 `.anoni-spinner`，觸控尺寸與停用樣式跟換版提示那兩顆同一份。

## 一個實作上踩到的坑

抽屜長在 `.md-header` 裡面，文字色從 header 繼承下來是白的。抽屜裡原本每一列都各自指定過顏色所以看不出問題，直到放進一顆用 `color: inherit` 的 `.anoni-banner-action`，白字落在白底上整顆按鈕變空白。截圖才看得出來，computed style 量文字內容是正常的。

改成在 `.anoni-settings` 這一層定一次文字色，之後往抽屜裡加東西不會再踩到。

## 測試

補在 `tools/test_update_banner.mjs`，跟換版提示同一支，用同一套從 `base.html` 原地抽函式的做法，多十一個案例（共 16 個）。

兩次變異驗證確認抓得到真的壞掉：

| 變異 | 結果 |
|---|---|
| 拿掉 `box.hidden = false` | 1 個紅 |
| 把 `if (mode === "apply")` 改成 `if (false)` | 2 個紅 |

## 端到端驗證

真的 headless Chrome 註冊 service worker 跑完整條路，換掉 `output/sw.js` 的 `VERSION` 模擬部署新版：

```
抽屜打開  : {hidden:false, label:"檢查更新", status:""}
點下同 tick: {label:"檢查中", disabled:true, busy:"true", spinner:true}
檢查完     : {label:"檢查更新", disabled:false, status:"已是最新版本"}
有新版     : {label:"更新", cls:"...--primary", status:"離線存的內容有新版本。更新會重新載入這一頁。"}
套用同 tick: {label:"更新中", disabled:true, busy:"true", spinner:true}
套用之後   : 重新載入過= true
```

顏色與文案：

| 情境 | 文字色 | 底色 |
|---|---|---|
| zh-TW 亮色 | `rgba(0,0,0,.87)` | 透明 |
| en 亮色 | `rgba(0,0,0,.87)` | 透明 |
| zh-TW 暗色 | `rgb(255,255,255)` | 透明 |
| 有新版（暗色） | `rgb(255,255,255)` | `rgb(0,189,214)` |

三語系的文案都在地化（離線內容 / 离线内容 / Offline content，檢查更新 / 检查更新 / Check for updates），三語系都用 `run_*.sh` 以 `-s` 建置通過，`tools/` 十支相關測試全過。

## 一個既有的對比問題（不是這次引入的）

primary 按鈕在暗色下是白字配 `#00BDD6`，對比 2.27:1，低於 WCAG AA。那是站上 `--md-primary-fg-color` 與 `--md-primary-bg-color` 的配對，header 整條與既有的換版提示按鈕都是同一組，這次只是多了一個使用點。要調的話是全站的事，這個 PR 不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)