### PR TITLE
feat(header): 抽屜補上離線閱讀入口，檢查更新結果帶上日期

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -649,6 +649,7 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
+.anoni-settings__link,
 .anoni-settings__choice {
   display: none;
 }
@@ -764,16 +765,35 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     width: 1.2rem;
   }
 
-  .anoni-settings__update:not([hidden]) {
-    display: block;
+  /* 離線閱讀那一頁的入口。排版跟語言那幾列一致，兩組並排時左側圖示欄對得起來 */
+  .anoni-settings__link {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
   }
 
-  .anoni-settings__update-body {
-    padding: 0 0.8rem 0.8rem;
+  .anoni-settings__link-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__link-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+    padding: 0.2rem 0.8rem 0.8rem;
   }
 
   /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
-  .anoni-settings__update-body .anoni-banner-action {
+  .anoni-settings__update .anoni-banner-action {
     justify-content: center;
     width: 100%;
   }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -286,6 +286,7 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "閱讀語言"]
   # 抽屜裡「離線內容」那一組的文案，理由同上面 settings_*。
   settings_offline: !ENV [SETTINGS_OFFLINE, "離線內容"]
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "離線閱讀"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "檢查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -265,6 +265,7 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "阅读语言"]
   # 抽屉里「离线内容」那一组的文案，理由同上面 settings_*。
   settings_offline: !ENV [SETTINGS_OFFLINE, "离线内容"]
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "离线阅读"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "检查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -269,6 +269,7 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "Reading language"]
   # Copy for the "offline content" group in the drawer, same reason as settings_* above.
   settings_offline: !ENV [SETTINGS_OFFLINE, "Offline content"]
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "Offline reading"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "Check for updates"]
   # Icons for the three appearance options in the drawer, same order as theme.palette.
   # The upstream toggle.icon says "what this switches to", the drawer needs "what this

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -472,18 +472,21 @@
               text: "離線存的內容有新版本。更新會重新載入這一頁。",
               update: "更新", later: "稍後", updating: "更新中",
               checking: "檢查中", latest: "已是最新版本",
+              latestAt: "已是最新版本（{version}）",
               failed: "連不上，稍後再試"
             },
             "zh": {
               text: "离线存的内容有新版本。更新会重新加载这一页。",
               update: "更新", later: "稍后", updating: "更新中",
               checking: "检查中", latest: "已是最新版本",
+              latestAt: "已是最新版本（{version}）",
               failed: "连不上，稍后再试"
             },
             "en": {
               text: "A newer version is available for offline reading. Updating reloads this page.",
               update: "Update", later: "Later", updating: "Updating",
               checking: "Checking", latest: "Already up to date",
+              latestAt: "Already up to date ({version})",
               failed: "Could not check, try again later"
             }
           };
@@ -568,6 +571,16 @@
             dismiss = window.__anoniToast(banner);
           }
 
+          // 202609091018 這種十二位數對讀者沒有意義，拆成日期與時間。CI 產生它用的是
+          // date +%Y%m%d%H%M，runner 跑在 UTC，所以標出來免得讀者拿自己的時區去對。
+          // 認不出來的格式就回 null，改顯示不帶日期那句：本機建置沒有替換
+          // __BUILD_VERSION__，走的就是這條。
+          function formatVersion(value) {
+            var m = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})$/.exec(value || "");
+            if (!m) return null;
+            return m[1] + "-" + m[2] + "-" + m[3] + " " + m[4] + ":" + m[5] + " UTC";
+          }
+
           // 抽屜裡的檢查更新。換版提示是被動的，要等 service worker 自己裝好新版
           // 才浮出來，讀者按過稍後就得等下一次導覽，而 standalone 的 PWA 常常好幾天
           // 不產生新的導覽。這裡給一個隨時問得到的入口。
@@ -607,6 +620,41 @@
                 "anoni-banner-action" + (primary ? " anoni-banner-action--primary" : "");
             }
 
+            // 這台裝置上跑的是哪一版。VERSION 是輕量查詢，舊的 service worker 不認得
+            // 它，回不出東西就退回 OFFLINE_STATUS。那一則會順便算快取用量，存了整份
+            // 站的裝置上要走過每一筆項目，所以只當退路，讀者更新過一次就走輕的那條。
+            //
+            // 問不到就算了，按鈕不該因為這件事卡住，兩條路各給 1.5 秒。
+            function activeVersion() {
+              var active = navigator.serviceWorker.controller;
+              if (!active) return Promise.resolve(null);
+              function ask(message) {
+                return new Promise(function (resolve) {
+                  var channel = new MessageChannel();
+                  var settled = false;
+                  function finish(value) {
+                    if (settled) return;
+                    settled = true;
+                    resolve(value);
+                  }
+                  channel.port1.onmessage = function (event) {
+                    var reply = event.data || {};
+                    finish(typeof reply.version === "string" ? reply.version : null);
+                  };
+                  setTimeout(function () { finish(null); }, 1500);
+                  try {
+                    active.postMessage(message, [channel.port2]);
+                  } catch (err) {
+                    finish(null);
+                  }
+                });
+              }
+              return ask({ type: "VERSION" }).then(function (version) {
+                if (version) return version;
+                return ask({ type: "OFFLINE_STATUS", url: location.href });
+              });
+            }
+
             function toApply() {
               mode = "apply";
               status.textContent = t.text;
@@ -641,7 +689,15 @@
                 // update() 只保證檢查做完，裝新版可能還在跑，所以三種都要看
                 if (registration.waiting) { toApply(); return; }
                 var installing = registration.installing;
-                if (!installing) { toCheck(t.latest); return; }
+                if (!installing) {
+                  // 按鈕維持忙碌到版本問回來為止。先寫「已是最新版本」再補上日期的話
+                  // 那行字會在讀者眼前改兩次。
+                  activeVersion().then(function (version) {
+                    var stamp = formatVersion(version);
+                    toCheck(stamp ? t.latestAt.replace("{version}", stamp) : t.latest);
+                  });
+                  return;
+                }
                 installing.addEventListener("statechange", function () {
                   if (installing.state === "installed") toApply();
                   else if (installing.state === "redundant") toCheck(t.failed);

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -129,14 +129,23 @@
         同一份，定義在 base.html 的 styles block。狀態那一行的文字由 JS 填，
         role 與 aria-live 讓讀螢幕的人也拿得到結果。
       -#}
+      <p class="anoni-settings__group">{{ config.extra.settings_offline }}</p>
+      {#-
+        離線閱讀那一頁的入口。那一頁在 nav 裡的位置不淺，讀者不容易自己找到，
+        而它正是管理裝置上存了哪些內容的地方。
+
+        這個連結不跟著更新按鈕一起藏。沒有 service worker 的環境照樣看得到，
+        那一頁本來就會說明這個瀏覽器存不了離線內容，比一個消失的入口清楚。
+      -#}
+      <a href="{{ 'offline/' | url }}" class="anoni-settings__link">
+        <span class="anoni-settings__link-icon">{% include ".icons/material/wifi-off.svg" %}</span>
+        <span>{{ config.extra.settings_offline_link }}</span>
+      </a>
       <div class="anoni-settings__update" id="__anoni-update" hidden>
-        <p class="anoni-settings__group">{{ config.extra.settings_offline }}</p>
-        <div class="anoni-settings__update-body">
-          <button type="button" class="anoni-banner-action" id="__anoni-update-check">
-            {{ config.extra.settings_update_check }}
-          </button>
-          <p class="anoni-settings__status" id="__anoni-update-status" role="status" aria-live="polite"></p>
-        </div>
+        <button type="button" class="anoni-banner-action" id="__anoni-update-check">
+          {{ config.extra.settings_update_check }}
+        </button>
+        <p class="anoni-settings__status" id="__anoni-update-status" role="status" aria-live="polite"></p>
       </div>
     </div>
     {% if not config.theme.palette is mapping %}

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -641,6 +641,7 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
+.anoni-settings__link,
 .anoni-settings__choice {
   display: none;
 }
@@ -756,16 +757,35 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     width: 1.2rem;
   }
 
-  .anoni-settings__update:not([hidden]) {
-    display: block;
+  /* 離線閱讀那一頁的入口。排版跟語言那幾列一致，兩組並排時左側圖示欄對得起來 */
+  .anoni-settings__link {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
   }
 
-  .anoni-settings__update-body {
-    padding: 0 0.8rem 0.8rem;
+  .anoni-settings__link-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__link-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+    padding: 0.2rem 0.8rem 0.8rem;
   }
 
   /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
-  .anoni-settings__update-body .anoni-banner-action {
+  .anoni-settings__update .anoni-banner-action {
     justify-content: center;
     width: 100%;
   }

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -642,6 +642,7 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 .anoni-settings__overlay,
 .anoni-settings__head,
 .anoni-settings__group,
+.anoni-settings__link,
 .anoni-settings__choice {
   display: none;
 }
@@ -757,16 +758,35 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
     width: 1.2rem;
   }
 
-  .anoni-settings__update:not([hidden]) {
-    display: block;
+  /* 離線閱讀那一頁的入口。排版跟語言那幾列一致，兩組並排時左側圖示欄對得起來 */
+  .anoni-settings__link {
+    align-items: center;
+    color: var(--md-default-fg-color);
+    display: flex;
+    font-size: 0.7rem;
+    gap: 0.4rem;
+    padding: 0.5rem 0.8rem;
   }
 
-  .anoni-settings__update-body {
-    padding: 0 0.8rem 0.8rem;
+  .anoni-settings__link-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  .anoni-settings__link-icon svg {
+    display: block;
+    fill: currentcolor;
+    height: 0.9rem;
+    width: 0.9rem;
+  }
+
+  .anoni-settings__update:not([hidden]) {
+    display: block;
+    padding: 0.2rem 0.8rem 0.8rem;
   }
 
   /* 按鈕撐滿抽屜寬度。抽屜只有 12.1rem，靠左的窄按鈕在這個寬度裡看起來像沒排好 */
-  .anoni-settings__update-body .anoni-banner-action {
+  .anoni-settings__update .anoni-banner-action {
     justify-content: center;
     width: 100%;
   }

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -1000,6 +1000,18 @@ self.addEventListener("message", (event) => {
     return;
   }
 
+  // 只回版本的輕量查詢。設定抽屜按下檢查更新、結果是已經最新的時候，拿它把日期
+  // 一起顯示出來，讀者才知道手上這份是哪一天的。
+  //
+  // 不共用 OFFLINE_STATUS：那一則會順便算 cacheUsage，而那是走過每一筆快取項目、
+  // 缺 content-length 就把整個 blob 讀出來。存了整份站的裝置上，光為了一串版本號
+  // 付那個代價不划算。client 端認得舊 SW 不回這則的情況，會自己退回 OFFLINE_STATUS。
+  if (data.type === "VERSION") {
+    const versionPort = event.ports && event.ports[0];
+    if (versionPort) versionPort.postMessage({ type: "version", version: VERSION });
+    return;
+  }
+
   // 頁面載入時 client 送自己的網址過來，SW 據此補齊那個語系的預快取。
   //
   // 傳網址而不是語系代碼，是因為 document.documentElement.lang 在 zh-CN 版是 "zh"

--- a/tools/test_update_banner.mjs
+++ b/tools/test_update_banner.mjs
@@ -185,7 +185,7 @@ test('沒按更新之前兩顆都是可以按的', () => {
 // 抽屜裡的檢查更新
 // ---------------------------------------------------------------------------
 
-const loadCheck = ({ waiting = null, installing = null, updateFails = false, hasDom = true } = {}) => {
+const loadCheck = ({ waiting = null, installing = null, updateFails = false, hasDom = true, swVersion = '202609091018', legacySw = false } = {}) => {
   const box = new FakeElement('div');
   // 樣板給的初始狀態就是 hidden，假替身要照著來，不然「有沒有拿掉」驗不到東西
   box.hidden = true;
@@ -213,23 +213,50 @@ const loadCheck = ({ waiting = null, installing = null, updateFails = false, has
     installing,
     update: () => (updateFails ? Promise.reject(new Error('offline')) : Promise.resolve()),
   };
-  const navigator = { serviceWorker: { controller: {} } };
+  // MessagePort 的兩端在這裡不需要真的跨執行緒，接上就好
+  class FakeChannel {
+    constructor() {
+      this.port1 = { onmessage: null };
+      this.port2 = { deliver: (data) => { if (this.port1.onmessage) this.port1.onmessage({ data }); } };
+    }
+  }
+  const asked = [];
+  // swVersion 給 false 代表這一頁還沒被 service worker 接管，問不到任何東西。
+  // legacySw 模擬舊版 sw.js：它不認得 VERSION，會掉到 library 的分派回 unknown-command。
+  const controller = swVersion === false ? null : {
+    postMessage: (message, ports) => {
+      asked.push(message.type);
+      if (message.type === 'VERSION') {
+        ports[0].deliver(
+          legacySw ? { type: 'error', reason: 'unknown-command' }
+                   : { type: 'version', version: swVersion }
+        );
+        return;
+      }
+      ports[0].deliver({ type: 'status', version: swVersion });
+    },
+  };
+  const navigator = { serviceWorker: { controller } };
 
   const harness = `
     ${grab(/var STRINGS = \{[\s\S]*?\n          \};/)}
     var t = STRINGS["zh-TW"];
     var reloadOnTakeover = false;
     var onUpdateReady = function () {};
+    ${grab(/function formatVersion\(value\) \{[\s\S]*?\n          \}/)}
     ${grab(/function setupUpdateCheck\(registration\) \{[\s\S]*?\n          \}/)}
     return {
       setup: setupUpdateCheck,
+      formatVersion: formatVersion,
       reloaded: function () { return reloadOnTakeover; },
       ready: function () { return onUpdateReady; }
     };
   `;
-  const api = new Function('document', 'navigator', harness)(document, navigator);
+  const api = new Function('document', 'navigator', 'MessageChannel', 'location', harness)(
+    document, navigator, FakeChannel, { href: 'https://anoni.net/docs/tools/what-is-tor/' }
+  );
   api.setup(registration);
-  return { api, box, button, status, sent, registration };
+  return { api, box, button, status, sent, registration, asked };
 };
 
 // 讓 registration.update() 那條 promise 鏈跑完
@@ -273,13 +300,44 @@ test('按下檢查會停用並顯示檢查中與轉圈', async () => {
 });
 
 test('檢查完沒有新版就說已是最新版本', async () => {
-  const { button, status } = loadCheck();
+  // 這一頁還沒被 service worker 接管的話問不到版本，那就只說結論
+  const { button, status } = loadCheck({ swVersion: false });
   button.click();
   await flush();
   assert.equal(status.textContent, '已是最新版本');
   assert.equal(button.textContent, '檢查更新', '按鈕沒有還原成原本那串');
   assert.equal(button.disabled, false);
   assert.equal(button.getAttribute('aria-busy'), null);
+});
+
+test('版本號拆成看得懂的日期', () => {
+  const { api } = loadCheck();
+  assert.equal(api.formatVersion('202609091018'), '2026-09-09 10:18 UTC');
+});
+
+test('認不出來的版本字串不硬湊日期', () => {
+  // 本機建置沒有替換佔位字串，走的就是這條。硬拆會給出一個看起來像真的假日期。
+  const { api } = loadCheck();
+  for (const bad of ['__BUILD_VERSION__', '', null, undefined, '20260909101', '2026090910180', '2026-09-09'])
+    assert.equal(api.formatVersion(bad), null, String(bad));
+});
+
+test('已是最新版本會帶上日期', async () => {
+  const { button, status, asked } = loadCheck();
+  button.click();
+  await flush();
+  assert.equal(status.textContent, '已是最新版本（2026-09-09 10:18 UTC）');
+  assert.deepEqual(asked, ['VERSION'], '第一問就該用輕量的那則');
+});
+
+test('舊的 service worker 不認得 VERSION 就退回 OFFLINE_STATUS', async () => {
+  // 這顆按鈕上線的當下，讀者裝置上跑的還是舊版 sw.js，退路沒接好就整整一個
+  // 版本週期看不到日期
+  const { button, status, asked } = loadCheck({ legacySw: true });
+  button.click();
+  await flush();
+  assert.deepEqual(asked, ['VERSION', 'OFFLINE_STATUS']);
+  assert.equal(status.textContent, '已是最新版本（2026-09-09 10:18 UTC）');
 });
 
 test('檢查完抓不到 sw.js 就說連不上', async () => {


### PR DESCRIPTION
## 這個 PR 兩件事

1. 抽屜的「離線內容」加上離線閱讀那一頁的入口
2. 檢查更新的結果帶上離線內容的日期

---

## 一、離線閱讀的入口

離線閱讀在 nav 裡的位置不淺，讀者不容易自己找到，而它正是管理裝置上存了哪些內容的地方。抽屜的「離線內容」那一組補一個連結，排在檢查更新上面。

網址用 `{{ 'offline/' | url }}`，mkdocs 算相對路徑：

| 語系 | 連結文字 | 解析後 |
|---|---|---|
| zh-TW | 離線閱讀 | `/offline/` |
| zh-CN | 离线阅读 | `/zh-cn/offline/` |
| en | Offline reading | `/en/offline/` |

原本群組標題與按鈕一起包在 `#__anoni-update` 裡，整塊等 service worker 註冊成功才顯示。現在只有按鈕那一塊等，標題與連結永遠都在。沒有 service worker 的環境更需要看到那個入口，那一頁本來就會說明這個瀏覽器存不了離線內容。

關掉 JS 實測（`Emulation.setScriptExecutionDisabled`）：抽屜照樣打得開，連結在且 `href` 正確，檢查更新那一塊維持 `hidden`。

---

## 二、檢查更新帶上日期

按下檢查更新回「已是最新版本」時，讀者無從確認那是哪一版。補上日期之後那句話從一個宣稱變成可以核對的事實：

```
已是最新版本（2026-09-09 10:18 UTC）
```

### 為什麼不在抽屜放常駐的版本號

離線閱讀那一頁本來就有「離線內容版本」一行（`offline-library.js` 的 `ol-version`，三語系都有）。抽屜再放一份等於同一件事有兩個來源，取得時機不同還有機會顯示不一致。而那一頁現在就在抽屜的連結後面，不遠。

日期只在讀者主動問的那一刻出現，也剛好是這個問題會冒出來的時機。

### sw.js 加了一則輕量訊息

`VERSION` 只回版本字串。不共用既有的 `OFFLINE_STATUS`，那一則會順便算 `cacheUsage`，而那是走過每一筆快取項目、缺 `content-length` 就把整個 blob 讀出來。存了整份站的裝置上，光為了一串版本號付那個代價不划算。

### 上線當天就要能用

這顆按鈕上線的當下，讀者裝置上跑的還是舊版 `sw.js`，它不認得 `VERSION`，會掉到 library 的分派回 `unknown-command`。client 端認得這個情況，退回 `OFFLINE_STATUS`，所以第一天就看得到日期，讀者更新過一次之後改走輕的那條。

### 格式

版本字串是 CI 的 `date +%Y%m%d%H%M`，runner 跑在 UTC。十二位數對讀者沒有意義，`formatVersion` 拆成 `2026-09-09 10:18 UTC` 並標出時區，免得讀者拿自己的時區去對。認不出來的格式回 `null`，改顯示不帶日期那一句，本機建置沒有替換佔位字串就走這條。

---

## 測試

`tools/test_update_banner.mjs` 多四個案例（共 20 個），假的 `MessageChannel` 把兩端接起來，另外模擬舊版 SW 回 `unknown-command`。

兩次變異驗證確認測試抓得到真的壞掉：

| 變異 | 結果 |
|---|---|
| 拿掉 `OFFLINE_STATUS` 退路 | 1 個紅 |
| `formatVersion` 直接回原字串 | 3 個紅 |

真的 headless Chrome 也跑過三種情況，把 `output/sw.js` 的 `VERSION` 換成 `202609091018`：

| 情況 | 結果 |
|---|---|
| 正常時間戳 | 已是最新版本（2026-09-09 10:18 UTC） |
| 移除 `VERSION` 處理器（模擬舊 SW） | 已是最新版本（2026-09-09 10:18 UTC），走退路 |
| 留著 `__BUILD_VERSION__` 佔位字串 | 已是最新版本 |

三語系用 `run_*.sh` 以 `-s` 建置通過，`tools/` 十一支相關測試全過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
