### PR TITLE
fix(header): 抽屜的離線那一列改成動作講法，按鈕字級補回來

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -719,6 +719,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
        在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
        primary 那組。 */
     color: var(--md-default-fg-color);
+    /* 字級也要在容器定一次，理由跟上面的文字色一樣。Material 的 body 是 .5rem
+       （10px），各元件自己設自己的。抽屜裡每一列都指定過所以看不出問題，直到
+       放進一顆 font:inherit 的 .anoni-banner-action，那顆按鈕就掉到 10px，比
+       旁邊每一列都小，連它自己底下的狀態列都比它大。底部提示卡那份沒事，是因為
+       .anoni-toast 有設 .7rem。 */
+    font-size: 0.7rem;
     bottom: 0;
     display: block;
     overflow-y: auto;

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -286,7 +286,11 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "閱讀語言"]
   # 抽屜裡「離線內容」那一組的文案，理由同上面 settings_*。
   settings_offline: !ENV [SETTINGS_OFFLINE, "離線內容"]
-  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "離線閱讀"]
+  # 這一列是連到離線閱讀那一頁的連結，不是開關。名詞開頭（「離線閱讀」）排在
+  # 亮色、暗色那幾列旁邊會被讀成狀態，動詞開頭才看得出是一個去得了的地方。
+  # 不用「管理離線內容」是因為正上方的群組標題就是「離線內容」，相鄰兩行重複
+  # 同一個詞讀起來卡。
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "管理裝置中的內容"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "檢查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -265,7 +265,11 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "阅读语言"]
   # 抽屉里「离线内容」那一组的文案，理由同上面 settings_*。
   settings_offline: !ENV [SETTINGS_OFFLINE, "离线内容"]
-  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "离线阅读"]
+  # 这一列是连到离线阅读那一页的链接，不是开关。名词开头（「离线阅读」）排在
+  # 浅色、深色那几列旁边会被读成状态，动词开头才看得出是一个去得了的地方。
+  # 不用「管理离线内容」是因为正上方的分组标题就是「离线内容」，相邻两行重复
+  # 同一个词读起来卡。
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "管理设备中的内容"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "检查更新"]
   # 外觀那三個選項在抽屜裡的圖示，順序跟 theme.palette 一致。上游 toggle.icon 講的是
   # 「點下去會切到哪一種」，抽屜要的是「這一項本身是什麼」，兩者對不起來，所以另外列。

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -269,7 +269,11 @@ extra:
   settings_language: !ENV [SETTINGS_LANGUAGE, "Reading language"]
   # Copy for the "offline content" group in the drawer, same reason as settings_* above.
   settings_offline: !ENV [SETTINGS_OFFLINE, "Offline content"]
-  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "Offline reading"]
+  # This row links to the offline reading page, it is not a switch. A noun phrase
+  # sitting next to Light and Dark reads like a state, a verb makes it a place you
+  # can go. Not "Manage offline content": the group heading right above it already
+  # says "Offline content".
+  settings_offline_link: !ENV [SETTINGS_OFFLINE_LINK, "Manage stored content"]
   settings_update_check: !ENV [SETTINGS_UPDATE_CHECK, "Check for updates"]
   # Icons for the three appearance options in the drawer, same order as theme.palette.
   # The upstream toggle.icon says "what this switches to", the drawer needs "what this

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -711,6 +711,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
        在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
        primary 那組。 */
     color: var(--md-default-fg-color);
+    /* 字級也要在容器定一次，理由跟上面的文字色一樣。Material 的 body 是 .5rem
+       （10px），各元件自己設自己的。抽屜裡每一列都指定過所以看不出問題，直到
+       放進一顆 font:inherit 的 .anoni-banner-action，那顆按鈕就掉到 10px，比
+       旁邊每一列都小，連它自己底下的狀態列都比它大。底部提示卡那份沒事，是因為
+       .anoni-toast 有設 .7rem。 */
+    font-size: 0.7rem;
     bottom: 0;
     display: block;
     overflow-y: auto;

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -712,6 +712,12 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
        在容器這一層定一次，之後往抽屜裡加東西不會再踩到。標題列自己會覆蓋回
        primary 那組。 */
     color: var(--md-default-fg-color);
+    /* 字級也要在容器定一次，理由跟上面的文字色一樣。Material 的 body 是 .5rem
+       （10px），各元件自己設自己的。抽屜裡每一列都指定過所以看不出問題，直到
+       放進一顆 font:inherit 的 .anoni-banner-action，那顆按鈕就掉到 10px，比
+       旁邊每一列都小，連它自己底下的狀態列都比它大。底部提示卡那份沒事，是因為
+       .anoni-toast 有設 .7rem。 */
+    font-size: 0.7rem;
     bottom: 0;
     display: block;
     overflow-y: auto;


### PR DESCRIPTION
## 這個 PR 兩件事

1. 離線那一列的文案改成動作講法
2. 檢查更新按鈕的字級補回來

---

## 一、文案改成動作講法

「離線閱讀」是名詞片語，排在亮色、暗色那幾列旁邊會被讀成一個狀態或開關，而它其實是連到一頁的連結。

| 語系 | 原本 | 改成 |
|---|---|---|
| zh-TW | 離線閱讀 | 管理裝置中的內容 |
| zh-CN | 离线阅读 | 管理设备中的内容 |
| en | Offline reading | Manage stored content |

不用「管理離線內容」，因為正上方的群組標題就是「離線內容」，相鄰兩行重複同一個詞讀起來卡。「裝置」既避開重複，也比「離線」更接近讀者在那一頁實際會看到的東西。

寬度量過，抽屜文字可用約 196px，最長的英文候選 144px。360px 螢幕上三個語系都是單行。

圖示維持 `material/wifi-off`，跟目的地那一頁 frontmatter 的 `icon` 同一顆。文字負責動作，圖示負責主題。

---

## 二、按鈕字級

那顆按鈕的字是 **10px**，而抽屜裡每一列都是 14px，連它自己底下的狀態列都有 12.4px，變成整個抽屜最小的一段字。

原因：`.anoni-banner-action` 用 `font: inherit`，而 Material 的 `body` 是 `.5rem`（10px），各元件自己設自己的。抽屜裡每一列都指定過所以看不出問題，直到放進一顆 `font: inherit` 的按鈕就掉到 body 那個值。底部提示卡那份沒事，是因為 `.anoni-toast` 有設 `.7rem`。

修法是在 `.anoni-settings` 這一層定一次 `font-size: 0.7rem`，跟先前那次文字色是同一個修法，之後往抽屜裡加東西不會再踩到。規則在窄螢幕的媒體查詢裡，桌面不受影響。

| 元素 | 改前 | 改後 |
|---|---|---|
| 群組標題 | 12.8px | 12.8px |
| 外觀列 | 14px | 14px |
| 語言列 | 14px | 14px |
| 管理列 | 14px | 14px |
| **檢查更新按鈕** | **10px** | **14px** |
| 狀態列 | 12.4px | 12.4px |

按鈕列高維持 34px。

---

## 驗證

- 三語系用 `run_*.sh` 以 `-s` 建置通過
- 連結解析仍是 `/offline/`、`/zh-cn/offline/`、`/en/offline/`，實際點下去到得了那一頁
- 觸控四條關閉路徑與選色都正常，全程沒有 tooltip
- 檢查更新的三種情況（正常時間戳、模擬舊 SW、認不出的格式）結果不變
- 1440px 的 header 與改之前一致
- `tools/` 八支相關測試全過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
