### PR TITLE
content(tor): 補上 en 的行動版一節，說明頁指過去，Snowflake 說法對齊

### DIFF
--- a/docs/en/about/how-you-are-reading.md
+++ b/docs/en/about/how-you-are-reading.md
@@ -35,6 +35,8 @@ An `.onion` address carries no certificate authority endorsement, so checking th
 
 This edition loads no analytics and registers no background Service Worker, which is why offline reading is absent. Latency is higher than the standard site, as it is for Tor generally.
 
+Which app to use on a phone, and why iOS has no official Tor Browser, is in [Tor on a phone](../tools/tor-browser-advanced.md#Tor-on-a-phone).
+
 ## IPFS mirror
 
 Content is addressed by fingerprint (CID), so any node can serve the same copy and there is no single location to take down. Community members can help keep a copy alive, described in [pin the IPFS mirror](../community/pin-ipfs-mirror.md).

--- a/docs/en/tools/tor-browser-advanced.md
+++ b/docs/en/tools/tor-browser-advanced.md
@@ -78,7 +78,7 @@ Neither platform gives you what the desktop browser gives you, and they fall sho
 
 Two more things are weaker on a phone than on a laptop:
 
-- Running a Snowflake proxy from a phone is a poor fit. It drains the battery, heats the device, and the system kills it once the app goes to the background.
+- The browser-tab version of Snowflake is a poor fit on a phone, where the system cuts the WebRTC connection once the tab goes to the background. For sustained contribution from a phone the Tor Project publishes a standalone app, covered in [Tor Snowflake bridges](./tor-snowflake.md).
 - If your threat model is the journalist or activist end of the range, prefer the desktop browser, or [Tails](./what-is-tails.md) where the operating system enforces the isolation rather than the browser.
 
 ## Where to go from here

--- a/docs/en/tools/tor-browser-advanced.md
+++ b/docs/en/tools/tor-browser-advanced.md
@@ -68,6 +68,19 @@ Most people who lose anonymity on Tor don't lose it to a broken setting. They lo
 
 These come back to the same idea covered in [anonymity, privacy, pseudonymity, and confidentiality](../basics/anonymity-vs-privacy.md): Tor protects the *who-talked-to-what* of a connection, and you give that away the moment your own actions reattach a name to it.
 
+## Tor on a phone
+
+Neither platform gives you what the desktop browser gives you, and they fall short for different reasons.
+
+**Android** has an official Tor Browser from the Tor Project, listed alongside the desktop builds on the [download page](https://www.torproject.org/download/){target="_blank"}. It runs the same Tor engine, and most of the settings on this page are there: security levels, bridges, New Identity.
+
+**iOS has no official Tor Browser, and cannot have one.** Apple requires every browser on iOS to render with WebKit, so an app can route your traffic through Tor but cannot ship the engine changes that Tor Browser's fingerprinting defences are built from. The Tor Project points iOS users to [Onion Browser](https://onionbrowser.com/){target="_blank"}, an open-source app whose contributors include Mike Tigas, Benjamin Erhart and the Guardian Project.[^7] Traffic goes over Tor; the fingerprint resistance described earlier on this page does not carry over.
+
+Two more things are weaker on a phone than on a laptop:
+
+- Running a Snowflake proxy from a phone is a poor fit. It drains the battery, heats the device, and the system kills it once the app goes to the background.
+- If your threat model is the journalist or activist end of the range, prefer the desktop browser, or [Tails](./what-is-tails.md) where the operating system enforces the isolation rather than the browser.
+
 ## Where to go from here
 
 - [Tor Browser manual](https://tb-manual.torproject.org/){target="_blank"} — the canonical, current step-by-step for every setting on this page, including exact bridge and security-level instructions.
@@ -82,3 +95,4 @@ These come back to the same idea covered in [anonymity, privacy, pseudonymity, a
 [^4]: [What is lyrebird?](https://support.torproject.org/tbb/lyrebird/){target="_blank"} — Tor Project Support. Lyrebird is the program in Tor Browser that implements obfs4, meek, Snowflake, and WebTunnel.
 [^5]: [Hiding in plain sight: Introducing WebTunnel](https://blog.torproject.org/introducing-webtunnel-evading-censorship-by-hiding-in-plain-sight/){target="_blank"} — The Tor Project Blog.
 [^6]: [Managing identities](https://support.torproject.org/managing-identities/){target="_blank"} — Tor Project Support.
+[^7]: [Can I run Tor Browser on an iOS device?](https://support.torproject.org/tormobile/tormobile-3/){target="_blank"} — Tor Project Support. "Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser."

--- a/docs/en/tools/tor-snowflake.md
+++ b/docs/en/tools/tor-snowflake.md
@@ -79,7 +79,7 @@ If your computer is on for long stretches, the extension version is better than 
 
 ??? question "Can I run it on a phone?"
 
-    Yes, but with limited effect. Mobile networks change IP often, and the OS cuts WebRTC connections once the app goes to the background. For sustained contribution, use a desktop or laptop.
+    The browser-tab version has limited effect: mobile networks change IP often, and the OS cuts WebRTC connections once the tab goes to the background. For sustained contribution from a phone, the Tor Project publishes a standalone app, [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}, which runs as a background service rather than a browser tab and is not subject to that limit. The [announcement](../blog/posts/snowflake-volunteer-android-app.md) has the detail.
 
 ??? question "How does it compare with running a Tor relay?"
 

--- a/docs/zh-CN/about/how-you-are-reading.md
+++ b/docs/zh-CN/about/how-you-are-reading.md
@@ -35,6 +35,8 @@ icon: material/routes
 
 这一版不加载任何分析脚本，也不注册后台的 Service Worker，所以没有离线阅读。延迟比标准网站高，那是 Tor 的常态。
 
+手机上要用哪一个 App、iOS 为什么没有官方版本，见 [Tor Browser 进阶设定的移动版一节](../tools/tor-browser-advanced.md#移动版)。
+
 ## IPFS 镜像
 
 内容用指纹（CID）寻址，任何节点都能提供同一份内容，没有单一可以被下架的位置。社群成员可以帮忙留存一份，做法见 [帮忙 pin 文档站的 IPFS 镜像](../community/pin-ipfs-mirror.md)。

--- a/docs/zh-CN/tools/tor-browser-advanced.md
+++ b/docs/zh-CN/tools/tor-browser-advanced.md
@@ -138,7 +138,7 @@ Tor Browser 的匿名性靠「全球用户长得一样」维持。几个基本�
 移动装置上的 Tor 体验较弱，跟桌面版有几个差异：
 
 - iOS 因 WebKit 限制，无法做到桌面版完整的指纹抗性
-- 移动装置不适合长时间执行 Snowflake 客户端，耗电、发热、进入背景会被系统杀
+- 浏览器标签页版的 Snowflake 在手机上效果有限，标签页进入后台后系统经常中断 WebRTC 连线。想用手机长期贡献，改用官方的独立 App，见 [Tor Snowflake 桥接点](./tor-snowflake.md)
 - 进阶威胁模型（记者、行动者）建议优先用桌面版的 Tor Browser，或直接改用 [Tails](./what-is-tails.md)
 
 ## 台湾常见错误排解

--- a/docs/zh-CN/tools/tor-browser-advanced.md
+++ b/docs/zh-CN/tools/tor-browser-advanced.md
@@ -133,7 +133,7 @@ Tor Browser 的匿名性靠「全球用户长得一样」维持。几个基本�
 桌面版以外的选择有限：
 
 - **Android**：[Tor Browser for Android](https://www.torproject.org/download/#android){target="_blank"}（Tor Project 官方），跟桌面版同一个 Tor 引擎，多数设定齐备
-- **iOS**：[Onion Browser](https://onionbrowser.com/){target="_blank"}（Mike Tigas 维护的社群版本，**非 Tor Project 官方**）。Apple 的 App Store 政策不允许 Tor Project 直接发 iOS 版本，所有 iOS 上的浏览器底层都受限于 WebKit（Safari 内核）
+- **iOS**：[Onion Browser](https://onionbrowser.com/){target="_blank"}（开源社群版本，**非 Tor Project 官方**，贡献者包含 Mike Tigas、Benjamin Erhart 与 Guardian Project）。Apple 的 App Store 政策不允许 Tor Project 直接发 iOS 版本，所有 iOS 上的浏览器底层都受限于 WebKit（Safari 内核）
 
 移动装置上的 Tor 体验较弱，跟桌面版有几个差异：
 

--- a/docs/zh-TW/about/how-you-are-reading.md
+++ b/docs/zh-TW/about/how-you-are-reading.md
@@ -35,6 +35,8 @@ icon: material/routes
 
 這一版不載入任何分析腳本，也不註冊背景的 Service Worker，所以沒有離線閱讀。延遲比標準網站高，那是 Tor 的常態。
 
+手機上要用哪一個 App、iOS 為什麼沒有官方版本，見 [Tor Browser 進階設定的行動版一節](../tools/tor-browser-advanced.md#行動版)。
+
 ## IPFS 鏡像
 
 內容用指紋（CID）定址，任何節點都能提供同一份內容，沒有單一可以被下架的位置。社群成員可以幫忙留存一份，做法見 [幫忙 pin 文件站的 IPFS 鏡像](../community/pin-ipfs-mirror.md)。

--- a/docs/zh-TW/tools/tor-browser-advanced.md
+++ b/docs/zh-TW/tools/tor-browser-advanced.md
@@ -133,7 +133,7 @@ Tor Browser 的匿名性靠「全球使用者長得一樣」維持。幾個基�
 桌面版以外的選擇有限：
 
 - **Android**：[Tor Browser for Android](https://www.torproject.org/download/#android){target="_blank"}（Tor Project 官方），跟桌面版同一個 Tor 引擎，多數設定齊備
-- **iOS**：[Onion Browser](https://onionbrowser.com/){target="_blank"}（Mike Tigas 維護的社群版本，**非 Tor Project 官方**）。Apple 的 App Store 政策不允許 Tor Project 直接發 iOS 版本，所有 iOS 上的瀏覽器底層都受限於 WebKit（Safari 內核）
+- **iOS**：[Onion Browser](https://onionbrowser.com/){target="_blank"}（開源社群版本，**非 Tor Project 官方**，貢獻者包含 Mike Tigas、Benjamin Erhart 與 Guardian Project）。Apple 的 App Store 政策不允許 Tor Project 直接發 iOS 版本，所有 iOS 上的瀏覽器底層都受限於 WebKit（Safari 內核）
 
 行動裝置上的 Tor 體驗較弱，跟桌面版有幾個差異：
 

--- a/docs/zh-TW/tools/tor-browser-advanced.md
+++ b/docs/zh-TW/tools/tor-browser-advanced.md
@@ -138,7 +138,7 @@ Tor Browser 的匿名性靠「全球使用者長得一樣」維持。幾個基�
 行動裝置上的 Tor 體驗較弱，跟桌面版有幾個差異：
 
 - iOS 因 WebKit 限制，無法做到桌面版完整的指紋抗性
-- 行動裝置不適合長時間執行 Snowflake 客戶端，耗電、發熱、進入背景會被系統殺
+- 瀏覽器分頁版的 Snowflake 在手機上效果有限，分頁進入背景後系統經常中斷 WebRTC 連線。想用手機長期貢獻，改用官方的獨立 App，見 [Tor Snowflake 橋接點](./tor-snowflake.md)
 - 進階威脅模型（記者、行動者）建議優先用桌面版的 Tor Browser，或直接改用 [Tails](./what-is-tails.md)
 
 ## 台灣常見錯誤排解


### PR DESCRIPTION
## 問題

「你正在用哪一種方式閱讀」的對照表寫著 Onion 那一欄需要 Tor Browser，但那一格沒有連結，整個 Onion 段落也沒有任何連結。讀者知道需要 Tor Browser，卻沒有下一步可以點，而手機上該用哪一個 App 正是最需要指路的地方。

查下去發現三語系的覆蓋也不一致：

| 語系 | 行動版一節 | 位置 |
|---|---|---|
| zh-TW | 有 | `tools/tor-browser-advanced.md` 的「行動版」 |
| zh-CN | 有 | 同上的「移动版」 |
| en | **沒有** | 那份是另一份較短的內容，整頁沒出現 Onion Browser 或 Android |

## 四處修正

**一、補上 en 的「Tor on a phone」。** 涵蓋 Android 有官方版、iOS 沒有也不可能有（WebKit 限制）、以及手機上較弱的地方。

**二、三語系的說明頁在 Onion 段落末尾補一句指過去。**

**三、Onion Browser 的維護者資訊更新。** 中文版原本寫「Mike Tigas 維護的社群版本」，`onionbrowser.com` 現在列的貢獻者是 Mike Tigas、Benjamin Erhart 與 Guardian Project。

**四、手機上的 Snowflake 說法對齊。** 三份 `tor-browser-advanced.md` 都寫著「行動裝置不適合長時間執行 Snowflake 客戶端，耗電、發熱、進入背景會被系統殺」。en 那一節是這個 PR 前一個 commit 加的，我照抄了中文版的說法，錯誤跟著複製了一份。

站上自己的文件說的是另一回事：

- `tools/tor-snowflake.md` 的 Q&A 寫著想用手機長期貢獻可以改用官方推出的獨立 App Snowflake Volunteer，用的是背景服務而非瀏覽器分頁
- `blog/posts/snowflake-volunteer-android-app.md` 是一整篇翻譯官方公告的專文，三個語系都有

三份都改成區分瀏覽器分頁版與獨立 App。「發熱」查不到出處，移除。

順帶補 en 的 `tor-snowflake.md`：它的「Can I run it on a phone?」只寫瀏覽器分頁版的限制與「用桌機或筆電」，沒有提獨立 App，跟 zh-TW、zh-CN 的同一則 Q&A 不一致，也跟 en 自己的部落格專文矛盾。

## 事實查證

逐項查過，不靠記憶：

- `torproject.org` 的下載頁只列 Desktop 與 Android，沒有 iOS
- `tormobile-3` 確認沒有官方 iOS 版本，指向 Onion Browser。原文：「Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser.」這句放進 en 那節的註腳
- `onionbrowser.com` 列出的貢獻者如上
- Snowflake Volunteer 的來源是站上既有的翻譯專文與 Tor Project 官方公告

## 錨點

三語系都逐一比對產物裡的 id：

| 語系 | 連結 | 目標 id |
|---|---|---|
| zh-TW | `#行動版` | 有 |
| zh-CN | `#移动版` | 有 |
| en | `#Tor-on-a-phone` | 有 |

這個站的標題 id 保留大小寫。en 那條一開始寫成小寫的 `#tor-on-a-phone`，實際 id 是 `#Tor-on-a-phone`，而建置不會為此報錯，是查產物才發現的。

## 驗證

三語系依 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 順序建置通過，變更的檔案都跑過 `docs_style_lint.py`，`tools/` 四支相關測試全過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
