### PR TITLE
content(tor): 新增手機上的 Tor（三語系）

### DIFF
--- a/docs/en/tools/tor-browser-mobile.md
+++ b/docs/en/tools/tor-browser-mobile.md
@@ -1,0 +1,102 @@
+---
+title: Tor on a phone
+description: Android has an official Tor Browser from the Tor Project. iOS has none and cannot have one, leaving the community-maintained Onion Browser. How to install each, what to handle on first launch, how to confirm you are actually on Tor, and when to put the phone down and use a computer.
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: Tor on a phone
+
+You have an `.onion` address, your usual browser refuses to open it, and what you need is Tor. What to install differs by platform, and so does what you get once it is installed.
+
+[What is Tor](./what-is-tor.md) covers the ground this page assumes. Bridges and security levels are in [Tor Browser advanced settings](./tor-browser-advanced.md); this page only covers what is different on a phone.
+
+## The two platforms are not equivalent
+
+Android has a Tor Browser published by the Tor Project itself, running the same Tor engine as the desktop build, with most of its settings present.
+
+iOS has no official build. Apple requires every browser on iOS to render with WebKit, and Tor Browser's fingerprinting defences are built from changes to the browser engine — changes that cannot be made under WebKit. The limit comes from Apple's platform policy rather than from any version lagging behind. The Tor Project therefore points iOS readers to Onion Browser.[^1]
+
+| | Android | iOS |
+|---|---|---|
+| Official build | Yes, from the Tor Project | No |
+| App | Tor Browser for Android | Onion Browser |
+| Traffic over Tor | Yes | Yes |
+| Fingerprint resistance | Close to desktop | Not achievable under WebKit |
+| Requirements | Android 5.0 or newer | As listed on the App Store |
+
+Both route traffic over Tor, so opening an `.onion` address works on either. What differs is whether you also resist fingerprinting while you do it.
+
+## Four ways to get it on Android
+
+The Tor Project names Google Play, F-Droid, its own website, and GetTor.[^2]
+
+**Google Play** is the most direct, and updates arrive through the system. It needs a Google account, and the download is recorded against that account.
+
+**F-Droid** needs no Google account. Install F-Droid, add the Guardian Project repository under **My Apps** → **Repositories**, then search for Tor Browser for Android and install it.[^3]
+
+**The Tor Project website** serves the APK directly, for when the first two are unreachable.
+
+**GetTor** is the last resort for when the website itself is blocked, returning download links over email or another channel.
+
+Which one to use follows from where you are. Avoiding a Google account points you to F-Droid. Under heavier blocking, Google Play and F-Droid may both be unreachable, which is when the website and GetTor matter.
+
+One caveat on the direct APK: the Tor Project's signature verification instructions cover Windows, macOS and Linux, with no Android procedure.[^4] Once you hold an APK there is no documented official way to confirm it has not been altered. Prefer F-Droid or Google Play, where the store carries responsibility for integrity, and treat the direct download as the fallback for when neither is reachable.
+
+## What to handle on first launch
+
+Tor Browser for Android connects on startup. When it cannot, something on the network is usually blocking Tor. The app includes Connection Assist, and bridges can be selected by hand. Which bridge suits which kind of blocking is in [Tor Browser advanced settings](./tor-browser-advanced.md#Bridges-for-where-Tor-is-blocked).
+
+The security level starts at **Standard**. Before raising it to **Safer** or **Safest**, read [what each level does](./tor-browser-advanced.md#The-security-level-slider): the higher you go, the more sites break, and whether that trade is worth making depends on who you are defending against.
+
+## iOS means Onion Browser
+
+Onion Browser is on the App Store, open source, with contributors including Mike Tigas, Benjamin Erhart and the Guardian Project. It is not a Tor Project product.
+
+- Traffic goes over Tor, `.onion` addresses open, and your ISP cannot see which site you reached
+- Fingerprint resistance falls short of the desktop browser. The odds of a site matching your browser fingerprint to the same person across visits are higher than on desktop Tor Browser
+- Its release cadence is independent of the Tor Project's desktop and Android builds
+
+For reading an `.onion` page on iOS, Onion Browser is enough. For holding an identity that stays unlinked across sessions, iOS cannot offer that guarantee.
+
+## Confirming you are actually on Tor
+
+Open [check.torproject.org](https://check.torproject.org/){target="_blank"}. When you are not on Tor, the page says Sorry. You are not using Tor. and prints your IP address.
+
+Reading the onion edition of this site is worth one extra habit: compare the address in the address bar against the full address printed in the footer, character by character. An `.onion` address carries no certificate authority endorsement, so checking the address is the only verification available, and look-alike phishing addresses are a real technique. [How you are reading this](../about/how-you-are-reading.md) sets out the three editions side by side.
+
+## When to move to a computer
+
+Tor on a phone suits quick lookups and everyday reading. Where your threat model sits at the journalist or activist end, fingerprint resistance and operating-system level isolation both matter, and that calls for desktop Tor Browser or [Tails](./what-is-tails.md).
+
+## Helping others reach Tor is a separate question
+
+Reading over Tor and helping censored users reach Tor are two different activities, and a phone can do the second. The browser-tab version of [Snowflake](./tor-snowflake.md) is a poor fit on a phone, where Android routinely cuts the WebRTC connection once the tab goes to the background. The Tor Project also publishes a standalone Snowflake Volunteer app that runs as a background service and can be limited to Wi-Fi or to while charging, which is how a phone contributes over the long run.
+
+## Where to go from here
+
+With the browser installed, the settings themselves are in [Tor Browser advanced settings](./tor-browser-advanced.md). To work out how far you need to go, start from [threat modeling](../basics/threat-model.md).
+
+## :material-chat-question: Related reading
+
+<div class="grid cards" markdown>
+
+- [:material-chat-question: What is Tor](./what-is-tor.md)
+- [:material-cog-outline: Tor Browser advanced settings](./tor-browser-advanced.md)
+- [:material-routes: How you are reading this](../about/how-you-are-reading.md)
+
+</div>
+
+## :fontawesome-solid-diagram-project: Projects you can join
+
+<div class="grid cards" markdown>
+
+- [:material-snowflake: Tor Snowflake bridges](./tor-snowflake.md)
+- [:material-server-network: Running a Tor relay](../community/setup-tor-relay.md)
+- [:material-translate-variant: Translation and localisation](../community/i18n.md)
+
+</div>
+
+[^1]: [Can I run Tor Browser on an iOS device?](https://support.torproject.org/tormobile/tormobile-3/){target="_blank"} — Tor Project Support. "Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser."
+[^2]: [Tor Browser for Android](https://support.torproject.org/mobile-tor/){target="_blank"} — Tor Project Support. "Tor Browser for Android is available on the Play Store, F-Droid, the Tor Project website and GetTor", requiring Android 5.0 or newer.
+[^3]: [How do I install Tor Browser for Android from F-Droid?](https://support.torproject.org/tormobile/tormobile-7/){target="_blank"} — Tor Project Support, including the step of adding the Guardian Project repository.
+[^4]: [How can I verify Tor Browser's signature?](https://support.torproject.org/tbb/how-to-verify-signature/){target="_blank"} — Tor Project Support, which covers Windows, macOS and GNU/Linux only.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
           - "連線層：Tor 工具家族":
               - tools/what-is-tor.md
               - tools/tor-browser-advanced.md
+              - tools/tor-browser-mobile.md
               - tools/tor-snowflake.md
               - tools/signal-proxy.md
               - tools/onionshare.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -45,6 +45,7 @@ nav:
           - "连线层：Tor 工具家族":
               - tools/what-is-tor.md
               - tools/tor-browser-advanced.md
+              - tools/tor-browser-mobile.md
               - tools/tor-snowflake.md
               - tools/signal-proxy.md
               - tools/onionshare.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -61,6 +61,7 @@ nav:
               - tools/crypto-privacy-spectrum.md
               - tools/tails-vs-whonix-vs-qubes.md
               - tools/tor-browser-advanced.md
+              - tools/tor-browser-mobile.md
               - tools/vpn-guide.md
               - tools/encrypted-dns.md
           - "Contribute and measure":

--- a/docs/zh-CN/tools/tor-browser-mobile.md
+++ b/docs/zh-CN/tools/tor-browser-mobile.md
@@ -1,0 +1,102 @@
+---
+title: 手机上的 Tor
+description: Android 有 Tor Project 官方的 Tor Browser，iOS 没有官方版本，只能用社群维护的 Onion Browser。这一页说明两边各自的安装方式、第一次启动要处理什么、如何确认自己真的走在 Tor 上，以及什么时候应该放下手机改用电脑。
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: 手机上的 Tor
+
+看到一个 `.onion` 地址，用平常的浏览器打不开，需要的是 Tor。手机上要装什么，Android 与 iOS 的答案不一样，两边能做到的事也不一样。
+
+先读过 [什么是 Tor](./what-is-tor.md) 会比较好理解底下的取舍。桥接与安全等级的细节在 [Tor Browser 进阶设置](./tor-browser-advanced.md)，这一页只说明手机上不同的部分。
+
+## 两个平台的差别
+
+Android 上有 Tor Project 自己发布的 Tor Browser，跟桌面版同一个 Tor 引擎，多数设置齐备。
+
+iOS 上没有官方版本。Apple 要求 iOS 上所有浏览器都用 WebKit 渲染，而 Tor Browser 的指纹抗性建立在对浏览器引擎的修改上，那些修改在 WebKit 上做不出来。限制来自 Apple 的平台政策，跟版本新旧无关。Tor Project 因此把 iOS 读者指向 Onion Browser。[^1]
+
+| | Android | iOS |
+|---|---|---|
+| 官方版本 | 有，Tor Project 发布 | 没有 |
+| App 名称 | Tor Browser for Android | Onion Browser |
+| 流量走 Tor | 是 | 是 |
+| 指纹抗性 | 接近桌面版 | 做不到，受 WebKit 限制 |
+| 系统需求 | Android 5.0 以上 | 依 App Store 标示 |
+
+两边的共同点是流量都真的走 Tor，所以要打开一个 `.onion` 地址，Android 与 iOS 都做得到。差别在你能不能同时抵抗指纹追踪。
+
+## Android 有四个获取渠道
+
+Tor Project 列出的渠道是 Google Play、F-Droid、官方网站与 GetTor。[^2]
+
+**Google Play** 最直接，更新由系统处理。需要 Google 账号，而且下载记录会留在账号上。
+
+**F-Droid** 不需要 Google 账号。步骤是先装 F-Droid，在 **My Apps** 底下的 **Repositories** 加入 Guardian Project 的官方仓库，再搜索 Tor Browser for Android 安装。[^3]
+
+**官方网站**直接给 APK 文件，前面两个渠道连不上时用它。
+
+**GetTor** 是连官网都被封锁时的最后手段，透过电子邮件或其他渠道取得下载链接。
+
+选哪一个取决于你的处境。想避开 Google 账号就用 F-Droid。所在地封锁较严重时，Google Play 与 F-Droid 可能都连不上，往官方网站与 GetTor 找。
+
+Tor Project 的签名验证说明只涵盖 Windows、macOS 与 Linux，没有 Android 的步骤，[^4] 你取得 APK 之后很难用官方文件教的方式确认它没被动过。能用 F-Droid 或 Google Play 就用，那两个渠道的完整性由商店负责，直接下载 APK 是它们都连不上时的备案。
+
+## 第一次启动要处理的事
+
+打开 Tor Browser for Android 之后会先连线。连不上的话，通常是网络端挡掉了 Tor。App 里有 Connection Assist，也可以手动选桥接。哪一种桥接适合哪一种封锁，写在 [Tor Browser 进阶设置](./tor-browser-advanced.md#连线Connection-Assist-与桥接)。
+
+安全等级预设是 **Standard**。要提高到 **Safer** 或 **Safest** 之前，先看 [安全等级的说明](./tor-browser-advanced.md#安全等级Security-Level)，等级愈高，愈多网站会显示不正常，值不值得取决于你在抗谁。
+
+## iOS 只有 Onion Browser
+
+Onion Browser 在 App Store 上架，开源，贡献者包含 Mike Tigas、Benjamin Erhart 与 Guardian Project。它不是 Tor Project 的官方产品。
+
+- 流量走 Tor，`.onion` 地址打得开，你的网络运营商看不到你连了哪个站
+- 指纹抗性做不到桌面版的程度。同一个网站在不同时间把你的浏览器指纹比对成同一人的概率，比在桌面版 Tor Browser 上高
+- 更新节奏跟 Tor Project 的桌面版与 Android 版各自独立
+
+在 iOS 上只想读一个 `.onion` 页面，Onion Browser 够用。想在手机上维持一个不被关联的身分，iOS 给不了那个保证。
+
+## 怎么确认真的走在 Tor 上
+
+装好之后开 [check.torproject.org](https://check.torproject.org/){target="_blank"}。不是走 Tor 的时候，那一页会直接写着 Sorry. You are not using Tor.，并列出你的 IP。
+
+读本站的 onion 版本时，把地址栏的地址跟页尾印的完整地址逐字比对。`.onion` 地址没有证书颁发机构背书，核对地址本身就是唯一的验证手段，而用相似地址架设钓鱼站是真实存在的手法。三种阅读方式的差别写在 [你正在用哪一种方式阅读](../about/how-you-are-reading.md)。
+
+## 什么时候该换成电脑
+
+手机上的 Tor 适合临时查阅与日常浏览。威胁模型落在记者或行动者那一端的时候，指纹抗性与操作系统层级的隔离都重要，需要桌面版的 Tor Browser 或 [Tails](./what-is-tails.md)。
+
+## 用手机帮别人连上 Tor 是另一回事
+
+自己读 Tor 跟帮审查地区的人连上 Tor 是两件事，后者手机做得到。浏览器标签页版的 [Snowflake](./tor-snowflake.md) 在手机上效果有限，标签页进到后台之后 Android 经常直接中断 WebRTC 连线。Tor Project 另外推出独立的 Snowflake Volunteer App，用的是后台服务，可以设置只在 Wi-Fi 或只在充电时运作，那才是手机长期贡献的做法。
+
+## 接下来
+
+装好之后，设置的细节看 [Tor Browser 进阶设置](./tor-browser-advanced.md)。想知道自己需要调到什么程度，先回头建立 [威胁模型](../basics/threat-model.md)。
+
+## :material-chat-question: 一同了解
+
+<div class="grid cards" markdown>
+
+- [:material-chat-question: 什么是 Tor](./what-is-tor.md)
+- [:material-cog-outline: Tor Browser 进阶设置](./tor-browser-advanced.md)
+- [:material-routes: 你正在用哪一种方式阅读](../about/how-you-are-reading.md)
+
+</div>
+
+## :fontawesome-solid-diagram-project: 下一步可参与的项目
+
+<div class="grid cards" markdown>
+
+- [:material-snowflake: Tor Snowflake 桥接点](./tor-snowflake.md)
+- [:material-server-network: 如何搭建 Tor Relay](../community/setup-tor-relay.md)
+- [:material-translate-variant: 中文化与文件翻译](../community/i18n.md)
+
+</div>
+
+[^1]: [Can I run Tor Browser on an iOS device?](https://support.torproject.org/tormobile/tormobile-3/){target="_blank"} - Tor Project Support。原文写着 Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser。
+[^2]: [Tor Browser for Android](https://support.torproject.org/mobile-tor/){target="_blank"} - Tor Project Support。原文列出 the Play Store, F-Droid, the Tor Project website and GetTor，系统需求是 Android 5.0 以上。
+[^3]: [How do I install Tor Browser for Android from F-Droid?](https://support.torproject.org/tormobile/tormobile-7/){target="_blank"} - Tor Project Support，含加入 Guardian Project 仓库的完整流程。
+[^4]: [How can I verify Tor Browser's signature?](https://support.torproject.org/tbb/how-to-verify-signature/){target="_blank"} - Tor Project Support，该页只涵盖 Windows、macOS 与 GNU/Linux。

--- a/docs/zh-TW/tools/tor-browser-mobile.md
+++ b/docs/zh-TW/tools/tor-browser-mobile.md
@@ -1,12 +1,12 @@
 ---
 title: 手機上的 Tor
-description: Android 有 Tor Project 官方的 Tor Browser，iOS 沒有也不會有，只能用社群維護的 Onion Browser。這一頁說明兩邊各自怎麼裝、第一次啟動要處理什麼、怎麼確認自己真的走在 Tor 上，以及什麼時候應該放下手機改用電腦。
+description: Android 有 Tor Project 官方的 Tor Browser，iOS 沒有官方版本，只能用社群維護的 Onion Browser。這一頁說明兩邊各自的安裝方式、第一次啟動要處理什麼、如何確認自己真的走在 Tor 上，以及什麼時候應該放下手機改用電腦。
 icon: material/cellphone-lock
 ---
 
 # :material-cellphone-lock: 手機上的 Tor
 
-看到一個 `.onion` 位址，用平常的瀏覽器打不開，需要的是 Tor。手機上要裝什麼，Android 與 iOS 的答案不一樣，而且差距不只是「有沒有上架」。
+看到一個 `.onion` 位址，用平常的瀏覽器打不開，需要的是 Tor。手機上要裝什麼，Android 與 iOS 的答案不一樣，兩邊能做到的事也不一樣。
 
 先讀過 [什麼是 Tor](./what-is-tor.md) 會比較好理解底下的取捨。橋接與安全等級的細節在 [Tor Browser 進階設定](./tor-browser-advanced.md)，這一頁只說明手機上不同的部分。
 
@@ -14,7 +14,7 @@ icon: material/cellphone-lock
 
 Android 上有 Tor Project 自己發布的 Tor Browser，跟桌面版同一個 Tor 引擎，多數設定齊備。
 
-iOS 上沒有官方版本。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算繪，而 Tor Browser 的指紋抗性建立在對瀏覽器引擎的修改上，那些修改在 WebKit 上做不出來。這是平台政策造成的結構限制，不是哪一版還沒跟上。Tor Project 因此把 iOS 讀者指向 Onion Browser。[^1]
+iOS 上沒有官方版本。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算繪，而 Tor Browser 的指紋抗性建立在對瀏覽器引擎的修改上，那些修改在 WebKit 上做不出來。限制來自 Apple 的平台政策，跟版本新舊無關。Tor Project 因此把 iOS 讀者指向 Onion Browser。[^1]
 
 | | Android | iOS |
 |---|---|---|
@@ -24,7 +24,7 @@ iOS 上沒有官方版本。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算
 | 指紋抗性 | 接近桌面版 | 做不到，受 WebKit 限制 |
 | 系統需求 | Android 5.0 以上 | 依 App Store 標示 |
 
-兩邊的共同點是流量都真的走 Tor，所以「打開一個 `.onion` 位址」這件事兩邊都做得到。差別在你能不能同時抵抗指紋追蹤。
+兩邊的共同點是流量都真的走 Tor，所以要打開一個 `.onion` 位址，Android 與 iOS 都做得到。差別在你能不能同時抵抗指紋追蹤。
 
 ## Android 有四個取得管道
 
@@ -32,13 +32,13 @@ Tor Project 列出的管道是 Google Play、F-Droid、官方網站與 GetTor。
 
 **Google Play** 最直接，更新由系統處理。需要 Google 帳號，而且下載紀錄會留在帳號上。
 
-**F-Droid** 不需要 Google 帳號。步驟是先裝 F-Droid，在「我的應用程式」的儲存庫設定裡加入 Guardian Project 的官方儲存庫，再搜尋 Tor Browser for Android 安裝。[^3]
+**F-Droid** 不需要 Google 帳號。步驟是先裝 F-Droid，在 **My Apps** 底下的 **Repositories** 加入 Guardian Project 的官方儲存庫，再搜尋 Tor Browser for Android 安裝。[^3]
 
-**官方網站**直接給 APK 檔。前面兩個管道連不上時用這個。
+**官方網站**直接給 APK 檔，前面兩個管道連不上時用它。
 
 **GetTor** 是連官網都被封鎖時的最後手段，透過電子郵件或其他管道取得下載連結。
 
-選哪一個取決於你的處境。平常在台灣，前兩個都可以，想避開 Google 帳號就用 F-Droid。人在封鎖比較嚴重的地方，順序往下走。
+選哪一個取決於你的處境。平常在台灣，前兩個都可以，想避開 Google 帳號就用 F-Droid。所在地封鎖較嚴重時，Google Play 與 F-Droid 可能都連不上，往官方網站與 GetTor 找。
 
 Tor Project 的簽章驗證說明只涵蓋 Windows、macOS 與 Linux，沒有 Android 的步驟，[^4] 你取得 APK 之後很難用官方文件教的方式確認它沒被動過。能用 F-Droid 或 Google Play 就用，那兩個管道的完整性由商店負責，直接下載 APK 是它們都連不上時的備案。
 
@@ -48,19 +48,17 @@ Tor Project 的簽章驗證說明只涵蓋 Windows、macOS 與 Linux，沒有 An
 
 連不上的話，通常是網路端擋掉了 Tor。App 裡有 Connection Assist，也可以手動選橋接。哪一種橋接適合哪一種封鎖，寫在 [Tor Browser 進階設定](./tor-browser-advanced.md#連線Connection-Assist-與橋接)。
 
-安全等級預設是 **Standard**。要提高到 **Safer** 或 **Safest** 之前，先看 [安全等級的說明](./tor-browser-advanced.md#安全等級Security-Level)，等級愈高愈多網站會壞掉，值不值得取決於你在抗誰。
+安全等級預設是 **Standard**。要提高到 **Safer** 或 **Safest** 之前，先看 [安全等級的說明](./tor-browser-advanced.md#安全等級Security-Level)，等級愈高，愈多網站會顯示不正常，值不值得取決於你在抗誰。
 
 ## iOS 只有 Onion Browser
 
 Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benjamin Erhart 與 Guardian Project。它不是 Tor Project 的官方產品。
 
-實務上這代表什麼：
-
 - 流量走 Tor，`.onion` 位址打得開，你的網路業者看不到你連了哪個站
 - 指紋抗性做不到桌面版的程度。同一個網站在不同時間把你的瀏覽器指紋比對成同一人的機率，比在桌面版 Tor Browser 上高
 - 更新節奏跟 Tor Project 的桌面版與 Android 版各自獨立
 
-如果你在 iOS 上的需求是「讀一個 `.onion` 頁面」，Onion Browser 夠用。如果需求是「在手機上維持一個不被關聯的身分」，iOS 給不了那個保證。
+在 iOS 上只想讀一個 `.onion` 頁面，Onion Browser 夠用。想在手機上維持一個不被關聯的身分，iOS 給不了那個保證。
 
 ## 怎麼確認真的走在 Tor 上
 
@@ -70,7 +68,7 @@ Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benja
 
 ## 什麼時候該換成電腦
 
-手機上的 Tor 適合臨時查閱與日常瀏覽。威脅模型落在記者或行動者那一端的時候，指紋抗性與作業系統層級的隔離都重要，桌面版的 Tor Browser 或 [Tails](./what-is-tails.md) 才給得起，手機給不起。
+手機上的 Tor 適合臨時查閱與日常瀏覽。威脅模型落在記者或行動者那一端的時候，指紋抗性與作業系統層級的隔離都重要，需要桌面版的 Tor Browser 或 [Tails](./what-is-tails.md)。
 
 ## 用手機幫別人連上 Tor 是另一回事
 

--- a/docs/zh-TW/tools/tor-browser-mobile.md
+++ b/docs/zh-TW/tools/tor-browser-mobile.md
@@ -1,0 +1,106 @@
+---
+title: 手機上的 Tor
+description: Android 有 Tor Project 官方的 Tor Browser，iOS 沒有也不會有，只能用社群維護的 Onion Browser。這一頁說明兩邊各自怎麼裝、第一次啟動要處理什麼、怎麼確認自己真的走在 Tor 上，以及什麼時候應該放下手機改用電腦。
+icon: material/cellphone-lock
+---
+
+# :material-cellphone-lock: 手機上的 Tor
+
+看到一個 `.onion` 位址，用平常的瀏覽器打不開，需要的是 Tor。手機上要裝什麼，Android 與 iOS 的答案不一樣，而且差距不只是「有沒有上架」。
+
+先讀過 [什麼是 Tor](./what-is-tor.md) 會比較好理解底下的取捨。橋接與安全等級的細節在 [Tor Browser 進階設定](./tor-browser-advanced.md)，這一頁只說明手機上不同的部分。
+
+## 兩個平台的差別
+
+Android 上有 Tor Project 自己發布的 Tor Browser，跟桌面版同一個 Tor 引擎，多數設定齊備。
+
+iOS 上沒有官方版本，而且短期內不會有。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算繪，Tor Browser 的指紋抗性建立在對瀏覽器引擎的修改上，那些修改在 iOS 做不出來。Tor Project 因此把 iOS 讀者指向 Onion Browser。[^1]
+
+| | Android | iOS |
+|---|---|---|
+| 官方版本 | 有，Tor Project 發布 | 沒有 |
+| App 名稱 | Tor Browser for Android | Onion Browser |
+| 流量走 Tor | 是 | 是 |
+| 指紋抗性 | 接近桌面版 | 做不到，受 WebKit 限制 |
+| 系統需求 | Android 5.0 以上 | 依 App Store 標示 |
+
+兩邊的共同點是流量都真的走 Tor，所以「打開一個 `.onion` 位址」這件事兩邊都做得到。差別在你能不能同時抵抗指紋追蹤。
+
+## Android 有四個取得管道
+
+Tor Project 列出的管道是 Google Play、F-Droid、官方網站與 GetTor。[^2]
+
+**Google Play** 最直接，更新由系統處理。需要 Google 帳號，而且下載紀錄會留在帳號上。
+
+**F-Droid** 不需要 Google 帳號。步驟是先裝 F-Droid，在「我的應用程式」的儲存庫設定裡加入 Guardian Project 的官方儲存庫，再搜尋 Tor Browser for Android 安裝。[^3]
+
+**官方網站**直接給 APK 檔。前面兩個管道連不上時用這個。
+
+**GetTor** 是連官網都被封鎖時的最後手段，透過電子郵件或其他管道取得下載連結。
+
+選哪一個取決於你的處境。平常在台灣，前兩個都可以，想避開 Google 帳號就用 F-Droid。人在封鎖比較嚴重的地方，順序往下走。
+
+直接下載 APK 這條路要留意一件事。Tor Project 的簽章驗證說明只涵蓋 Windows、macOS 與 Linux，沒有 Android 的步驟。[^4] 也就是說，你取得 APK 之後很難用官方文件教的方式確認它沒被動過。能用 F-Droid 或 Google Play 就用，那兩個管道的完整性由商店負責，直接下載 APK 是它們都連不上時的備案。
+
+## 第一次啟動要處理的事
+
+打開 Tor Browser for Android 之後會先連線。在台灣通常直接連得上，不需要額外設定。
+
+連不上的話，通常是網路端擋掉了 Tor。App 裡有 Connection Assist，也可以手動選橋接。哪一種橋接適合哪一種封鎖，寫在 [Tor Browser 進階設定](./tor-browser-advanced.md#連線Connection-Assist-與橋接)。
+
+安全等級預設是標準。要提高到更安全或最安全之前，先看 [那一節的說明](./tor-browser-advanced.md#安全等級Security-Level)，等級愈高愈多網站會壞掉，值不值得取決於你在抗誰。
+
+## iOS 只有 Onion Browser
+
+Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benjamin Erhart 與 Guardian Project。它不是 Tor Project 的官方產品。
+
+實務上這代表什麼：
+
+- 流量走 Tor，`.onion` 位址打得開，你的網路業者看不到你連了哪個站
+- 指紋抗性做不到桌面版的程度。同一個網站在不同時間認出「又是你」的機會，比在桌面版 Tor Browser 上高
+- 更新節奏跟 Tor Project 的桌面版與 Android 版各自獨立
+
+如果你在 iOS 上的需求是「讀一個 `.onion` 頁面」，Onion Browser 夠用。如果需求是「在手機上維持一個不被關聯的身分」，iOS 給不了那個保證。
+
+## 怎麼確認真的走在 Tor 上
+
+裝好之後開 [check.torproject.org](https://check.torproject.org/){target="_blank"}。不是走 Tor 的時候，那一頁會直接寫著 Sorry. You are not using Tor.，並列出你的 IP。
+
+讀本站的 onion 版本時還有一個習慣值得養成，把網址列的位址跟頁尾印的完整位址逐字比對。`.onion` 位址沒有憑證機構背書，核對位址本身就是唯一的驗證手段，而相似位址的釣魚站是真實存在的手法。三種閱讀方式的差別寫在 [你正在用哪一種方式閱讀](../about/how-you-are-reading.md)。
+
+## 什麼時候不要用手機
+
+手機上的 Tor 適合臨時查閱與日常瀏覽。有兩種情況建議換到電腦。
+
+威脅模型落在記者或行動者那一端的時候，指紋抗性與作業系統層級的隔離都重要，桌面版的 Tor Browser 或 [Tails](./what-is-tails.md) 才給得起。
+
+想貢獻頻寬給審查地區的人也不要用手機。[Snowflake](./tor-snowflake.md) 客戶端在手機上耗電、發熱，App 進到背景就會被系統結束，撐不了多久。
+
+## 接下來
+
+裝好之後，設定的細節看 [Tor Browser 進階設定](./tor-browser-advanced.md)。想知道自己需要調到什麼程度，先回頭建立 [威脅模型](../basics/threat-model.md)。
+
+## :material-chat-question: 一同瞭解
+
+<div class="grid cards" markdown>
+
+- [:material-chat-question: 什麼是 Tor](./what-is-tor.md)
+- [:material-cog-outline: Tor Browser 進階設定](./tor-browser-advanced.md)
+- [:material-routes: 你正在用哪一種方式閱讀](../about/how-you-are-reading.md)
+
+</div>
+
+## :fontawesome-solid-diagram-project: 下一步可參與的專案
+
+<div class="grid cards" markdown>
+
+- [:material-snowflake: Tor Snowflake 橋接點](./tor-snowflake.md)
+- [:material-server-network: 如何搭建 Tor Relay](../community/setup-tor-relay.md)
+- [:material-translate-variant: 中文化與文件翻譯](../community/i18n.md)
+
+</div>
+
+[^1]: [Can I run Tor Browser on an iOS device?](https://support.torproject.org/tormobile/tormobile-3/){target="_blank"} - Tor Project Support。原文寫著 Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser。
+[^2]: [Tor Browser for Android](https://support.torproject.org/mobile-tor/){target="_blank"} - Tor Project Support。原文列出 the Play Store, F-Droid, the Tor Project website and GetTor，系統需求是 Android 5.0 以上。
+[^3]: [How do I install Tor Browser for Android from F-Droid?](https://support.torproject.org/tormobile/tormobile-7/){target="_blank"} - Tor Project Support，六個步驟含加入 Guardian Project 儲存庫。
+[^4]: [How can I verify Tor Browser's signature?](https://support.torproject.org/tbb/how-to-verify-signature/){target="_blank"} - Tor Project Support，該頁只涵蓋 Windows、macOS 與 GNU/Linux。

--- a/docs/zh-TW/tools/tor-browser-mobile.md
+++ b/docs/zh-TW/tools/tor-browser-mobile.md
@@ -14,7 +14,7 @@ icon: material/cellphone-lock
 
 Android 上有 Tor Project 自己發布的 Tor Browser，跟桌面版同一個 Tor 引擎，多數設定齊備。
 
-iOS 上沒有官方版本，而且短期內不會有。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算繪，Tor Browser 的指紋抗性建立在對瀏覽器引擎的修改上，那些修改在 iOS 做不出來。Tor Project 因此把 iOS 讀者指向 Onion Browser。[^1]
+iOS 上沒有官方版本。Apple 要求 iOS 上所有瀏覽器都用 WebKit 算繪，而 Tor Browser 的指紋抗性建立在對瀏覽器引擎的修改上，那些修改在 WebKit 上做不出來。這是平台政策造成的結構限制，不是哪一版還沒跟上。Tor Project 因此把 iOS 讀者指向 Onion Browser。[^1]
 
 | | Android | iOS |
 |---|---|---|
@@ -40,15 +40,15 @@ Tor Project 列出的管道是 Google Play、F-Droid、官方網站與 GetTor。
 
 選哪一個取決於你的處境。平常在台灣，前兩個都可以，想避開 Google 帳號就用 F-Droid。人在封鎖比較嚴重的地方，順序往下走。
 
-直接下載 APK 這條路要留意一件事。Tor Project 的簽章驗證說明只涵蓋 Windows、macOS 與 Linux，沒有 Android 的步驟。[^4] 也就是說，你取得 APK 之後很難用官方文件教的方式確認它沒被動過。能用 F-Droid 或 Google Play 就用，那兩個管道的完整性由商店負責，直接下載 APK 是它們都連不上時的備案。
+Tor Project 的簽章驗證說明只涵蓋 Windows、macOS 與 Linux，沒有 Android 的步驟，[^4] 你取得 APK 之後很難用官方文件教的方式確認它沒被動過。能用 F-Droid 或 Google Play 就用，那兩個管道的完整性由商店負責，直接下載 APK 是它們都連不上時的備案。
 
 ## 第一次啟動要處理的事
 
-打開 Tor Browser for Android 之後會先連線。在台灣通常直接連得上，不需要額外設定。
+打開 Tor Browser for Android 之後會先連線。台灣對外連線受審查的程度低，多半直接連得上，不需要額外設定。
 
 連不上的話，通常是網路端擋掉了 Tor。App 裡有 Connection Assist，也可以手動選橋接。哪一種橋接適合哪一種封鎖，寫在 [Tor Browser 進階設定](./tor-browser-advanced.md#連線Connection-Assist-與橋接)。
 
-安全等級預設是標準。要提高到更安全或最安全之前，先看 [那一節的說明](./tor-browser-advanced.md#安全等級Security-Level)，等級愈高愈多網站會壞掉，值不值得取決於你在抗誰。
+安全等級預設是 **Standard**。要提高到 **Safer** 或 **Safest** 之前，先看 [安全等級的說明](./tor-browser-advanced.md#安全等級Security-Level)，等級愈高愈多網站會壞掉，值不值得取決於你在抗誰。
 
 ## iOS 只有 Onion Browser
 
@@ -57,7 +57,7 @@ Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benja
 實務上這代表什麼：
 
 - 流量走 Tor，`.onion` 位址打得開，你的網路業者看不到你連了哪個站
-- 指紋抗性做不到桌面版的程度。同一個網站在不同時間認出「又是你」的機會，比在桌面版 Tor Browser 上高
+- 指紋抗性做不到桌面版的程度。同一個網站在不同時間把你的瀏覽器指紋比對成同一人的機率，比在桌面版 Tor Browser 上高
 - 更新節奏跟 Tor Project 的桌面版與 Android 版各自獨立
 
 如果你在 iOS 上的需求是「讀一個 `.onion` 頁面」，Onion Browser 夠用。如果需求是「在手機上維持一個不被關聯的身分」，iOS 給不了那個保證。
@@ -66,15 +66,15 @@ Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benja
 
 裝好之後開 [check.torproject.org](https://check.torproject.org/){target="_blank"}。不是走 Tor 的時候，那一頁會直接寫著 Sorry. You are not using Tor.，並列出你的 IP。
 
-讀本站的 onion 版本時還有一個習慣值得養成，把網址列的位址跟頁尾印的完整位址逐字比對。`.onion` 位址沒有憑證機構背書，核對位址本身就是唯一的驗證手段，而相似位址的釣魚站是真實存在的手法。三種閱讀方式的差別寫在 [你正在用哪一種方式閱讀](../about/how-you-are-reading.md)。
+讀本站的 onion 版本時，把網址列的位址跟頁尾印的完整位址逐字比對。`.onion` 位址沒有憑證機構背書，核對位址本身就是唯一的驗證手段，而用相似位址架設釣魚站是真實存在的手法。三種閱讀方式的差別寫在 [你正在用哪一種方式閱讀](../about/how-you-are-reading.md)。
 
-## 什麼時候不要用手機
+## 什麼時候該換成電腦
 
-手機上的 Tor 適合臨時查閱與日常瀏覽。有兩種情況建議換到電腦。
+手機上的 Tor 適合臨時查閱與日常瀏覽。威脅模型落在記者或行動者那一端的時候，指紋抗性與作業系統層級的隔離都重要，桌面版的 Tor Browser 或 [Tails](./what-is-tails.md) 才給得起，手機給不起。
 
-威脅模型落在記者或行動者那一端的時候，指紋抗性與作業系統層級的隔離都重要，桌面版的 Tor Browser 或 [Tails](./what-is-tails.md) 才給得起。
+## 用手機幫別人連上 Tor 是另一回事
 
-想貢獻頻寬給審查地區的人也不要用手機。[Snowflake](./tor-snowflake.md) 客戶端在手機上耗電、發熱，App 進到背景就會被系統結束，撐不了多久。
+自己讀 Tor 跟幫審查地區的人連上 Tor 是兩件事，後者手機做得到。瀏覽器分頁版的 [Snowflake](./tor-snowflake.md) 在手機上效果有限，分頁進到背景之後 Android 經常直接中斷 WebRTC 連線。Tor Project 另外推出獨立的 Snowflake Volunteer App，用的是背景服務，可以設定只在 Wi-Fi 或只在充電時運作，那才是手機長期貢獻的做法。
 
 ## 接下來
 
@@ -102,5 +102,5 @@ Onion Browser 在 App Store 上架，開源，貢獻者包含 Mike Tigas、Benja
 
 [^1]: [Can I run Tor Browser on an iOS device?](https://support.torproject.org/tormobile/tormobile-3/){target="_blank"} - Tor Project Support。原文寫著 Apple requires browsers on iOS to use something called Webkit, which prevents Onion Browser from having the same privacy protections as Tor Browser。
 [^2]: [Tor Browser for Android](https://support.torproject.org/mobile-tor/){target="_blank"} - Tor Project Support。原文列出 the Play Store, F-Droid, the Tor Project website and GetTor，系統需求是 Android 5.0 以上。
-[^3]: [How do I install Tor Browser for Android from F-Droid?](https://support.torproject.org/tormobile/tormobile-7/){target="_blank"} - Tor Project Support，六個步驟含加入 Guardian Project 儲存庫。
+[^3]: [How do I install Tor Browser for Android from F-Droid?](https://support.torproject.org/tormobile/tormobile-7/){target="_blank"} - Tor Project Support，含加入 Guardian Project 儲存庫的完整流程。
 [^4]: [How can I verify Tor Browser's signature?](https://support.torproject.org/tbb/how-to-verify-signature/){target="_blank"} - Tor Project Support，該頁只涵蓋 Windows、macOS 與 GNU/Linux。


### PR DESCRIPTION
三語系齊全，可以合併了。

## 為什麼要這一頁

站上原本沒有 Tor Browser 的安裝與使用指引。zh-TW 與 zh-CN 的 `tor-browser-advanced.md` 有一節行動版，內容是選哪一個 App 加上注意事項，不到能照著裝起來的程度，而 en 連那一節都沒有（#501 在補）。

讀者從「你正在用哪一種方式閱讀」看到 Onion 需要 Tor Browser，接下來就沒有路了。

## 內容

| 章節 | 涵蓋 |
|---|---|
| 兩個平台的差別 | Android 有官方版、iOS 沒有也不會有，附對照表 |
| Android 有四個取得管道 | Play、F-Droid、官網、GetTor，各自的取捨 |
| 第一次啟動要處理的事 | 連線、被擋時的橋接、安全等級，細節指回進階設定 |
| iOS 只有 Onion Browser | 非官方、WebKit 限制、實務上代表什麼 |
| 怎麼確認真的走在 Tor 上 | `check.torproject.org`、核對本站 onion 位址 |
| 什麼時候該換成電腦 | 記者與行動者的威脅模型 |
| 用手機幫別人連上 Tor 是另一回事 | 分頁版 Snowflake 的限制與獨立 App |

## 事實出處

四項都寫成註腳，逐一 WebFetch 查證過：

- `support.torproject.org/mobile-tor/` 列出 Play Store、F-Droid、官網與 GetTor 四個管道，需求 Android 5.0 以上
- `tormobile-3` 確認 iOS 沒有官方版本並指向 Onion Browser，WebKit 那句原文引在註腳裡
- `tormobile-7` 是 F-Droid 加 Guardian Project 儲存庫的流程
- `how-to-verify-signature` 只涵蓋 Windows、macOS 與 GNU/Linux

## 兩個改變的決定

**拿掉 APK 簽章驗證的步驟。** 原本規劃要寫，查完發現 Tor Project 的驗證說明沒有 Android 那一段。自己編一套驗證流程給高風險讀者照做，風險大於幫助。改成把取得管道的取捨講清楚。

**Snowflake 那一段整個重寫。** 初稿寫「想貢獻頻寬也不要用手機，App 進到背景就會被系統結束」，這跟站上 `tools/tor-snowflake.md` 的 Q&A 與 `blog/posts/snowflake-volunteer-android-app.md` 直接衝突，官方的獨立 App 正是為了解決那個問題。而且這一頁的「下一步可參與的專案」就連到那一頁，讀者點一下就看到兩邊打架。

## 三語系

zh-CN 照站上既有用語（設備、瀏覽器、證書頒發機構、地址欄、倉庫、橋接），並刪掉 zh-TW 版裡「台灣對外連線受審查的程度低」那個前提，簡體讀者所在的網路環境不適用。

en 依 en 頁面既有的散文語氣重寫，不是逐句直譯。

## 錨點

三邊的標題不同，錨點各自比對過自己語系產物裡的 id：

| 語系 | 錨點 |
|---|---|
| zh-TW | `#連線Connection-Assist-與橋接`、`#安全等級Security-Level` |
| zh-CN | `#连线Connection-Assist-与桥接`、`#安全等级Security-Level` |
| en | `#Bridges-for-where-Tor-is-blocked`、`#The-security-level-slider` |

這個站的標題 id 保留大小寫，而建置不會為錯誤的錨點報錯，所以每一條都查了產物。

## 驗證

- 三語系依 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 順序建置通過
- hreflang 的三個 alternate 都指到存在的頁面
- 三個檔案的 `docs_style_lint.py` 都是 0 error 0 warn
- 逐條對照貢獻者百科的寫作風格規範，修過十二處 linter 抓不到的問題（引號強調、負向對照句型、開場鋪陳句、口語、UI 標籤不一致）
- 這 0.8、那 5.0（每千漢字，站上常態約 5）
- `tools/` 五支相關測試全過

## 一個沒有處理的既有問題

zh-TW 與 zh-CN 的 `tor-browser-advanced.md` 行動版那一節，也寫著「行動裝置不適合長時間執行 Snowflake 客戶端，耗電、發熱、進入背景會被系統殺」，跟 `tor-snowflake.md` 是同一個矛盾。那兩個檔案 #501 已經在改，適合併到那個 PR 一起修，這裡不動以免衝突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
