### PR TITLE
content(tor): 說明頁的手機連結改指完整的那一頁

### DIFF
--- a/docs/en/about/how-you-are-reading.md
+++ b/docs/en/about/how-you-are-reading.md
@@ -35,7 +35,7 @@ An `.onion` address carries no certificate authority endorsement, so checking th
 
 This edition loads no analytics and registers no background Service Worker, which is why offline reading is absent. Latency is higher than the standard site, as it is for Tor generally.
 
-Which app to use on a phone, and why iOS has no official Tor Browser, is in [Tor on a phone](../tools/tor-browser-advanced.md#Tor-on-a-phone).
+Which app to use on a phone, how to install it, and why iOS has no official Tor Browser are in [Tor on a phone](../tools/tor-browser-mobile.md).
 
 ## IPFS mirror
 

--- a/docs/zh-CN/about/how-you-are-reading.md
+++ b/docs/zh-CN/about/how-you-are-reading.md
@@ -35,7 +35,7 @@ icon: material/routes
 
 这一版不加载任何分析脚本，也不注册后台的 Service Worker，所以没有离线阅读。延迟比标准网站高，那是 Tor 的常态。
 
-手机上要用哪一个 App、iOS 为什么没有官方版本，见 [Tor Browser 进阶设定的移动版一节](../tools/tor-browser-advanced.md#移动版)。
+手机上要用哪一个 App、怎么装、iOS 为什么没有官方版本，见 [手机上的 Tor](../tools/tor-browser-mobile.md)。
 
 ## IPFS 镜像
 

--- a/docs/zh-TW/about/how-you-are-reading.md
+++ b/docs/zh-TW/about/how-you-are-reading.md
@@ -35,7 +35,7 @@ icon: material/routes
 
 這一版不載入任何分析腳本，也不註冊背景的 Service Worker，所以沒有離線閱讀。延遲比標準網站高，那是 Tor 的常態。
 
-手機上要用哪一個 App、iOS 為什麼沒有官方版本，見 [Tor Browser 進階設定的行動版一節](../tools/tor-browser-advanced.md#行動版)。
+手機上要用哪一個 App、怎麼裝、iOS 為什麼沒有官方版本，見 [手機上的 Tor](../tools/tor-browser-mobile.md)。
 
 ## IPFS 鏡像
 


### PR DESCRIPTION
## 做法

「你正在用哪一種方式閱讀」的 Onion 段落原本連到 `tor-browser-advanced.md` 的行動版一節。那一節只講選哪一個 App 加上注意事項，而 #502 已經把完整的安裝與使用指引獨立成 `tools/tor-browser-mobile.md`，讀者要的下一步在後者。

| 語系 | 原本 | 改成 |
|---|---|---|
| zh-TW | 進階設定的行動版一節 | [手機上的 Tor](../tools/tor-browser-mobile.md) |
| zh-CN | 进阶设定的移动版一节 | [手机上的 Tor](../tools/tor-browser-mobile.md) |
| en | Tor on a phone（advanced 的錨點） | [Tor on a phone](../tools/tor-browser-mobile.md) |

連結文字也加上「怎麼裝」，讓讀者知道點過去有安裝步驟。

進階設定那一節保留不動。它服務的是已經在讀進階設定的人，跟從說明頁過來的讀者需求不同，兩邊各自指向合適的深度。

## 驗證

- 三語系依 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 順序建置通過
- 三個連結都解析到存在的頁面（`/tools/tor-browser-mobile/`、`/zh-cn/…`、`/en/…`，各自 200）
- `grep` 確認沒有殘留指向 advanced 錨點的連結
- 三個變更檔案的 `docs_style_lint.py` 都是 0 error 0 warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)