### PR TITLE
fix(home): 近期公告的分類標籤恢復顏色分類，並修好亮暗模式對比

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -949,3 +949,36 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   height: 0.9rem;
   width: 0.9rem;
 }
+
+/* ==========================================================================
+   .post-tag — category label in front of each row of "Recent updates" on the
+   home page. Emitted by hooks/latest_posts.py as `Category`{.post-tag
+   .post-tag--community}.
+
+   Classes replaced inline styles because an inline colour cannot follow the
+   colour scheme: every one of the six values failed AA 4.5 in one mode or the
+   other, and the old default --brand-cyan-800 scores only 2.80 on slate.
+   The label is a <code> element, so contrast is measured against Material's
+   code background: #f5f5f5 in light, #272a35 in slate. The number at the end
+   of each line is the measured ratio. All six pass AA 4.5 in both modes.
+
+   The category-to-class table lives in CATEGORY_CLASSES in
+   hooks/latest_posts.py. Anything not listed there falls back to the neutral
+   colour. The news and tech hues sit close to --guide-scenarios and
+   --guide-advanced, which are sidebar navigation UI colours used in a
+   different component, so the hue is reused but the token is not.
+   ========================================================================== */
+
+.md-typeset .post-tag            { color: #546e7a; }  /* default   4.95 */
+.md-typeset .post-tag--update    { color: #2e7d32; }  /* update    4.70 */
+.md-typeset .post-tag--event     { color: #b35309; }  /* event     4.63 */
+.md-typeset .post-tag--community { color: #006d99; }  /* community 5.28 */
+.md-typeset .post-tag--news      { color: #ad1457; }  /* news      6.39 */
+.md-typeset .post-tag--tech      { color: #673ab7; }  /* tech      6.72 */
+
+[data-md-color-scheme="slate"] .md-typeset .post-tag            { color: #b0bec5; }  /* 7.50 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--update    { color: #81c784; }  /* 7.10 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--event     { color: #ffb74d; }  /* 8.26 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--community { color: #4dbfff; }  /* 6.95 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--news      { color: #f48fb1; }  /* 6.41 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--tech      { color: #b39ddb; }  /* 5.97 */

--- a/docs/hooks/latest_posts.py
+++ b/docs/hooks/latest_posts.py
@@ -8,8 +8,9 @@
 建置時掃描就不會再有這個問題。
 
 三語系共用這一支，各自掃 config['docs_dir'] 底下的 blog/posts。標籤取 front
-matter 的第一個 category，各語系的 front matter 本來就是自己的語言，所以標籤
-文字不必在這裡維護對照表。需要對照的只有標點、日期格式與顏色 token。
+matter 的 categories 裡第一個對得到顏色的那一個，挑法見 _pick_category。各語系
+的 front matter 本來就是自己的語言，所以標籤文字不必在這裡維護對照表。需要對照
+的只有標點、日期格式，以及分類到顏色 class 的 CATEGORY_CLASSES。
 
 只掃 blog/posts。改版前的清單混進過 activity/ 底下的活動頁（COSCUP 徵稿），
 那類頁面現在不會自動出現，需要放上首頁的話照慣例也發一篇 blog post。
@@ -30,41 +31,38 @@ PLACEHOLDER = re.compile(r"<!--\s*latest-posts:(\d+)\s*-->")
 ICON = re.compile(r":[a-z0-9_-]+:\s*")
 H1 = re.compile(r"^#\s+(.+)$", re.MULTILINE)
 
-ACTION = "var(--accent-action)"
+# 標籤顏色走 CSS class，不寫 inline style。理由是 inline 的色值沒辦法跟著亮暗
+# 模式換，改版前六個色值裡每一個都在其中一個模式低於 WCAG AA 4.5（例如預設的
+# --brand-cyan-800 在 slate 只有 2.80）。色值與兩個模式的對比數字寫在三份
+# stylesheets/extra.css 的 .post-tag 區塊。
 
-# 三語系的標點、日期格式與顏色 token 都不同，照各自首頁改版前的既有寫法。
-# colors 的 key 比對時轉小寫。
-LOCALES = {
-    "zh-TW": {
-        "sep": "：",
-        "dash": " - ",
-        "date": "{y}/{m}/{d}",
-        "colors": {"活動": ACTION, "更新": "#2e7d32"},
-        "default_color": "var(--brand-cyan-800)",
-    },
-    "zh-CN": {
-        "sep": "：",
-        "dash": " - ",
-        "date": "{y}/{m}/{d}",
-        "colors": {"活动": ACTION, "更新": "#2e7d32"},
-        "default_color": "var(--brand-cyan-800)",
-    },
+# 分類到 class 後綴的對照。三語系是同一套語意，同一篇文章在三邊的分類本來就
+# 對得起來（社群 / 社区 / Community）。key 比對時轉小寫，所以英文那組全部小寫。
+# 對不到的分類走 .post-tag 自己的中性色，不必在這裡窮舉所有主題分類。
+CATEGORY_CLASSES = {
+    "zh-TW": {"更新": "update", "活動": "event", "社群": "community", "公告": "news", "技術": "tech"},
+    "zh-CN": {"更新": "update", "活动": "event", "社区": "community", "公告": "news", "技术": "tech"},
     "en": {
-        "sep": ": ",
-        "dash": " — ",
-        "date": "{y}-{m}-{d}",
-        "colors": {
-            "event": ACTION,
-            "update": "var(--cat-privacy)",
-            "updates": "var(--cat-privacy)",
-        },
-        "default_color": "var(--brand-cyan-600)",
+        "update": "update",
+        "updates": "update",
+        "event": "event",
+        "events": "event",
+        "community": "community",
+        "news": "news",
+        "technology": "tech",
     },
+}
+
+# 三語系的標點與日期格式不同，照各自首頁改版前的既有寫法。
+LOCALES = {
+    "zh-TW": {"sep": "：", "dash": " - ", "date": "{y}/{m}/{d}"},
+    "zh-CN": {"sep": "：", "dash": " - ", "date": "{y}/{m}/{d}"},
+    "en": {"sep": ": ", "dash": " — ", "date": "{y}-{m}-{d}"},
 }
 
 
 def _parse_post(path):
-    """回傳 (date, category, title, slug)，格式不合就回 None。"""
+    """回傳 (date, categories, title, slug)，格式不合就回 None。"""
     text = path.read_text(encoding="utf-8")
     if not text.startswith("---"):
         return None
@@ -86,9 +84,34 @@ def _parse_post(path):
     if not title:
         match = H1.search(parts[2])
         title = ICON.sub("", match.group(1)).strip() if match else path.stem
-    categories = meta.get("categories") or []
-    category = str(categories[0]).strip() if categories else None
-    return date, category, str(title).strip(), path.stem
+    categories = [str(c).strip() for c in (meta.get("categories") or []) if str(c).strip()]
+    return date, categories, str(title).strip(), path.stem
+
+
+# 同一篇文章掛得到多個分類時的挑選順序，愈前面愈優先。社群排最後是因為它涵蓋
+# 面最廣，2026-09 的五篇裡有四篇都掛著它，固定取 categories[0] 的話首頁整排都
+# 是同一個顏色，標籤等於沒有在分類。把它讓給比較具體的那幾個，讀者掃過去才知道
+# 每一列是什麼性質的內容。
+CATEGORY_PRIORITY = ("event", "update", "news", "tech", "community")
+
+
+def _pick_category(categories, classes):
+    """挑出要顯示的分類與它的 class 後綴。
+
+    不固定取 categories[0]，改成在對得到顏色的分類裡照 CATEGORY_PRIORITY 挑。
+    例如 `社群 / 技術 / 公告` 顯示公告，`社群 / 活動` 顯示活動。
+
+    整串都對不到顏色時回第一個，標籤照樣出現，只是走中性色。
+    """
+    matched = {}
+    for category in categories:
+        suffix = classes.get(category.lower())
+        if suffix and suffix not in matched:
+            matched[suffix] = category
+    for suffix in CATEGORY_PRIORITY:
+        if suffix in matched:
+            return matched[suffix], suffix
+    return (categories[0], None) if categories else (None, None)
 
 
 def on_page_markdown(markdown, page, config, files, **kwargs):
@@ -98,6 +121,7 @@ def on_page_markdown(markdown, page, config, files, **kwargs):
 
     docs_dir = Path(config["docs_dir"])
     locale = LOCALES.get(docs_dir.name)
+    classes = CATEGORY_CLASSES.get(docs_dir.name, {})
     if locale is None:
         # strict 模式下 warning 會讓建置失敗，這裡刻意如此：語系設定漏了的話，
         # 首頁會留下一個裸露的 HTML 註解，不該悄悄上線。
@@ -122,12 +146,13 @@ def on_page_markdown(markdown, page, config, files, **kwargs):
     indent = markdown[line_start:match.start()]
 
     lines = []
-    for date, category, title, slug in posts[:limit]:
+    for date, categories, title, slug in posts[:limit]:
         shown = locale["date"].format(y=date.year, m=f"{date.month:02d}", d=f"{date.day:02d}")
         link = f"[{title}](./blog/posts/{slug}.md)"
+        category, suffix = _pick_category(categories, classes)
         if category:
-            color = locale["colors"].get(category.lower(), locale["default_color"])
-            label = f'`{category}`{{style="color: {color};"}}{locale["sep"]}'
+            names = f".post-tag .post-tag--{suffix}" if suffix else ".post-tag"
+            label = f'`{category}`{{{names}}}{locale["sep"]}'
         else:
             label = ""
         lines.append(f'- {label}{link}{locale["dash"]}{shown}')

--- a/docs/zh-CN/stylesheets/extra.css
+++ b/docs/zh-CN/stylesheets/extra.css
@@ -941,3 +941,31 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   height: 0.9rem;
   width: 0.9rem;
 }
+
+/* ==========================================================================
+   .post-tag — 首页「近期公告」每一列前面的分类标签
+   由 hooks/latest_posts.py 生成，形式是 `分類`{.post-tag .post-tag--community}。
+
+   改用 class 的理由是原本的 inline style 没办法跟着亮暗模式换色，六个色值每一个
+   都在其中一个模式低于 AA 4.5，默认的 --brand-cyan-800 在 slate 只有 2.80。
+   标签是 <code>，对比要对 Material 的 code 底色算，亮色 #f5f5f5、slate #272a35。
+   行末括号是实测对比，六组在两个模式都过 AA 4.5。
+
+   分类到 class 的对照表在 hooks/latest_posts.py 的 CATEGORY_CLASSES，对不到的
+   分类走中性色。news 与 tech 的色相接近 --guide-scenarios 与 --guide-advanced，
+   那两个是侧边栏导览的 UI 色，用在不同组件，这里沿用色相但不共用 token。
+   ========================================================================== */
+
+.md-typeset .post-tag            { color: #546e7a; }  /* 默认 4.95 */
+.md-typeset .post-tag--update    { color: #2e7d32; }  /* 更新 4.70 */
+.md-typeset .post-tag--event     { color: #b35309; }  /* 活动 4.63 */
+.md-typeset .post-tag--community { color: #006d99; }  /* 社区 5.28 */
+.md-typeset .post-tag--news      { color: #ad1457; }  /* 公告 6.39 */
+.md-typeset .post-tag--tech      { color: #673ab7; }  /* 技术 6.72 */
+
+[data-md-color-scheme="slate"] .md-typeset .post-tag            { color: #b0bec5; }  /* 7.50 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--update    { color: #81c784; }  /* 7.10 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--event     { color: #ffb74d; }  /* 8.26 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--community { color: #4dbfff; }  /* 6.95 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--news      { color: #f48fb1; }  /* 6.41 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--tech      { color: #b39ddb; }  /* 5.97 */

--- a/docs/zh-TW/stylesheets/extra.css
+++ b/docs/zh-TW/stylesheets/extra.css
@@ -942,3 +942,31 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
   height: 0.9rem;
   width: 0.9rem;
 }
+
+/* ==========================================================================
+   .post-tag — 首頁「近期公告」每一列前面的分類標籤
+   由 hooks/latest_posts.py 產生，形式是 `分類`{.post-tag .post-tag--community}。
+
+   改用 class 的理由是原本的 inline style 沒辦法跟著亮暗模式換色，六個色值每一個
+   都在其中一個模式低於 AA 4.5，預設的 --brand-cyan-800 在 slate 只有 2.80。
+   標籤是 <code>，對比要對 Material 的 code 底色算，亮色 #f5f5f5、slate #272a35。
+   行末括號是實測對比，六組在兩個模式都過 AA 4.5。
+
+   分類到 class 的對照表在 hooks/latest_posts.py 的 CATEGORY_CLASSES，對不到的
+   分類走中性色。news 與 tech 的色相接近 --guide-scenarios 與 --guide-advanced，
+   那兩個是側邊欄導覽的 UI 色，用在不同元件，這裡沿用色相但不共用 token。
+   ========================================================================== */
+
+.md-typeset .post-tag            { color: #546e7a; }  /* 預設 4.95 */
+.md-typeset .post-tag--update    { color: #2e7d32; }  /* 更新 4.70 */
+.md-typeset .post-tag--event     { color: #b35309; }  /* 活動 4.63 */
+.md-typeset .post-tag--community { color: #006d99; }  /* 社群 5.28 */
+.md-typeset .post-tag--news      { color: #ad1457; }  /* 公告 6.39 */
+.md-typeset .post-tag--tech      { color: #673ab7; }  /* 技術 6.72 */
+
+[data-md-color-scheme="slate"] .md-typeset .post-tag            { color: #b0bec5; }  /* 7.50 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--update    { color: #81c784; }  /* 7.10 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--event     { color: #ffb74d; }  /* 8.26 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--community { color: #4dbfff; }  /* 6.95 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--news      { color: #f48fb1; }  /* 6.41 */
+[data-md-color-scheme="slate"] .md-typeset .post-tag--tech      { color: #b39ddb; }  /* 5.97 */


### PR DESCRIPTION
## 問題

首頁「近期公告」五列的分類標籤全部是同一個 cyan，看起來像顏色分類壞掉。

追下去不是哪一版改壞的。#261 把首頁清單改成自動生成時，標籤來源從手寫的三類語意（`新增` / `更新` / `活動`）換成 blog front matter 的 `categories[0]`，而那是另一套軸線。`hooks/latest_posts.py` 的顏色對照表沿用改版前的兩個 key：

```python
"colors": {"活動": ACTION, "更新": "#2e7d32"},
"default_color": "var(--brand-cyan-800)",
```

zh-TW 的第一分類實際有九種（更新 38、社群 10、活動 9、技術 7、公告 5、OONI 2…），最近五篇是 社群 ×4 加 公告 ×1，兩個都不在表裡，所以一律落在預設值。英文版更明顯，最常用的 `News` 22 篇與 `Community` 10 篇都沒有顏色。

## 順帶修掉的對比問題

標籤用 inline `style`，色值沒辦法跟著亮暗模式換。標籤是 `<code>`，對比要對 Material 的 code 底色算（亮色 `#f5f5f5`、slate `#272a35`），六個舊值每一個都在其中一個模式低於 WCAG AA 4.5：

| 舊色 | 白底 | slate |
|---|---|---|
| `#006d99` 預設 | 5.76 ✓ | 2.80 ✗ |
| `#2e7d32` 更新（中文） | 5.13 ✓ | 3.14 ✗ |
| `#ef6c00` 活動 | 3.08 ✗ | 5.22 ✓ |
| `#4caf50` update（英文） | 2.78 ✗ | 5.79 ✓ |

`extra.css` 自己就寫著 cyan-800 在 slate 只有 2.27，公告標籤卻無條件用它。

## 改了什麼

- **對照表擴充成五類**，社群、公告、技術、更新、活動，放在 `CATEGORY_CLASSES`。三語系逐篇比對過是同一套語意（社群 / 社区 / Community）。
- **標籤改成照 `CATEGORY_PRIORITY` 挑**，不固定取 `categories[0]`。順序是 event、update、news、tech、community。社群排最後，它涵蓋面最廣，固定取第一個的話整排同色，標籤等於沒有在分類。整串都對不到顏色時仍然回第一個，走中性色。
- **inline style 改成 CSS class**，照站上 `.sess-tag` 既有的模式，加 `[data-md-color-scheme="slate"]` 覆寫。

新配色，六組在兩個模式都過 AA 4.5：

| 分類 | 亮色 | 對比 | 暗色 | 對比 |
|---|---|---|---|---|
| 社群 Community | `#006d99` | 5.28 | `#4dbfff` | 6.95 |
| 公告 News | `#ad1457` | 6.39 | `#f48fb1` | 6.41 |
| 更新 Update | `#2e7d32` | 4.70 | `#81c784` | 7.10 |
| 活動 Event | `#b35309` | 4.63 | `#ffb74d` | 8.26 |
| 技術 Technology | `#673ab7` | 6.72 | `#b39ddb` | 5.97 |
| 其他（中性） | `#546e7a` | 4.95 | `#b0bec5` | 7.50 |

配色避開三大主題保留色與緊急紅。`news` 與 `tech` 的色相接近 `--guide-scenarios` 與 `--guide-advanced`，那兩個是側邊欄導覽的 UI 色、用在不同元件，這裡沿用色相但不共用 token，理由寫在 CSS 註解。

## 結果

三個語系的前五列都是三種顏色：

| 語系 | 五列標籤 |
|---|---|
| zh-TW | 技術、公告、活動、技術、公告 |
| zh-CN | 技术、公告、活动、技术、公告 |
| en | Technology、News、Events、Technology、News |

社群在目前的前五列不會出現，它仍是文章的第一分類，標籤改顯示比較具體的那一個。想調回來改 `CATEGORY_PRIORITY` 的順序即可。

## 動到哪些檔案

- `docs/hooks/latest_posts.py`
- `docs/{zh-TW,zh-CN,en}/stylesheets/extra.css`

沒有動任何 Markdown，沒有 URL 變動。

## 驗證

- `run.sh`、`run_en.sh`、`run_zh-cn.sh` 三支 strict 建置全部 exit 0
- 三個語系的產物都確認 `class="post-tag post-tag--*"` 正確輸出
- 亮暗兩個 scheme 並排渲染確認六色可辨（本機環境的 Chrome 開了自動深色會反轉整頁，改用只載入建置後 `extra.css` 的對照頁避開）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
