### PR TITLE
fix(offline): 狀態列改成真的段落，不靠 br 硬斷行

### DIFF
--- a/docs/zh-TW/js/offline-library.js
+++ b/docs/zh-TW/js/offline-library.js
@@ -201,6 +201,7 @@
       readyOk: "沒有網路時，{items}都可以開啟。",
       readyMissing: "沒有網路時無法開啟：{items}。連上網路後會自動補回來。",
       readyJoin: "、",
+      sentenceJoin: "",
       readyHere: "這一頁",
       fallbackNotice: "你要開的頁面不在裝置上，你的語言也還沒有存下離線閱讀頁，所以看到的是另一個語言的版本。連上網路之後，用你的語言打開離線閱讀頁就會存進來。",
       readyHome: "首頁",
@@ -259,6 +260,7 @@
       readyOk: "没有网络时，{items}都可以打开。",
       readyMissing: "没有网络时无法打开：{items}。连上网络后会自动补回来。",
       readyJoin: "、",
+      sentenceJoin: "",
       readyHere: "这一页",
       fallbackNotice: "你要开的页面不在设备上，你的语言也还没有存下离线阅读页，所以看到的是另一个语言的版本。连上网络之后，用你的语言打开离线阅读页就会存进来。",
       readyHome: "首页",
@@ -317,6 +319,7 @@
       readyOk: "Without a network, {items} all open.",
       readyMissing: "Without a network these do not open: {items}. They come back once you are online.",
       readyJoin: ", ",
+      sentenceJoin: " ",
       readyHere: "this page",
       fallbackNotice: "The page you opened is not on this device, and this offline reading page is not stored in your language either, so you are seeing another language's version. Open this page in your language once you are online and it will be stored.",
       readyHome: "the home page",
@@ -625,59 +628,60 @@
   }
 
   function renderStatus() {
-    const status = el("p", "ol-status");
+    const status = el("div", "ol-status");
     if (state.swMissing) {
-      status.textContent = t.noSupport;
+      status.appendChild(el("p", null, t.noSupport));
       return status;
     }
     if (!state.swReady) {
-      status.textContent = t.preparing;
+      status.appendChild(el("p", null, t.preparing));
       return status;
     }
-    // 三行狀態原本是「名詞片語」「沒有句號的句子」「有句號的句子」三種寫法疊在一起，
-    // 用 <br> 斷行之後讀起來像沒寫完的片段。三行都寫成完整句子並統一以句號收尾。
-    // 頭一行以前是兩個片語用 readyJoin 串起來，英文版會變成
+    // 這幾句原本擠在同一個 <p> 裡用 <br> 硬斷行。句子本身在窄螢幕會折行，兩種斷點
+    // 長得一模一樣，讀者分不出哪裡是一句話的結尾，整塊看起來像被切碎的片段。改成
+    // 真的段落，「裝置上存了什麼」與「沒有網路時開得了什麼」各成一段，中間有段距。
+    //
+    // 頭一句以前是兩個片語用 readyJoin 串起來，英文版會變成
     // 「0 pages you chose to keep、0 pages stored automatically」，改成各語系一句
     // 完整的模板之後，中文用頓號、英文用 and，不必再靠共用的分隔符。
-    status.appendChild(
-      document.createTextNode(
-        fill("countLine", { saved: state.saved.size, auto: state.precached.size })
-      )
-    );
+    const stored = [
+      fill("countLine", { saved: state.saved.size, auto: state.precached.size }),
+    ];
     // 佔用量由 SW 直接量自己的快取，見 sw.js 的 cacheUsage。可用空間仍舊問瀏覽器，
     // 那是整台裝置的配額，本來就不是這個站算得出來的，慢個幾十秒才更新也沒差。
     if (typeof state.usage === "number") {
       const est = state.estimate;
       const free =
         est && est.quota && est.quota > est.usage ? est.quota - est.usage : null;
-      status.appendChild(document.createElement("br"));
-      status.appendChild(
-        document.createTextNode(
-          free === null
-            ? fill("usage", { used: size(state.usage) })
-            : fill("usageFree", { used: size(state.usage), free: size(free) })
-        )
+      stored.push(
+        free === null
+          ? fill("usage", { used: size(state.usage) })
+          : fill("usageFree", { used: size(state.usage), free: size(free) })
       );
     }
-    // 「能不能用」直接寫出來，缺哪一塊就講哪一塊
+    // 同一段裡兩句話中間要不要空一格跟著語系走。中文不空，英文空一格。
+    status.appendChild(el("p", null, stored.join(t.sentenceJoin)));
+    // 「能不能用」自成一段，缺哪一塊就講哪一塊。跟上面的容量數字擺在一起，讀者會
+    // 把它當成同一件事的延伸，而容量健康跟打得開本來就是兩回事。
     if (state.readiness) {
       // 並列的連接符跟著語系走。中文用頓號，英文用逗號加空格。
       const names = (keys) => keys.map((key) => t[key]).join(t.readyJoin);
-      status.appendChild(document.createElement("br"));
       status.appendChild(
-        document.createTextNode(
+        el(
+          "p",
+          null,
           state.readiness.missing.length
             ? fill("readyMissing", { items: names(state.readiness.missing) })
             : fill("readyOk", { items: names(state.readiness.all) })
         )
       );
     }
-    // 版本另起一行。讀者回報離線出問題時，這是分辨「換到新版了沒」唯一看得到的地方。
+    // 版本另起一段。讀者回報離線出問題時，這是分辨「換到新版了沒」唯一看得到的地方。
     if (state.version) {
-      status.appendChild(document.createElement("br"));
-      const line = document.createElement("small");
-      line.className = "ol-version";
-      line.textContent = fill("version", { version: state.version });
+      const line = el("p");
+      line.appendChild(
+        el("small", "ol-version", fill("version", { version: state.version }))
+      );
       status.appendChild(line);
     }
     return status;

--- a/tools/test_offline_library.mjs
+++ b/tools/test_offline_library.mjs
@@ -210,6 +210,7 @@ const makeServiceWorker = (opts) => {
             autoPrecache: state.autoPrecache,
             precacheImages: state.precacheImages,
             estimate: opts.estimate || null,
+            usage: opts.usage,
             version: opts.version,
           });
         } else if (message.type === 'OFFLINE_ADD') {
@@ -912,6 +913,41 @@ test('狀態列直接回答沒有網路時能不能開啟，三個語系都有',
       `${lang} 缺首頁時應該看到「${missing}」`
     );
   }
+});
+
+test('狀態列分成真的段落，不靠 <br> 硬斷行', async () => {
+  // 原本三句擠在同一個 <p> 裡用 <br> 斷開。句子本身在窄螢幕會折行，兩種斷點長得
+  // 一模一樣，讀者分不出哪裡才是一句話的結尾，整塊讀起來像被切碎的片段。
+  // 守的是分組：頁數與容量講同一件事放一段，離線可用性另一段，版本自己一段。
+  const CSS = 'https://anoni.net/docs/stylesheets/extra.css';
+  const HERE = 'https://anoni.net/docs/offline/';
+  const HOME = 'https://anoni.net/docs/';
+  const store = {
+    precached: ['basics/'],
+    usage: 113600000,
+    estimate: { usage: 200000000, quota: 10200000000 },
+  };
+  const { root } = await load({
+    ...store,
+    stylesheets: [CSS],
+    cached: [HERE, HOME, CSS],
+    version: '202609100832',
+  });
+  const status = root.querySelector('.ol-status');
+  assert.equal(status.querySelectorAll('br').length, 0, '狀態列不該再有 <br>');
+  const paras = status.querySelectorAll('p').map((n) => n.textContent);
+  assert.equal(paras.length, 3, `該是三段，實際是：${JSON.stringify(paras)}`);
+  assert.ok(paras[0].includes('網站自動存的') && paras[0].includes('佔用'), `頁數與容量該在同一段，實際是：${paras[0]}`);
+  assert.ok(paras[1].startsWith('沒有網路時'), `離線可用性該自成一段，實際是：${paras[1]}`);
+  assert.ok(paras[2].includes('離線內容版本'), `版本該自成一段，實際是：${paras[2]}`);
+  // 同一段裡兩句之間的空白跟著語系走：中文直接相接，英文空一格
+  assert.ok(paras[0].includes('頁。本站'), `中文同段兩句之間不該有空白，實際是：${paras[0]}`);
+  const en = await load({ ...store, lang: 'en' });
+  const first = en.root.querySelector('.ol-status').querySelectorAll('p')[0].textContent;
+  assert.ok(
+    /automatically\. This site uses/.test(first),
+    `英文同段兩句之間該有一個空格，實際是：${first}`
+  );
 });
 
 test('瀏覽器沒有 Cache Storage 時不畫那一行，其餘照舊', async () => {


### PR DESCRIPTION
## 問題

「裝置上的離線內容」那一段的狀態列把三句話擠在同一個 `<p>` 裡，中間用 `<br>` 斷開：

```html
<p class="ol-status">裝置上有你自己選存的 234 頁、網站自動存的 2 頁。<br>本站在這台裝置上佔用 113.6 MB，可用空間還有 10.0 GB。<br>沒有網路時，這一頁、首頁、樣式與程式都可以開啟。<br><small class="ol-version">離線內容版本 …</small></p>
```

句子本身在窄螢幕會自己折行，`<br>` 的斷點與折行的斷點在畫面上長得一模一樣，讀者分不出哪裡才是一句話的結尾。實測手機 390 寬、裝置上存了 234 頁時，那一塊是六行等距文字，三句之間沒有任何間距。桌機 1280 也一樣，三句黏成一塊。

#506 只把三句的寫法統一成完整句子，`<br>` 那個結構留著，所以排版問題還在。

## 修法

改成三個真的段落，讓段距去分組：

- 頁數與容量講的是同一件事，合成一段
- 沒有網路時開得了什麼自成一段，那是另一個問題，容量健康跟打得開是兩回事
- 版本自己一段，維持 `<small class="ol-version">`

`renderStatus()` 回傳的節點從 `<p class="ol-status">` 換成 `<div class="ol-status">` 裝三個 `<p>`。`.ol-status` 沒有任何 CSS，換容器不影響樣式。

同一段裡兩句之間要不要空一格跟著語系走，新增 `sentenceJoin`：中文空字串，英文一個半形空格。

## 怎麼驗的

本機建置起 service worker，用 CDP 開離線頁，按「全部存到裝置」把 234 頁真的存進去，再截桌機 1280 與手機 390 兩個寬度。之前只檢查了部署的 js 內容，那看不出排版，這次是有存檔案的狀態下量出來的。

手機 390 的狀態列高度：改前 202px 六行黏在一起，改後 205px 分成兩組加版本行。

四種排法都截過圖比較（一段連續、兩段、三段各一句、清單），選的是兩段。

## 測試

`node tools/test_offline_library.mjs` 55 通過、0 失敗。新增一則守住分組與「不再有 `<br>`」，那則在改動前的程式上會紅（驗過）。

順手補了 harness 的缺口：`OFFLINE_STATUS` 的回覆原本沒有 `usage` 欄位，容量那一行從來沒有被測試涵蓋過。

`node tools/test_busy_feedback.mjs` 13 通過。`python3 tools/docs_style_lint.py` 0 error、0 warn。三語系 `run.sh` / `run_zh-cn.sh` / `run_en.sh` 都是 strict 建置通過。

## 已知、這次沒動

英文版 `1 pages` 的複數問題還在（`countLine` 的 `{saved}`／`{auto}`），跟 #506 記的一樣，等決定要在 `fill` 加複數語法或改寫文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)