### PR TITLE
refactor(nav): 小工具的分組名稱縮短

### DIFF
--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -38,7 +38,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 </div>
 
-### Passwords and keys
+### Passwords, encryption
 
 <div class="grid cards" markdown>
 

--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -24,7 +24,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 ## Available now
 
-### Decide what to protect
+### What to protect
 
 <div class="grid cards" markdown>
 
@@ -38,7 +38,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 </div>
 
-### Passwords, keys and encryption
+### Passwords and keys
 
 <div class="grid cards" markdown>
 
@@ -56,7 +56,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 </div>
 
-### Handing files over in person
+### Handing things over
 
 <div class="grid cards" markdown>
 
@@ -78,7 +78,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 </div>
 
-### Clean up before you send
+### Before you send
 
 <div class="grid cards" markdown>
 
@@ -92,7 +92,7 @@ Handle the two separately. Open the suspicious site at the higher level, copy ou
 
 </div>
 
-### Check what you receive
+### After you receive
 
 <div class="grid cards" markdown>
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -132,7 +132,7 @@ nav:
       - "要防什麼":
           - utils/threat-model.md
           - utils/checklist.md
-      - "密碼與金鑰":
+      - "密碼與加密":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,22 +129,22 @@ nav:
       #
       # 分組名稱跟索引頁的 ### 小標題是同一組字，讀者從側邊欄與從索引頁看到的分法
       # 一致，tools/test_utils_index_order.mjs 盯著這件事。
-      - "先確認要防什麼":
+      - "要防什麼":
           - utils/threat-model.md
           - utils/checklist.md
-      - "密碼、金鑰與加密":
+      - "密碼與金鑰":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md
-      - "當面把東西傳過去":
+      - "當面傳東西":
           - utils/qrcode.md
           - utils/qr-read.md
           - utils/qr-stream.md
           - utils/hash.md
-      - "送出去之前先清乾淨":
+      - "送出去之前":
           - utils/strip-metadata.md
           - utils/redact.md
-      - "收到東西之後先看清楚":
+      - "收到之後":
           - utils/clean-url.md
           - utils/invisible.md
           - utils/leaks.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -111,22 +111,22 @@ nav:
       #
       # 分组名称跟索引页的 ### 小标题是同一组字，读者从侧边栏与从索引页看到的分法
       # 一致，tools/test_utils_index_order.mjs 盯着这件事。
-      - "先确认要防什么":
+      - "要防什么":
           - utils/threat-model.md
           - utils/checklist.md
-      - "密码、密钥与加密":
+      - "密码与密钥":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md
-      - "当面把东西传过去":
+      - "当面传东西":
           - utils/qrcode.md
           - utils/qr-read.md
           - utils/qr-stream.md
           - utils/hash.md
-      - "发出去之前先清干净":
+      - "发出去之前":
           - utils/strip-metadata.md
           - utils/redact.md
-      - "收到东西之后先看清楚":
+      - "收到之后":
           - utils/clean-url.md
           - utils/invisible.md
           - utils/leaks.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -114,7 +114,7 @@ nav:
       - "要防什么":
           - utils/threat-model.md
           - utils/checklist.md
-      - "密码与密钥":
+      - "密码与加密":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -114,7 +114,7 @@ nav:
       - "What to protect":
           - utils/threat-model.md
           - utils/checklist.md
-      - "Passwords and keys":
+      - "Passwords, encryption":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -111,22 +111,22 @@ nav:
       # The group names are the same strings as the ### headings on the index
       # page, so the sidebar and the index page show the same grouping.
       # tools/test_utils_index_order.mjs watches that.
-      - "Decide what to protect":
+      - "What to protect":
           - utils/threat-model.md
           - utils/checklist.md
-      - "Passwords, keys and encryption":
+      - "Passwords and keys":
           - utils/passphrase.md
           - utils/age.md
           - utils/passkey.md
-      - "Handing files over in person":
+      - "Handing things over":
           - utils/qrcode.md
           - utils/qr-read.md
           - utils/qr-stream.md
           - utils/hash.md
-      - "Clean up before you send":
+      - "Before you send":
           - utils/strip-metadata.md
           - utils/redact.md
-      - "Check what you receive":
+      - "After you receive":
           - utils/clean-url.md
           - utils/invisible.md
           - utils/leaks.md

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -24,7 +24,7 @@ icon: material/tools
 
 ## 目前有的
 
-### 先确认要防什么
+### 要防什么
 
 <div class="grid cards" markdown>
 
@@ -38,7 +38,7 @@ icon: material/tools
 
 </div>
 
-### 密码、密钥与加密
+### 密码与密钥
 
 <div class="grid cards" markdown>
 
@@ -56,7 +56,7 @@ icon: material/tools
 
 </div>
 
-### 当面把东西传过去
+### 当面传东西
 
 <div class="grid cards" markdown>
 
@@ -78,7 +78,7 @@ icon: material/tools
 
 </div>
 
-### 发出去之前先清干净
+### 发出去之前
 
 <div class="grid cards" markdown>
 
@@ -92,7 +92,7 @@ icon: material/tools
 
 </div>
 
-### 收到东西之后先看清楚
+### 收到之后
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -38,7 +38,7 @@ icon: material/tools
 
 </div>
 
-### 密码与密钥
+### 密码与加密
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -38,7 +38,7 @@ icon: material/tools
 
 </div>
 
-### 密碼與金鑰
+### 密碼與加密
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -24,7 +24,7 @@ icon: material/tools
 
 ## 目前有的
 
-### 先確認要防什麼
+### 要防什麼
 
 <div class="grid cards" markdown>
 
@@ -38,7 +38,7 @@ icon: material/tools
 
 </div>
 
-### 密碼、金鑰與加密
+### 密碼與金鑰
 
 <div class="grid cards" markdown>
 
@@ -56,7 +56,7 @@ icon: material/tools
 
 </div>
 
-### 當面把東西傳過去
+### 當面傳東西
 
 <div class="grid cards" markdown>
 
@@ -78,7 +78,7 @@ icon: material/tools
 
 </div>
 
-### 送出去之前先清乾淨
+### 送出去之前
 
 <div class="grid cards" markdown>
 
@@ -92,7 +92,7 @@ icon: material/tools
 
 </div>
 
-### 收到東西之後先看清楚
+### 收到之後
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## 改了什麼

原本五個組名最長十個字，後兩組讀起來已經接近句子。

| 舊 | 字數 | 新 | 字數 |
|---|---|---|---|
| 先確認要防什麼 | 7 | 要防什麼 | 4 |
| 密碼、金鑰與加密 | 8 | 密碼與金鑰 | 5 |
| 當面把東西傳過去 | 8 | 當面傳東西 | 5 |
| 送出去之前先清乾淨 | 9 | 送出去之前 | 5 |
| 收到東西之後先看清楚 | 10 | 收到之後 | 4 |

三語系都縮到四到五個字。375x667 上五列全部單行，那一層從 449px 降到 308px。

## 英文那一組另外量過

`Passwords and encryption` 在抽屜寬度下量到 182px，會斷成兩行。量了幾個候選：

| 候選 | 文字寬 | 列高 |
|---|---|---|
| Passwords and encryption | 182px | 72px 換行 |
| Passwords, encryption | 161px | 48px |
| Keys and encryption | 143px | 48px |
| Passwords and keys | 146px | 48px |

取 `Passwords and keys`，留的餘裕比逗號版多。同一組的中文跟著改成「密碼與金鑰」，三語系講的是同一件事。這一組裡的本機檔案加密沒有寫進組名，它的頁面標題自己說得夠清楚。

## 錨點

索引頁的 `###` 小標題跟著改，組名與小標題必須一致由 `tools/test_utils_index_order.mjs` 守著。小標題的錨點跟著變，站上沒有任何地方連到舊錨點，grep 過三語系的 md、yml 與 html。那批錨點今天才上線，外部連結的風險可以忽略。

## 驗證

- 三語系依序 `run.sh` → `run_zh-cn.sh` → `run_en.sh` 建置通過
- headless Chrome 量 375x667 三語系：五列都是單行，合計 308px
- `docs_style_lint` 三個檔案 0 error 0 warn
- `test_utils_index_order` 六條全過