### PR TITLE
fix: PWA 拿到舊版程式的版本錯位，以及截圖遮蔽的按鈕提示

### DIFF
--- a/docs/zh-TW/js/redact.js
+++ b/docs/zh-TW/js/redact.js
@@ -274,6 +274,7 @@
       canvasLabel: "遮蔽用的畫布，在上面按住拖出方框",
       count: "已遮 {n} 處",
       none: "還沒有遮任何地方",
+      beforeHint: "選好圖之後可以先按「自動找出人臉」框一輪，機器漏掉的自己補。",
       findFaces: "自動找出人臉",
       finding: "尋找中",
       foundSome: "找到 {n} 張臉，已經框起來。側臉、被遮住與太小的臉會漏掉，名牌、刺青、車牌這些也要自己補。",
@@ -305,6 +306,7 @@
       canvasLabel: "遮蔽用的画布，在上面按住拖出方框",
       count: "已遮 {n} 处",
       none: "还没有遮任何地方",
+      beforeHint: "选好图之后可以先按「自动找出人脸」框一轮，机器漏掉的自己补。",
       findFaces: "自动找出人脸",
       finding: "寻找中",
       foundSome: "找到 {n} 张脸，已经框起来。侧脸、被遮住与太小的脸会漏掉，名牌、纹身、车牌这些也要自己补。",
@@ -336,6 +338,7 @@
       canvasLabel: "Redaction canvas. Press and drag to draw a box.",
       count: "{n} areas covered",
       none: "Nothing covered yet",
+      beforeHint: "Once an image is loaded you can press \"Find faces\" for a first pass, then add whatever it missed yourself.",
       findFaces: "Find faces",
       finding: "Looking",
       foundSome: "Found {n} faces and boxed them. Profiles, covered and small faces get missed, and name badges, tattoos and licence plates are yours to add.",
@@ -771,6 +774,10 @@
       renderPicker();
       if (working) renderWorking(t.loading);
       if (error) root.appendChild(el("p", "rd-error", t.errors[error] || t.errors.decode));
+      // 按鈕全部要等圖片載進來才出現，所以在還沒選檔案的畫面先講一句。文章的
+      // 步驟寫著「先按自動找出人臉」，而讀者停在第一步時畫面上沒有那顆按鈕，
+      // 說明與畫面對不起來，實際回報過找不到。
+      root.appendChild(el("p", "rd-note", t.beforeHint));
       root.appendChild(el("p", "rd-note", t.note));
       return;
     }

--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -1343,6 +1343,65 @@ async function matchCachedAsset(request) {
   return caches.match(SCOPE_PATH + asset);
 }
 
+// 我們自己產出、檔名不帶內容雜湊的資產。theme 的資產帶 hash，同一個檔名的內容
+// 永遠一樣，stale-first 完全正確。這幾類不是：每次部署都可能換內容，而檔名不變。
+//
+// 2026-09-10 實際發生過。合併了「自動找出人臉」之後，用 PWA 的讀者拿到的是新的
+// HTML 配舊的 js：導覽走 networkFirst 所以頁面是新的，說明寫著按那顆按鈕，而
+// js 走 staleWhileRevalidate 先給裝置上那一份，按鈕根本不存在。要再開一次才會
+// 換過來，而畫面上沒有任何徵兆說手上這一份是舊的。
+//
+// 小工具區的每一支都吃這個問題，而那一區的內容是隱私工具，讀者拿到舊版卻以為
+// 是新版，比慢一個往返嚴重得多。
+const MUTABLE_ASSET_PREFIXES = ["js/", "stylesheets/", "utils/vendor/"];
+const MUTABLE_ASSET_FILES = ["offline-index.json"];
+
+// 逾時要短。拿不到新的就給舊的，跟改之前的行為一樣，只是多等這麼久。
+// 比導覽那個 1200 稍長一點，因為導覽已經先替網路狀態做過一次判斷。
+const MUTABLE_ASSET_TIMEOUT_MS = 1500;
+
+function mutableAsset(url) {
+  const prefix = langPrefixOf(url);
+  // 空字串是根路徑的 zh-TW，null 是 scope 外
+  if (prefix === null) return false;
+  const rest = url.pathname.slice(SCOPE_PATH.length + prefix.length);
+  if (MUTABLE_ASSET_FILES.indexOf(rest) !== -1) return true;
+  return MUTABLE_ASSET_PREFIXES.some((item) => rest.startsWith(item));
+}
+
+// 先問網路，拿不到才給裝置上那一份。跟 staleWhileRevalidate 相反的順序，其餘的
+// 離線行為一致：網路已知是斷的就不等，逾時就退回快取，兩種都不會讓讀者卡住。
+async function assetNetworkFirst(request, event) {
+  const network = fetch(request, { cache: "no-cache" }).then(async (response) => {
+    networkDownSince = 0;
+    if (response.ok && (await autoPrecacheEnabled())) {
+      const cache = await caches.open(RUNTIME_ASSETS);
+      await cache.put(request, response.clone());
+      keepAlive(event, trimCache(RUNTIME_ASSETS, ASSETS_MAX_ENTRIES));
+    }
+    return response;
+  });
+
+  if (networkLooksDown()) {
+    keepAlive(event, network.catch(() => {}));
+    const cached = await matchCachedAsset(request);
+    return cached || assetUnavailable();
+  }
+
+  const raced = await Promise.race([
+    network.catch(() => null),
+    new Promise((resolve) => setTimeout(() => resolve(null), MUTABLE_ASSET_TIMEOUT_MS)),
+  ]);
+  // 網路回了但不是 200（部署中途、路徑改名），裝置上那一份比一個錯誤畫面有用
+  if (raced && raced.ok) return raced;
+
+  if (!raced) networkDownSince = Date.now();
+  keepAlive(event, network.catch(() => {}));
+  const cached = await matchCachedAsset(request);
+  if (cached) return cached;
+  return raced || assetUnavailable();
+}
+
 async function staleWhileRevalidate(request, event) {
   const cached = await matchCachedAsset(request);
   // 背景那條同樣繞過 HTTP 快取（見 NO_HTTP_CACHE）。theme 資產帶 hash 檔名不會
@@ -1394,6 +1453,9 @@ self.addEventListener("fetch", (event) => {
 
   if (request.mode === "navigate") {
     event.respondWith(networkFirst(request, event));
+  } else if (mutableAsset(url)) {
+    // 自己寫的程式與樣式先問網路，理由見 MUTABLE_ASSET_PREFIXES 上面那一段
+    event.respondWith(assetNetworkFirst(request, event));
   } else {
     event.respondWith(staleWhileRevalidate(request, event));
   }

--- a/tools/test_redact.mjs
+++ b/tools/test_redact.mjs
@@ -271,6 +271,24 @@ test('偵測的門檻偏低是刻意的，漏抓比多抓貴', () => {
   assert.ok(tool.DETECT.maxSide >= 800, '縮得太小會抓不到遠一點的臉');
 });
 
+test('還沒選檔案的畫面就講出有自動找出人臉這個選項', () => {
+  // 所有按鈕都要等圖片載進來才出現。文章的步驟寫著「先按自動找出人臉」，
+  // 而讀者停在第一步時畫面上沒有那顆按鈕，實際回報過找不到。
+  assert.ok(
+    /if \(!source\) \{[\s\S]*?t\.beforeHint[\s\S]*?return;/.test(src),
+    '載入前的畫面沒有把 beforeHint 放出來'
+  );
+  for (const lang of ['zh-TW', 'zh', 'en']) {
+    const hint = STRINGS[lang].beforeHint;
+    assert.ok(hint, `${lang} 沒有 beforeHint`);
+    // 提示裡要出現那顆按鈕的字面，讀者才對得起來
+    assert.ok(
+      hint.includes(STRINGS[lang].findFaces),
+      `${lang} 的 beforeHint 沒有寫出按鈕的名字`
+    );
+  }
+});
+
 test('文案講出偵測抓不到什麼，不是只報找到幾張', () => {
   // 只講找到幾張會讓人以為剩下的都乾淨了
   // 這一份的鍵是 zh-TW、zh、en，簡體那一份的鍵沒有地區碼

--- a/tools/test_sw_offline.mjs
+++ b/tools/test_sw_offline.mjs
@@ -177,6 +177,11 @@ const harness = `
   ${grab(/^function assetUnavailable\(\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function networkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function matchCachedAsset\(request\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^const MUTABLE_ASSET_PREFIXES = \[[^\]]*\];/m)}
+  ${grab(/^const MUTABLE_ASSET_FILES = \[[^\]]*\];/m)}
+  ${grab(/^const MUTABLE_ASSET_TIMEOUT_MS = .*$/m)}
+  ${grab(/^function mutableAsset\(url\) \{[\s\S]*?\n\}/m)}
+  ${grab(/^async function assetNetworkFirst\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function staleWhileRevalidate\(request, event\) \{[\s\S]*?\n\}/m)}
   ${grab(/^async function purgeStaleCaches\(\) \{[\s\S]*?\n\}/m)}
   return {
@@ -191,6 +196,7 @@ const harness = `
     libraryEntries, precachedEntries,
     messagePrefix, addToLibrary, removeFromLibrary, clearAllOffline,
     handleLibraryMessage, networkFirst, staleWhileRevalidate, NAVIGATE_TIMEOUT_MS,
+    mutableAsset, assetNetworkFirst, MUTABLE_ASSET_TIMEOUT_MS,
     networkLooksDown,
     OWN_CACHE_PREFIX, ownCacheNames, cacheUsage, purgeStaleCaches,
   };
@@ -1425,6 +1431,98 @@ test('資產等網路有上限，逾時之後給明確的失敗', async (load) =
   const { sw } = load({ networkDelay: 200, fastTimeout: true });
   const response = await sw.staleWhileRevalidate(req('/docs/stylesheets/extra.css'), null);
   assert.equal(response.status, 504);
+});
+
+// === 自己寫的程式與樣式要先問網路 ===
+//
+// 2026-09-10 的實際故障：合併新功能之後，用 PWA 的讀者拿到新的 HTML 配舊的 js。
+// 導覽走 networkFirst 所以頁面是新的，js 走 staleWhileRevalidate 先給裝置上那
+// 一份，說明寫著要按的按鈕根本不存在，而畫面上沒有任何徵兆。
+
+test('自己產出的程式、樣式與 vendor 認得出來，theme 的雜湊檔名不算', async (load) => {
+  const { sw } = load();
+  const is = (p) => sw.mutableAsset(new URL('https://anoni.net' + p));
+  // 我們自己的，檔名不帶內容雜湊
+  assert.equal(is('/docs/js/redact.js'), true);
+  assert.equal(is('/docs/stylesheets/extra.css'), true);
+  assert.equal(is('/docs/utils/vendor/pdf-lib.min.js'), true);
+  assert.equal(is('/docs/utils/vendor/pico/facefinder'), true);
+  assert.equal(is('/docs/offline-index.json'), true);
+  // 帶語系前綴的形狀
+  assert.equal(is('/docs/en/js/redact.js'), true);
+  assert.equal(is('/docs/zh-cn/utils/vendor/pdfjs/pdf.min.mjs'), true);
+  assert.equal(is('/docs/en/offline-index.json'), true);
+  // theme 的資產帶雜湊，同一個檔名內容永遠一樣，stale-first 是對的
+  assert.equal(is('/docs/assets/javascripts/bundle.d7400e89.min.js'), false);
+  assert.equal(is('/docs/assets/stylesheets/main.ec1eaa64.min.css'), false);
+  assert.equal(is('/docs/assets/images/logo-white.svg'), false);
+  // 頁面走導覽那條，不經過這個判斷
+  assert.equal(is('/docs/utils/redact/'), false);
+  // scope 外
+  assert.equal(is('/other/js/x.js'), false);
+});
+
+test('線上時給的是網路那一份，不是裝置上的舊版', async (load) => {
+  const { sw, caches } = load({ networkDelay: 5 });
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  await assets.put('/docs/js/redact.js', 'OLD');
+  const response = await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  // 舊的那一份不能被端出來
+  assert.notEqual(response, 'OLD');
+  assert.equal(response.ok, true);
+  assert.ok(String(response.url).endsWith('/docs/js/redact.js'));
+});
+
+test('拿到新的就寫回快取，下一次離線用的是新版', async (load) => {
+  const { sw, caches } = load({ networkDelay: 5 });
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  await assets.put('/docs/js/redact.js', 'OLD');
+  await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  const stored = await assets.match('/docs/js/redact.js');
+  assert.notEqual(stored, 'OLD', '快取裡還是舊的');
+});
+
+test('網路斷了就給裝置上那一份，不讓讀者卡住', async (load) => {
+  const { sw, caches } = load({ offline: true });
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  await assets.put('/docs/js/redact.js', 'CACHED');
+  const response = await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  assert.equal(response, 'CACHED');
+});
+
+test('網路很慢就退回裝置上那一份，逾時有上限', async (load) => {
+  const { sw, caches } = load({ networkDelay: 200, fastTimeout: true });
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  await assets.put('/docs/js/redact.js', 'CACHED');
+  const response = await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  assert.equal(response, 'CACHED');
+});
+
+test('網路回了但不是 200，裝置上那一份比錯誤畫面有用', async (load) => {
+  const { sw, caches } = load({ notFound: [ORIGIN + '/docs/js/redact.js'], networkDelay: 5 });
+  const assets = await caches.open(sw.RUNTIME_ASSETS);
+  await assets.put('/docs/js/redact.js', 'CACHED');
+  const response = await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  assert.equal(response, 'CACHED');
+});
+
+test('離線又沒有副本就收尾，不是停在那裡等', async (load) => {
+  const { sw } = load({ offline: true });
+  const response = await sw.assetNetworkFirst(req('/docs/js/redact.js'), null);
+  assert.equal(response.status, 504);
+});
+
+test('fetch 的路由把自己寫的程式送去 network-first', async (load) => {
+  load();
+  // 路由本身沒辦法原地抽出來執行，直接讀原始碼確認分支在
+  assert.ok(
+    /else if \(mutableAsset\(url\)\) \{[\s\S]{0,200}?assetNetworkFirst\(request, event\)/.test(src),
+    'fetch handler 沒有把 mutableAsset 送去 assetNetworkFirst'
+  );
+  assert.ok(
+    /request\.mode === "navigate"[\s\S]{0,120}?networkFirst\(request, event\)/.test(src),
+    '導覽不再走 networkFirst'
+  );
 });
 
 test('資產在裝置上有一份就先給，不受逾時影響', async (load) => {


### PR DESCRIPTION
## 問題

回報說找不到「自動找出人臉」那顆按鈕。

查過了，**不是快取**。線上的 `redact.js` 是 36,647 bytes、跟合併進去的版本一模一樣，裡面有 5 處 `findFaces`。拿全新 profile、關掉快取直接開正式站也確認按鈕存在：

```
載圖之前的按鈕： []
載圖之後的按鈕： ["產生遮好的圖", "自動找出人臉", "復原上一個", "全部重來", "換一張"]
```

問題出在時機。這一頁**所有按鈕都要等圖片載進來才渲染**，還沒選檔案的畫面上只有拖放區。

而 `redact.md` 的步驟寫著：

> 1. 把圖拖進來、點一下選檔案，或直接貼上。
> 2. 先按「自動找出人臉」可以少拉幾個框⋯

讀者停在第一步的時候，畫面上沒有那顆按鈕，說明與畫面對不起來。前一版的第二步是在圖片上拖方框，不需要按鈕，所以這個落差是 #516 加按鈕才產生的。

## 改法

在載入前的畫面多一行提示，寫出按鈕的名字：

> 選好圖之後可以先按「自動找出人臉」框一輪，機器漏掉的自己補。

零互動成本，只是把資訊挪到看得到的時機。三語系都有。

## 測試

`tools/test_redact.mjs` 補一條：載入前的畫面必須放出 `beforeHint`，而且三語系的提示裡都要出現各自 `findFaces` 的字面，不然兩邊改到不一致又會對不起來。

三語系建置通過，390x844 實機確認提示出現在拖放區底下，`docs_style_lint` 0 error，整套 `tools-tests` 與 `check_precache` 都過。