### PR TITLE
docs(utils): 寫明不做分享連結，並把判準寫進 CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,13 @@ uv run python ooni.py sheetrow --path=./lookback_TW_20250101_36_hours.csv
 - 語系的資料夾與對外 URL 規則不同：`docs/zh-TW/` 對應 `https://anoni.net/docs/`（預設語系不帶語系區段），`docs/zh-CN/` 對應 `/docs/zh-cn/`（URL 小寫），`docs/en/` 對應 `/docs/en/`
 - `/docs/zh-tw/` 是已停用的舊網址，由 Cloudflare Redirect Rule 301 導回 `/docs/`。它曾經是 `run_zh-tw.sh` 建出來的第二棵樹，內容與根路徑完全相同，兩邊各自 self-canonical 又各自進 sitemap，等於自製重複內容。語言選單的 zh-TW 項填 `/docs/` 就夠，不要再加回那份建置
 
+### 做小工具時
+
+- 對外的四條規則寫在 `docs/zh-TW/utils/index.md` 的前言，要改規則先改那裡，三語系一起改
+- 不做任何把資料送到伺服器的便利功能，「存起來給別人看」的分享連結也算。核心運算在瀏覽器裡完成，跟這個工具有沒有側門是兩件事，而畫面上分不出來。JSONFormatter 與 CodeBeautify 的政策寫著 `99% of our tools are doing processing on browser using Java Script`，那句話是真的，出事的是另外一顆存檔按鈕，存下來的內容預設公開且搜尋引擎索引得到。watchTowr Labs 2025 年從那裡取得八萬多份提交、超過 5 GB，涵蓋五年份的內容，裡面有資料庫密碼、雲端金鑰與企業內部帳號。兩站的政策都警告過不要存機密資料，看到的人不多
+- 判準是「斷網之後這個工具還做得完它宣稱的事嗎」，做得完才收進來。這條同時擋掉需要外部服務的功能與需要伺服器才成立的便利功能
+- 互動成本有上限。讀者要做的選擇與輸入落在個位數到十位數，超過就變成在做一套應用程式，說明留給文章。開工前先量一次
+
 ### 修改 API 時
 
 - FastAPI 使用 `root_path="/api"` 設定，所有端點需加上 `/api` 前綴

--- a/docs/en/utils/index.md
+++ b/docs/en/utils/index.md
@@ -143,3 +143,7 @@ Why each of these is not written from scratch is explained at the bottom of the 
 ## What is not here
 
 Anything that needs an external service to work stays out, because the connection itself breaks both the offline rule and the no-data rule. For network measurement use [OONI Probe](../tools/what-is-ooni.md), which is built for network measurement and documents what happens to the data.
+
+There will be no share links either. Saving a result so someone else can look at it sounds like a convenience, but it sends the content to a server while the tool itself still runs in your browser, and nothing on screen tells the two apart. JSONFormatter and CodeBeautify, two paste-and-go tool sites, work exactly like that: their policies say that 99% of their tools process data in the browser, which is true, and they also have a save button whose output is public by default and indexed by search engines. In 2025 the security team at watchTowr Labs [pulled more than 80,000 submissions and over 5 GB](https://labs.watchtowr.com/stop-putting-your-passwords-into-random-websites-yes-seriously-you-are-the-problem/){target="_blank"} out of it, spanning five years, including database passwords, cloud keys and corporate account credentials. Both policies do warn against saving confidential data there. Not many people read them.
+
+So there is no side door here for the sake of convenience. To hand a result to someone, save it yourself and send it over a channel you trust.

--- a/docs/zh-CN/utils/index.md
+++ b/docs/zh-CN/utils/index.md
@@ -141,3 +141,7 @@ icon: material/tools
 ## 没有收进来的东西
 
 需要连到外部服务才能运作的功能不会收进小工具区，因为连接本身就违反「离线可用」与「不送出数据」两条规则。网络测量请用 [OONI Probe](../tools/what-is-ooni.md)，它是设计来做网络测量的工具，数据的处理方式也公开。
+
+分享链接也不会有。把结果存起来给别人看，听起来只是方便，实际上是把内容送到服务器，而工具本体仍然在浏览器里运算，画面上看不出差别。JSONFormatter 与 CodeBeautify 这两个粘贴型工具站就是这样，政策里写着九成九的工具在浏览器里处理，那句话是真的，但同时有一颗存档按钮，存下来的内容默认公开，搜索引擎索引得到。安全团队 watchTowr Labs 在 2025 年[从那里取得八万多份提交、超过 5 GB](https://labs.watchtowr.com/stop-putting-your-passwords-into-random-websites-yes-seriously-you-are-the-problem/){target="_blank"}，涵盖五年份的内容，里面有数据库密码、云端密钥与企业内部账号。两站的政策都写着不要拿它存机密数据，看到的人不多。
+
+所以这一区的规则没有为了方便开的侧门。要把结果给别人，自己存档再用你信得过的渠道传。

--- a/docs/zh-TW/utils/index.md
+++ b/docs/zh-TW/utils/index.md
@@ -141,3 +141,7 @@ icon: material/tools
 ## 沒有收進來的東西
 
 需要連到外部服務才能運作的功能不會收進小工具區，因為連線本身就違反「離線可用」與「不送出資料」兩條規則。網路測量請用 [OONI Probe](../tools/what-is-ooni.md)，它是設計來做網路測量的工具，資料的處理方式也公開。
+
+分享連結也不會有。把結果存起來給別人看，聽起來只是方便，實際上是把內容送到伺服器，而工具本體仍然在瀏覽器裡運算，畫面上看不出差別。JSONFormatter 與 CodeBeautify 這兩個貼上型工具站就是這樣，政策裡寫著九成九的工具在瀏覽器裡處理，那句話是真的，但同時有一顆存檔按鈕，存下來的內容預設公開，搜尋引擎索引得到。資安團隊 watchTowr Labs 在 2025 年[從那裡取得八萬多份提交、超過 5 GB](https://labs.watchtowr.com/stop-putting-your-passwords-into-random-websites-yes-seriously-you-are-the-problem/){target="_blank"}，涵蓋五年份的內容，裡面有資料庫密碼、雲端金鑰與企業內部帳號。兩站的政策都寫著不要拿它存機密資料，看到的人不多。
+
+所以這一區的規則沒有為了方便開的側門。要把結果給別人，自己存檔再用你信得過的管道傳。


### PR DESCRIPTION
## 為什麼

小工具區的四條規則寫著「全部在你的瀏覽器裡運算，不送出任何資料」，但沒有寫到最容易破功的那個形式：一顆「把結果存起來給別人看」的分享鈕。

這件事有現成的教訓。JSONFormatter 與 CodeBeautify 的隱私政策自己寫著：

> We do not store any data unless user does by Save Online feature. 99% of our tools are doing processing on browser using Java Script.

那句話是真的，格式化本身確實在瀏覽器裡執行。出事的是另外一顆存檔按鈕，存下來的內容預設公開而且搜尋引擎索引得到。watchTowr Labs 在 2025 年從那裡取得 80,000+ 份提交、5GB+ 內容，涵蓋五年份的 JSONFormatter 與一年份的 CodeBeautify，裡面有 Active Directory 憑證、資料庫密碼、雲端金鑰。

兩站的政策裡都警告過：

> DO NOT SAVE SENSITIVE DATA USING THE SAVE FUNCTIONALITY.

看到的人不多。核心在瀏覽器裡執行，跟這個工具有沒有側門是兩件事，而讀者在畫面上分不出來。

## 改了什麼

**三語系的「沒有收進來的東西」**補上一段，講明分享連結不會有，以及為什麼。結尾給讀者一條可行的路：要把結果給別人，自己存檔再用信得過的管道傳。

**`CLAUDE.md` 新增「做小工具時」一節**，四條：

- 對外的四條規則寫在 `docs/zh-TW/utils/index.md` 的前言，要改先改那裡，三語系一起改
- 不做任何把資料送到伺服器的便利功能，分享連結也算
- 判準是「斷網之後這個工具還做得完它宣稱的事嗎」。這條同時擋掉需要外部服務的功能與需要伺服器才成立的便利功能
- 互動成本有上限，讀者要做的選擇與輸入落在個位數到十位數

前兩條之前只存在於口頭共識，後兩條散在各個工具的註解裡，現在寫在同一個地方。

## 來源

這些引用來自 #512 這一輪的需求調查，每一條都自己抓過原文核對，完整的核對紀錄與被剔除的引用記在[那則留言](https://github.com/anoni-net/docs/issues/512#issuecomment-5625910266)裡。

## 驗證

- 三語系用 `run.sh`、`run_zh-cn.sh`、`run_en.sh` 依序建置，exit 0，新段落三份產物都在
- 外部連結補了站上慣用的 `{target="_blank"}`，建置產物確認渲染成 `target="_blank" rel="noopener"`
- `docs_style_lint.py` 對四個檔案 0 error、0 warn。中途報過兩個 `filler-transition`（「其實」），已改掉
- `tools-tests.yml` 的 35 條指令本機全過，`check_start_parity.py`、`check_invisible_chars.mjs`、`check_precache.mjs` 都乾淨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
