### PR TITLE
fix(docs): footnote 返回連結與標題永久連結的 tooltip 補上中文

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -482,5 +482,7 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
+      permalink_title: "本節的永久連結"
       slugify: !!python/object/apply:pymdownx.slugs.slugify {}
-  - footnotes
+  - footnotes:
+      BACKLINK_TITLE: "跳回內文的第 %d 個註解"

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -458,5 +458,7 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
+      permalink_title: "本节的永久链接"
       slugify: !!python/object/apply:pymdownx.slugs.slugify {}
-  - footnotes
+  - footnotes:
+      BACKLINK_TITLE: "跳回正文的第 %d 个注解"


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

zh-TW 與 zh-CN 的 footnote 返回連結、標題永久連結，tooltip 原本是英文的 `Jump back to footnote %d in the text` 與 `Permanent link`。這兩個字串來自 Python-Markdown 的 `footnotes` 與 `toc` 擴充預設值，theme 的 `language` 設定管不到那一層，兩份 config 原本都只寫 `- footnotes` 與 `- toc: permalink: true`，沒有帶參數。補上 `BACKLINK_TITLE` 與 `permalink_title`。

相關 Issue / Related issue：無，寫 https://github.com/anoni-net/docs/pull/523 那篇文章的 footnote 時發現

## 改動範圍 / Scope

- 語系 / Language：zh-TW（`docs/mkdocs.yml`）、zh-CN（`docs/mkdocs_cn.yml`）。`mkdocs_en.yml` 維持預設，英文那組本來就該是英文
- 分類 / Category：建置設定，沒有內容改動
- 對讀者的影響 / Reader impact：兩個 tooltip 的顯示文字，連結行為與 URL 都不變

| 檔案 | 參數 | 值 |
|---|---|---|
| `docs/mkdocs.yml` | `footnotes: BACKLINK_TITLE` | 跳回內文的第 %d 個註解 |
| `docs/mkdocs.yml` | `toc: permalink_title` | 本節的永久連結 |
| `docs/mkdocs_cn.yml` | `footnotes: BACKLINK_TITLE` | 跳回正文的第 %d 个注解 |
| `docs/mkdocs_cn.yml` | `toc: permalink_title` | 本节的永久链接 |

`%d` 這個寫法擴充內部會轉成 `{}`（`markdown/extensions/footnotes.py:81`），兩種寫法都可以。

## 驗證

- `run.sh` 與 `run_zh-cn.sh` 建置各 exit 0、0 error
- zh-TW 全站產物的 `Jump back to footnote` 與 `Permanent link` 殘留計數為 0，`output/en/` 不受影響
- zh-CN 抽 `activity/gg2026` 那頁確認 tooltip 是簡中

## 還沒處理的兩處英文

同一次掃描找到另外兩處，性質不同，沒有放進這個 PR：

- `palette.toggle.name` 的 `Switch to light mode` 與 `Switch to dark mode`，三份 config 各三處。那是站自己硬寫的英文，且 `mkdocs.yml` 註解提到自訂 partial 用的是 `settings_*` 那組標籤、選項數量對不上時才退回 `toggle.name`，改動會牽到外觀設定面板的顯示邏輯
- `git-revision-date-localized` 的 `locale: en`，影響頁尾更新時間的 tooltip 格式，會套到全站每一頁，也可能當初是刻意選英文

## 自我檢查 / Self-check

只動 mkdocs 設定，沒有新增或修改文件內容，內容類的檢查項目不適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
