### PR TITLE
fix(utils): 臉部偵測搬進 worker，按下去立刻看得到在做事

### DIFF
--- a/docs/en/js/redact-worker.js
+++ b/docs/en/js/redact-worker.js
@@ -1,0 +1,1 @@
+../../zh-TW/js/redact-worker.js

--- a/docs/en/utils/redact.md
+++ b/docs/en/utils/redact.md
@@ -6,6 +6,7 @@ offline_assets:
   # The face detector's code and cascade data are loaded on demand, so the page has
   # no script tag for them. The offline copy still needs both, otherwise pressing
   # "Find faces" with the network off does nothing.
+  - js/redact-worker.js
   - utils/vendor/pico/pico.js
   - utils/vendor/pico/facefinder
 ---

--- a/docs/zh-CN/js/redact-worker.js
+++ b/docs/zh-CN/js/redact-worker.js
@@ -1,0 +1,1 @@
+../../zh-TW/js/redact-worker.js

--- a/docs/zh-CN/utils/redact.md
+++ b/docs/zh-CN/utils/redact.md
@@ -5,6 +5,7 @@ icon: material/selection-remove
 offline_assets:
   # 人脸检测用的程序与级联数据是动态加载的，页面里没有 script 标签。离线副本
   # 仍然要包含它们，不然存下这一页的人在断网时按了自动找出人脸不会有反应。
+  - js/redact-worker.js
   - utils/vendor/pico/pico.js
   - utils/vendor/pico/facefinder
 ---

--- a/docs/zh-TW/js/redact-worker.js
+++ b/docs/zh-TW/js/redact-worker.js
@@ -1,0 +1,89 @@
+/*
+ * 截圖遮蔽的臉部偵測，跑在 worker 裡。呼叫端是 docs/zh-TW/js/redact.js 的 findFaces。
+ *
+ * === 為什麼要有這一支 ===
+ *
+ * pico 的 run_cascade 是同步的，留在主執行緒上就是整頁凍住。量過一張 4032x3024
+ * 的照片（縮到工作尺寸 1920x1440），在六倍 CPU 節流下各段的耗時是
+ *
+ *   drawImage 縮圖      19ms   0.9%
+ *   getImageData        65ms   3.0%
+ *   灰階迴圈            55ms   2.6%
+ *   run_cascade       2005ms  93.4%
+ *   分群                 3ms   0.1%
+ *
+ * 掃描那一段佔了九成三，搬進 worker 之後主執行緒剩下不到 4%，轉圈會真的轉，
+ * 頁面也還捲得動。canvas 只有主執行緒碰得到，前兩段搬不走，那 84ms 可以接受。
+ *
+ * 灰階迴圈放在這裡而不是留在呼叫端，是因為傳過來的 RGBA 是可轉移的緩衝區，
+ * 轉移之後主執行緒那一份就失效了，順手在這邊轉成灰階不必多複製一次。
+ *
+ * === 不做的事 ===
+ *
+ * 只有一個 fetch，網址由相對路徑組出來，指向本站 vendor 的級聯資料。沒有第二個
+ * 參數就不可能帶 method 或 body。除了把偵測結果回傳給開啟它的頁面之外，這裡沒有
+ * 任何送出或留存資料的手段，圖片的像素不會離開這個分頁。
+ *
+ * 三個語系共用這一份，docs/en/js/ 與 docs/zh-CN/js/ 底下是指向這裡的 symlink。
+ * tools/test_redact.mjs 掃這一支的原始碼，出現任何送出或留存的手段就紅。
+ */
+"use strict";
+
+// 位置是相對於這一支自己的網址（docs 的 js/ 底下），不是相對於頁面。
+importScripts("../utils/vendor/pico/pico.js");
+
+let cascade = null;
+let loading = null;
+
+function loadCascade() {
+  if (cascade) return Promise.resolve(cascade);
+  if (!loading) {
+    loading = (async () => {
+      try {
+        const url = new URL("../utils/vendor/pico/facefinder", location.href).href;
+        const response = await fetch(url);
+        if (!response.ok) throw new Error("no cascade");
+        cascade = pico.unpack_cascade(new Uint8Array(await response.arrayBuffer()));
+        return cascade;
+      } catch (err) {
+        // 失敗就讓下一次重試，不要卡在一個永遠不會完成的 promise 上
+        loading = null;
+        return null;
+      }
+    })();
+  }
+  return loading;
+}
+
+self.onmessage = async (event) => {
+  const job = event.data || {};
+  const classify = await loadCascade();
+  if (!classify) {
+    self.postMessage({ id: job.id, ok: false });
+    return;
+  }
+  try {
+    const rgba = new Uint8ClampedArray(job.rgba);
+    const gray = new Uint8Array(job.width * job.height);
+    for (let i = 0; i < gray.length; i += 1) {
+      const at = i * 4;
+      gray[i] = (rgba[at] * 0.299 + rgba[at + 1] * 0.587 + rgba[at + 2] * 0.114) | 0;
+    }
+    const raw = pico.run_cascade(
+      { pixels: gray, nrows: job.height, ncols: job.width, ldim: job.width },
+      classify,
+      {
+        shiftfactor: job.shiftFactor,
+        minsize: job.minSize,
+        maxsize: Math.max(job.width, job.height),
+        scalefactor: job.scaleFactor,
+      }
+    );
+    const dets = pico
+      .cluster_detections(raw, job.iou)
+      .filter((det) => det[3] > job.minQuality);
+    self.postMessage({ id: job.id, ok: true, dets: dets });
+  } catch (err) {
+    self.postMessage({ id: job.id, ok: false });
+  }
+};

--- a/docs/zh-TW/js/redact.js
+++ b/docs/zh-TW/js/redact.js
@@ -32,6 +32,10 @@
  *
  * 偵測用的程式與資料按下按鈕才載入，只想手動拉框的人不會被迫下載。
  *
+ * 掃描本身跑在 worker 裡（js/redact-worker.js）。run_cascade 是同步的，留在主
+ * 執行緒上就是整頁凍住，量過一張手機拍的照片在六倍 CPU 節流下要兩秒多，而且
+ * 那段時間連轉圈都不會轉。worker 起不來就退回頁面裡做，卡幾秒比功能消失好。
+ *
  * === 不做的事 ===
  *
  * 不做全自動遮蔽，理由見上一段。不做模糊與馬賽克。不處理影片。
@@ -349,6 +353,8 @@
       beforeHint: "選好圖之後可以先按「自動找出人臉」框一輪，機器漏掉的自己補。",
       findFaces: "自動找出人臉",
       finding: "尋找中",
+      elapsed: "（{s} 秒）",
+      findingNote: "掃描整張照片，手機上通常兩到三秒，照片越大越久。這段時間頁面照常可以操作。",
       foundSome: "找到 {n} 張臉，用藍框標起來，還沒有遮住任何東西。不需要遮的點一下移掉，其餘的按「全部遮起來」。側臉、墨鏡、被遮住與太小的臉會漏掉，名牌、刺青、車牌這些也要自己補。",
       foundNone: "沒有找到正面、直立又夠大的臉。這一張要自己拉框。",
       markLeft: "還有 {n} 個藍框沒有決定。不需要遮的點一下移掉，其餘的按「全部遮起來」。",
@@ -384,6 +390,8 @@
       beforeHint: "选好图之后可以先按「自动找出人脸」框一轮，机器漏掉的自己补。",
       findFaces: "自动找出人脸",
       finding: "寻找中",
+      elapsed: "（{s} 秒）",
+      findingNote: "扫描整张照片，手机上通常两到三秒，照片越大越久。这段时间页面照常可以操作。",
       foundSome: "找到 {n} 张脸，用蓝框标起来，还没有遮住任何东西。不需要遮的点一下移掉，其余的按「全部遮起来」。侧脸、墨镜、被遮住与太小的脸会漏掉，名牌、纹身、车牌这些也要自己补。",
       foundNone: "没有找到正面、直立又够大的脸。这一张要自己拉框。",
       markLeft: "还有 {n} 个蓝框没有决定。不需要遮的点一下移掉，其余的按「全部遮起来」。",
@@ -419,6 +427,8 @@
       beforeHint: "Once an image is loaded you can press \"Find faces\" for a first pass, then add whatever it missed yourself.",
       findFaces: "Find faces",
       finding: "Looking",
+      elapsed: " ({s}s)",
+      findingNote: "Scanning the whole photo. On a phone this usually takes two to three seconds, longer for larger photos. The page stays usable meanwhile.",
       foundSome: "Found {n} faces and outlined them in blue. Nothing is covered yet. Tap any outline you do not need, then press \"Cover them all\". Profiles, dark glasses, covered and small faces get missed, and name badges, tattoos and licence plates are yours to add.",
       foundNone: "No front-facing, upright, large enough face found. Draw the boxes yourself on this one.",
       markLeft: "{n} outlines are still undecided. Tap the ones you do not need, then press \"Cover them all\".",
@@ -480,6 +490,10 @@
   // 偵測跟輸出各自有自己的忙碌狀態，兩顆按鈕的轉圈才不會互相干擾
   let detecting = false;
   let detectNote = null;
+  // 偵測開始的時間、每秒跳一次的計時器，以及按鈕上那個放秒數的文字節點
+  let detectSince = 0;
+  let detectTicker = null;
+  let elapsedNode = null;
   let canvas = null;
   let ctx = null;
   let rafPending = false;
@@ -671,15 +685,21 @@
     return picoLoading;
   }
 
-  // 把畫面上的底圖轉成 pico 要的灰階緩衝區。偵測跑在縮小過的副本上，
-  // 座標再按比例放回原尺寸。
-  function grayscaleFrom(bitmap, width, height) {
+  // 把畫面上的底圖縮到工作尺寸再取出 RGBA。canvas 只有主執行緒碰得到，這一段
+  // 搬不進 worker。量過 4032x3024 的照片縮到 1920x1440 是 84ms，佔整段不到 4%。
+  function rgbaFrom(bitmap, width, height) {
     const work = document.createElement("canvas");
     work.width = width;
     work.height = height;
     const workCtx = work.getContext("2d", { willReadFrequently: true });
     workCtx.drawImage(bitmap, 0, 0, width, height);
-    const rgba = workCtx.getImageData(0, 0, width, height).data;
+    return workCtx.getImageData(0, 0, width, height).data;
+  }
+
+  // 灰階緩衝區，pico 吃的格式。worker 那條路自己在 worker 裡轉，這一份是給
+  // 退回頁面裡做的時候用的。
+  function grayscaleFrom(bitmap, width, height) {
+    const rgba = rgbaFrom(bitmap, width, height);
     const gray = new Uint8Array(width * height);
     for (let i = 0; i < gray.length; i += 1) {
       const at = i * 4;
@@ -688,49 +708,144 @@
     return gray;
   }
 
+  // 掃描搬到 worker 裡。起不來或中途死掉就記下來不再重試，退回頁面裡做。
+  let worker = null;
+  let workerDead = false;
+  let workerJob = 0;
+
+  function startWorker() {
+    if (worker || workerDead) return worker;
+    try {
+      worker = new Worker(new URL("../../js/redact-worker.js", location.href).href);
+    } catch (err) {
+      workerDead = true;
+      worker = null;
+    }
+    return worker;
+  }
+
+  // 把縮好的 RGBA 轉移給 worker。轉移之後主執行緒那一份就失效了，退回頁面裡做
+  // 的時候會從底圖重新取一次，那只要 84ms。
+  function detectInWorker(rgba, width, height) {
+    const node = startWorker();
+    if (!node) return Promise.resolve(null);
+    const id = workerJob + 1;
+    workerJob = id;
+    return new Promise((resolve) => {
+      const finish = (value) => {
+        node.removeEventListener("message", onMessage);
+        node.removeEventListener("error", onError);
+        resolve(value);
+      };
+      const onMessage = (event) => {
+        const data = event.data || {};
+        if (data.id !== id) return;
+        finish(data.ok ? data.dets : null);
+      };
+      const onError = () => {
+        workerDead = true;
+        node.terminate();
+        worker = null;
+        finish(null);
+      };
+      node.addEventListener("message", onMessage);
+      node.addEventListener("error", onError);
+      node.postMessage(
+        {
+          id: id,
+          rgba: rgba.buffer,
+          width: width,
+          height: height,
+          shiftFactor: DETECT.shiftFactor,
+          minSize: DETECT.minSize,
+          scaleFactor: DETECT.scaleFactor,
+          iou: DETECT.iou,
+          minQuality: DETECT.minQuality,
+        },
+        [rgba.buffer]
+      );
+    });
+  }
+
+  // 退回頁面裡做的那一條。worker 起不來的時候才走這裡，會卡住幾秒。
+  async function detectInPage(plan) {
+    const classify = await loadPico();
+    if (!classify) return null;
+    const lib = picoLib();
+    try {
+      const gray = grayscaleFrom(source.bitmap, plan.width, plan.height);
+      const raw = lib.run_cascade(
+        { pixels: gray, nrows: plan.height, ncols: plan.width, ldim: plan.width },
+        classify,
+        {
+          shiftfactor: DETECT.shiftFactor,
+          minsize: DETECT.minSize,
+          maxsize: Math.max(plan.width, plan.height),
+          scalefactor: DETECT.scaleFactor,
+        }
+      );
+      return lib.cluster_detections(raw, DETECT.iou).filter((det) => det[3] > DETECT.minQuality);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  // 偵測中每秒把按鈕上的秒數換掉。不重畫整個介面，那會連底圖一起重畫，在手機
+  // 上每秒多花十幾毫秒，而且要換的只有一個文字節點。
+  function startElapsed() {
+    detectSince = Date.now();
+    stopElapsed();
+    detectTicker = setInterval(() => {
+      if (!detecting || !elapsedNode) return;
+      const secs = Math.floor((Date.now() - detectSince) / 1000);
+      elapsedNode.nodeValue = secs >= 1 ? fill(t.elapsed, { s: secs }) : "";
+    }, 1000);
+  }
+
+  function stopElapsed() {
+    if (detectTicker) clearInterval(detectTicker);
+    detectTicker = null;
+    elapsedNode = null;
+  }
+
   async function findFaces() {
     if (!source || detecting || working) return;
     detecting = true;
     detectNote = null;
     error = null;
     render();
+    // 先讓瀏覽器把「尋找中」畫出來再開始工作。少了這一步，第二次按的時候 pico
+    // 已經在記憶體裡，await 只讓出一個 microtask，整段偵測會在同一個工作裡做完，
+    // 按鈕從頭到尾沒有變過。量過六倍節流下是按下去之後 2.5 秒才有第一個畫面。
+    //
+    // 用 rAF 再接一個 timeout，不只是 setTimeout。單獨的 setTimeout 只保證換一個
+    // 工作，不保證那之間畫過一次。掃描交給 worker 之後這一步影響不大，但 worker
+    // 起不來退回頁面裡做的時候，主執行緒仍然會被擋住，那時就靠它。
+    await new Promise((next) => requestAnimationFrame(() => setTimeout(next, 0)));
+    startElapsed();
 
-    const classify = await loadPico();
-    if (!classify) {
-      detecting = false;
-      error = "detectMissing";
-      render();
-      return;
-    }
-
-    const lib = picoLib();
     const plan = detectSize(source.width, source.height, DETECT.maxSide);
-    let found = [];
+    let dets = null;
     try {
-      const gray = grayscaleFrom(source.bitmap, plan.width, plan.height);
-      const image = {
-        pixels: gray,
-        nrows: plan.height,
-        ncols: plan.width,
-        ldim: plan.width,
-      };
-      const raw = lib.run_cascade(image, classify, {
-        shiftfactor: DETECT.shiftFactor,
-        minsize: DETECT.minSize,
-        maxsize: Math.max(plan.width, plan.height),
-        scalefactor: DETECT.scaleFactor,
-      });
-      found = lib
-        .cluster_detections(raw, DETECT.iou)
-        .filter((det) => det[3] > DETECT.minQuality)
-        .map((det) => detectionToBox(det, plan.scale, source.width, source.height))
-        .filter((box) => box && !isCovered(box, boxes));
+      dets = await detectInWorker(
+        rgbaFrom(source.bitmap, plan.width, plan.height), plan.width, plan.height
+      );
     } catch (err) {
+      dets = null;
+    }
+    if (!dets) dets = await detectInPage(plan);
+    stopElapsed();
+
+    if (!dets) {
       detecting = false;
       error = "detectMissing";
       render();
       return;
     }
+
+    const found = dets
+      .map((det) => detectionToBox(det, plan.scale, source.width, source.height))
+      .filter((box) => box && !isCovered(box, boxes));
 
     // 直接指派而不是接在後面。重按一次偵測得到的是同一批，接上去會變成兩層。
     marks = found;
@@ -748,7 +863,9 @@
     working = true;
     error = null;
     render();
-    await new Promise((next) => setTimeout(next, 0));
+    // 跟 findFaces 同一個理由：單獨的 setTimeout 只保證換一個工作，不保證那之間
+    // 畫過一次，而重新編碼再解開驗證這一段是同步的。
+    await new Promise((next) => requestAnimationFrame(() => setTimeout(next, 0)));
     try {
       dragging = null;
       draw({ marks: false });
@@ -781,7 +898,9 @@
 
   function bindPointer(target) {
     target.addEventListener("pointerdown", (event) => {
-      if (!source || working) return;
+      // 偵測中不收拖曳。按鈕在那個狀態下全部停用，畫布也要一致，不然拖出來的框
+      // 會排隊等到偵測結束才處理，讀者看不出那一下有沒有算數。
+      if (!source || working || detecting) return;
       event.preventDefault();
       const p = toImagePoint(
         event.clientX, event.clientY, target.getBoundingClientRect(), target.width, target.height
@@ -925,6 +1044,15 @@
 
     root.appendChild(el("p", "rd-status", boxes.length ? fill(t.count, { n: boxes.length }) : t.none));
 
+    // 掃描要幾秒，按下去之後就講出來。轉圈只說明「在做事」，沒有說明「要多久」，
+    // 而在手機上這一段有兩三秒，不給預期的話讀者會以為當掉了。
+    if (detecting) {
+      const busy = el("p", "rd-note", t.findingNote);
+      busy.setAttribute("role", "status");
+      busy.setAttribute("aria-live", "polite");
+      root.appendChild(busy);
+    }
+
     // 偵測的結果講在狀態列底下。找到幾張、以及它抓不到什麼，兩件事要一起說，
     // 只講找到幾張會讓人以為剩下的都乾淨了。
     if (detectNote) {
@@ -971,6 +1099,9 @@
       spin.setAttribute("aria-hidden", "true");
       find.appendChild(spin);
       find.appendChild(document.createTextNode(t.finding));
+      // 秒數單獨一個文字節點，計時器每秒只換它，不重畫整個介面
+      elapsedNode = document.createTextNode("");
+      find.appendChild(elapsedNode);
       find.setAttribute("aria-busy", "true");
     }
     find.disabled = working || detecting;
@@ -998,6 +1129,7 @@
     actions.appendChild(reset);
 
     const another = button(t.another, null, () => {
+      stopElapsed();
       releaseResult();
       releaseSource();
       boxes = [];
@@ -1050,7 +1182,7 @@
 
   // Ctrl+Z 復原上一個方框。只在有圖的時候接手，焦點在輸入欄位時不搶。
   document.addEventListener("keydown", (event) => {
-    if (!source || working || !boxes.length) return;
+    if (!source || working || detecting || !boxes.length) return;
     if (!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== "z") return;
     const target = event.target;
     if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;

--- a/docs/zh-TW/utils/redact.md
+++ b/docs/zh-TW/utils/redact.md
@@ -5,6 +5,7 @@ icon: material/selection-remove
 offline_assets:
   # 臉部偵測用的程式與級聯資料是動態載入的，頁面裡沒有 script 標籤。離線副本
   # 仍然要包含它們，不然存下這一頁的人在斷網時按了自動找出人臉不會有反應。
+  - js/redact-worker.js
   - utils/vendor/pico/pico.js
   - utils/vendor/pico/facefinder
 ---

--- a/tools/check_redact_ui.mjs
+++ b/tools/check_redact_ui.mjs
@@ -24,6 +24,12 @@
  *   - 按下全部遮起來，藍色像素要歸零，留下的臉要變成純黑，被點掉的那一張不可以黑
  *   - 產生出來的結果要說 3 處，也就是點掉的那一張真的沒有被算進去
  *
+ * 最後再按一次偵測，這一次盯的是回饋本身。回報過「按下去整個介面凍住」，根因是
+ * findFaces 少了 exportImage 已經有的那一行讓出，第二次按的時候 pico 已經在記憶體
+ * 裡，await 只讓出一個 microtask，整段掃描在同一個工作裡做完，按鈕從頭到尾沒變過。
+ * 所以這裡量的是「點擊到第一個畫面」與「轉圈有沒有被畫出來」，並確認掃描真的交給
+ * 了 worker。CPU 節流開到四倍，讓這一段在快機器上也測得出來。
+ *
  * 需要建置產物（docs/output）與 .cache 裡的樣張，兩者缺一就跳過，所以沒有進 CI。
  * 改過 redact.js 的介面之後在本機跑一次。
  *
@@ -184,6 +190,17 @@ const check = (ok, label) => {
 
 check(await evaluate(`${helpers} !!cv`), '圖載進來，畫布出現');
 
+// worker 是 startWorker 建一次就留著重用的，攔截要在第一次按之前裝好
+await evaluate(`
+  window.__seen = { spinner: false, firstFrame: null, workers: [] };
+  const RealWorker = window.Worker;
+  window.Worker = function (url, opts) {
+    window.__seen.workers.push(String(url));
+    return new RealWorker(url, opts);
+  };
+  true;
+`);
+
 await evaluate(`${helpers} btn(/自動找出人臉|自动找出人脸|Find faces/).click(); true`);
 await wait(4000);
 const found = await evaluate(`${helpers} ({
@@ -246,6 +263,47 @@ const done = await evaluate(`(() => {
 })()`);
 check(done.name === 'redacted.jpg' || done.name === 'redacted.png', '輸出檔名固定，不帶原檔名');
 check(/3 處都是純黑/.test(done.text), '驗證訊息說 3 處，點掉的那一張沒有被算進去');
+
+// --- 回饋：第二次按也要立刻看得到，而且不能凍住 ---
+
+await evaluate(`${helpers}
+  btn(/全部重來|全部重来|Start over/).click(); true`);
+await wait(500);
+
+await evaluate(`
+  window.__seen.spinner = false;
+  window.__seen.firstFrame = null;
+  window.__clickAt = null;
+  const tick = () => {
+    if (window.__clickAt !== null) {
+      if (window.__seen.firstFrame === null) {
+        window.__seen.firstFrame = Math.round(performance.now() - window.__clickAt);
+      }
+      const b = [...document.querySelectorAll('#redact-tool button')]
+        .find((x) => x.querySelector('.anoni-spinner'));
+      if (b) window.__seen.spinner = true;
+    }
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+  true;
+`);
+
+await send('Emulation.setCPUThrottlingRate', { rate: 4 });
+await evaluate(`${helpers}
+  window.__clickAt = performance.now();
+  btn(/自動找出人臉|自动找出人脸|Find faces/).click(); true`);
+await wait(6000);
+await send('Emulation.setCPUThrottlingRate', { rate: 1 });
+
+const feedback = await evaluate(`window.__seen`);
+check(feedback.spinner === true, '第二次按也看得到轉圈，按下去不是沒有反應');
+const quick = feedback.firstFrame !== null && feedback.firstFrame < 500;
+check(quick, `點擊之後 ${feedback.firstFrame}ms 畫出第一個畫面${quick ? '' : '，主執行緒被擋住了'}`);
+const viaWorker = feedback.workers.some((url) => /\/js\/redact-worker\.js$/.test(url));
+check(viaWorker, viaWorker
+  ? '掃描交給了 js/redact-worker.js'
+  : `掃描沒有交給 worker（建立過的 worker：${JSON.stringify(feedback.workers)}）`);
 
 console.log(failed ? `\n${failed} 項沒過` : '\n每一步都對');
 chrome.kill();

--- a/tools/test_redact.mjs
+++ b/tools/test_redact.mjs
@@ -32,6 +32,10 @@ const SRC = path.join(HERE, '..', 'docs', 'zh-TW', 'js', 'redact.js');
 const src = fs.readFileSync(SRC, 'utf8');
 const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 
+const WORKER = path.join(HERE, '..', 'docs', 'zh-TW', 'js', 'redact-worker.js');
+const workerSrc = fs.readFileSync(WORKER, 'utf8');
+const workerCode = workerSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
 const start = src.indexOf('// --- 純邏輯');
 const end = src.indexOf('// --- 介面');
 assert.ok(start > 0 && end > start, 'redact.js 裡找不到純邏輯與介面的分界註解');
@@ -513,6 +517,122 @@ test('提示文字要講出點一下可以移掉', () => {
   assert.ok(/點一下就移掉/.test(STRINGS['zh-TW'].hint));
   assert.ok(/点一下就移掉/.test(STRINGS.zh.hint));
   assert.ok(/tap one to take it away/i.test(STRINGS.en.hint));
+});
+
+
+// ---------------------------------------------------------------------------
+// 掃描跑在 worker 裡，主執行緒不會凍住
+// ---------------------------------------------------------------------------
+
+test('按下去之後先讓瀏覽器畫一次，再開始工作', () => {
+  // 這是回報「按下去沒反應」的根因。第二次按的時候 pico 已經在記憶體裡，
+  // await 只讓出一個 microtask，整段偵測會在同一個工作裡做完，按鈕從頭到尾
+  // 沒有變過。量過六倍節流下是按下去之後 2.5 秒才有第一個畫面。
+  const fn = src.slice(src.indexOf('async function findFaces'), src.indexOf('async function exportImage'));
+  const at = fn.indexOf('render();');
+  const yieldAt = fn.indexOf('requestAnimationFrame(() => setTimeout(next, 0))');
+  assert.ok(at > 0, 'findFaces 裡沒有 render()');
+  assert.ok(yieldAt > at, 'render() 之後沒有等一次繪製，畫面來不及更新就開始算');
+  assert.ok(
+    yieldAt < fn.indexOf('detectInWorker'),
+    '讓出的位置在開始工作之後，那就沒有用'
+  );
+});
+
+test('掃描交給 worker，網址是本站的相對路徑', () => {
+  const m = code.match(/new Worker\(new URL\((['"])([^'"]+)\1, location\.href\)\.href\)/);
+  assert.ok(m, 'worker 不是用相對路徑從同源組出來的');
+  assert.equal(m[2], '../../js/redact-worker.js');
+  assert.ok(
+    fs.existsSync(WORKER),
+    'worker 檔案不存在'
+  );
+});
+
+test('worker 起不來就退回頁面裡做，功能不會消失', () => {
+  const fn = src.slice(src.indexOf('async function findFaces'), src.indexOf('async function exportImage'));
+  assert.ok(/if \(!dets\) dets = await detectInPage\(plan\);/.test(fn), '沒有退路');
+  assert.ok(code.includes('workerDead'), '起不來之後沒有記下來，會一直重試');
+  assert.ok(
+    src.includes('async function detectInPage'),
+    '退回頁面裡做的那一條不見了'
+  );
+});
+
+test('偵測中畫布不收拖曳，跟按鈕的狀態一致', () => {
+  const bind = src.slice(src.indexOf('function bindPointer'), src.indexOf('function button('));
+  assert.ok(
+    /pointerdown[\s\S]{0,400}?if \(!source \|\| working \|\| detecting\) return;/.test(bind),
+    '偵測中還收得到拖曳，那一下會排隊到偵測結束才處理'
+  );
+});
+
+test('偵測中每秒只換秒數，不重畫整個介面', () => {
+  assert.ok(code.includes('elapsedNode'), '沒有單獨的秒數節點');
+  const tick = src.slice(src.indexOf('function startElapsed'), src.indexOf('function stopElapsed'));
+  assert.ok(tick.includes('elapsedNode.nodeValue'), '計時器沒有直接換文字節點');
+  assert.ok(!/\brender\(\)/.test(tick), '計時器每秒重畫整個介面，底圖會跟著重畫');
+});
+
+test('三個語系都給了秒數與時間預期', () => {
+  for (const lang of ['zh-TW', 'zh', 'en']) {
+    assert.ok(STRINGS[lang].elapsed.includes('{s}'), `${lang} 的 elapsed 沒有帶秒數`);
+    assert.ok(STRINGS[lang].findingNote, `${lang} 少了 findingNote`);
+  }
+  // 轉圈只說明「在做事」，沒有說明「要多久」。手機上這一段有兩三秒
+  assert.ok(/兩到三秒/.test(STRINGS['zh-TW'].findingNote));
+  assert.ok(/两到三秒/.test(STRINGS.zh.findingNote));
+  assert.ok(/two to three seconds/i.test(STRINGS.en.findingNote));
+});
+
+test('worker 只從本站相對路徑載入 pico 與級聯資料', () => {
+  const imp = workerCode.match(/importScripts\((['"])([^'"]+)\1\)/);
+  assert.ok(imp, 'worker 沒有載入 pico');
+  assert.equal(imp[2], '../utils/vendor/pico/pico.js');
+  assert.ok(
+    /const url = new URL\("\.\.\/utils\/vendor\/pico\/facefinder", location\.href\)\.href;/.test(workerCode),
+    '級聯檔的網址不是用相對路徑組出來的'
+  );
+  const calls = [...workerCode.matchAll(/fetch\(([^)]*)\)/g)].map((m) => m[1].trim());
+  assert.equal(calls.length, 1, `worker 裡 fetch 出現 ${calls.length} 次，應該只有一次`);
+  assert.equal(calls[0], 'url', 'fetch 的參數不是那個組好的 url 變數');
+  assert.ok(!/https?:\/\//.test(workerCode), 'worker 原始碼裡出現絕對網址');
+});
+
+test('worker 裡沒有任何把資料送出去或留下來的手段', () => {
+  // postMessage 是它回覆開啟它的頁面用的，不算送出去。其餘一律不准。
+  for (const bad of [
+    'XMLHttpRequest', 'sendBeacon', 'WebSocket', 'EventSource',
+    'localStorage', 'sessionStorage', 'indexedDB', 'document.cookie', 'importScripts(http',
+  ]) {
+    assert.ok(!workerCode.includes(bad), `worker 裡出現 ${bad}`);
+  }
+  const posts = [...workerCode.matchAll(/postMessage\(/g)];
+  assert.ok(posts.length >= 1, 'worker 沒有回傳結果');
+  assert.ok(
+    !/self\.postMessage\([^)]*rgba/.test(workerCode),
+    'worker 把像素傳回去了，回去的應該只有座標'
+  );
+});
+
+test('三語系的離線清單都收了 worker', () => {
+  for (const [lang, dir] of [['zh-TW', 'zh-TW'], ['zh-CN', 'zh-CN'], ['en', 'en']]) {
+    const md = fs.readFileSync(
+      path.join(HERE, '..', 'docs', dir, 'utils', 'redact.md'), 'utf8'
+    );
+    assert.ok(
+      md.includes('- js/redact-worker.js'),
+      `${lang} 的 offline_assets 沒有收 worker，存下這一頁的人斷網時偵測會退回慢的那條`
+    );
+  }
+  for (const dir of ['en', 'zh-CN']) {
+    const link = path.join(HERE, '..', 'docs', dir, 'js', 'redact-worker.js');
+    assert.ok(fs.existsSync(link), `${dir}/js/redact-worker.js 不存在`);
+    assert.equal(
+      fs.readlinkSync(link), '../../zh-TW/js/redact-worker.js',
+      `${dir}/js/redact-worker.js 不是指向 zh-TW 的 symlink`
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 回報

在手機上按「自動找出人臉」感覺整個介面凍住，沒有任何辨識中的提示。

量過之後是兩個獨立的毛病，測試圖用 4032×3024（跟手機拍出來的差不多）。

## 毛病一：按下去完全沒有回饋

`exportImage` 在 `render()` 之後有一行讓出，讓瀏覽器先把畫面畫出來再開始工作。`findFaces` 沒有。

第一次按之所以看得到轉圈，是因為 `await loadPico()` 要去抓檔案，那是真的非同步，順便讓出了一次繪製。第二次按 pico 已經在記憶體裡，`await` 只讓出一個 microtask，整段偵測在同一個工作裡做完，按鈕從頭到尾沒有變過。

## 毛病二：轉圈畫出來了也是凍住的

`run_cascade` 是同步的，把主執行緒擋住 1.5 到 2.5 秒。一顆不會轉的轉圈比沒有轉圈更糟，那看起來像當掉。

拆解各段耗時（工作影像 1920×1440，六倍 CPU 節流）：

| 階段 | 耗時 | 佔比 |
|---|---|---|
| drawImage 縮圖 | 19ms | 0.9% |
| getImageData | 65ms | 3.0% |
| 灰階迴圈 | 55ms | 2.6% |
| **run_cascade** | **2005ms** | **93.4%** |
| 分群 | 3ms | 0.1% |

## 改了什麼

**掃描搬進 worker**（`docs/zh-TW/js/redact-worker.js`）。站上已經有先例，`pdfpages.js` 用了 pdf.js 的 worker，而且站上沒有設 CSP。canvas 只有主執行緒碰得到，`drawImage` 與 `getImageData` 搬不走，那 84ms 可以接受。**worker 起不來就退回頁面裡做**，卡幾秒比功能消失好。

**讓出的寫法改成 rAF 再接一個 timeout。** 單獨的 `setTimeout` 只保證換一個工作，不保證那之間畫過一次。實測把 worker 停用之後轉圈仍然不會出現，換成 rAF 之後 9ms 就畫得出來。`exportImage` 一併統一。

**回饋補三件：**偵測中每秒在按鈕上顯示經過秒數（只換一個文字節點，不重畫整個介面，重畫會連底圖一起畫），狀態列底下講出掃描大概要幾秒，以及偵測中畫布不收拖曳（原本只擋 `working` 沒擋 `detecting`，那一下會排隊到偵測結束才處理）。

## 前後對照

主執行緒最長被擋的時間，以及點擊到第一個畫面：

| CPU 節流 | 改之前（第二次按） | 改之後（第二次按） |
|---|---|---|
| 4x | 轉圈從未出現，1535ms 才有第一個畫面，最長擋 1533ms | 轉圈 98ms 出現，第一個畫面 97ms，最長擋 95ms |
| 6x | 轉圈從未出現，2527ms 才有第一個畫面，最長擋 2525ms | 轉圈 47ms 出現，第一個畫面 47ms，最長擋 93ms |

要注意一件事：**CDP 的 CPU 節流只作用在算繪主執行緒，worker 那條不受影響**，所以上表右欄的總時間偏樂觀。真實慢裝置上掃描仍然要那兩秒，改變的是那兩秒裡主執行緒是空的，轉圈會轉、頁面捲得動、點擊有反應。這才是這次要解決的問題。

## 驗證

- `tools/test_redact.mjs` 從 42 條到 51 條。新增九條，每一條都做過突變檢查（拿掉讓出、worker 改絕對網址、拿掉退路、偵測中又收拖曳、計時器改成整個重畫、英文少了秒數、worker 改從外站載 pico、worker 動用 localStorage、離線清單漏掉 worker），九種改壞的方式全部被抓到
- `tools/check_redact_ui.mjs` 補兩項：第二次按也看得到轉圈、掃描真的交給 `js/redact-worker.js`。把建置產物裡的 `startWorker` 改成永遠回 null，這一支會紅並以退出碼 1 收尾
- `tools/check_redact_detect.mjs` 五個場景的召回與多框跟改之前完全一樣，偵測品質沒有動到
- 手機尺寸截圖確認偵測中的畫面：轉圈加「尋找中」、底下那句時間預期都在
- worker 的原始碼一起被掃：只有一個 `fetch`，網址由相對路徑組出來，`importScripts` 也是相對路徑，沒有任何送出或留存資料的手段，回傳的只有座標
- 三語系的 `offline_assets` 都收了 worker，`en/js` 與 `zh-CN/js` 補了 symlink，三份 `offline-index.json` 都有它
- `tools-tests.yml` 的 35 條指令本機全過，三語系依序建置 exit 0，`docs_style_lint.py` 對五個變更檔 0 error 0 warn，`check_precache.mjs` 乾淨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
