### PR TITLE
ci(docs): apt 走 https，並讓那兩步不擋發布

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -97,15 +97,31 @@ jobs:
       #
       # mirrorlist 的路徑是 runner 映像的實作細節，未來可能改。用 if 包住，檔案不在就
       # 略過，行為退回現況而不是讓整步失敗。
+      #
+      # 2026-09-11 又卡了一次，這次換成純 http 那一側不通。mirrorlist 裡的網址是
+      # http://，而 http://archive.ubuntu.com 每個 index 檔都等到逾時才 Ign，再退回
+      # https 抓成功，一來一回三十幾秒，八個檔案就把五分鐘用完。所以連通訊協定一起
+      # 改成 https，不要再走那條會逾時的路。log 裡 packages.microsoft.com 與
+      # dl.google.com 的 https 請求本來就成功，代表 runner 映像裡 ca-certificates
+      # 已經在，apt 走 https 不缺東西。
+      #
+      # 兩步都改成不擋建置。它們存在的目的只是補一次 ca-certificates，而那個套件
+      # 本來就在映像裡。Ubuntu 的 mirror 出狀況不該讓一次發布停在這裡，內容是好的
+      # 卻上不了線，代價比這兩步沒跑到高得多。真的缺套件的話後面會在用到的地方失敗。
       - name: Update libs
         timeout-minutes: 5
+        continue-on-error: true
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then
-            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+            sudo sed -i \
+              -e 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+              -e 's|http://|https://|g' \
+              /etc/apt/apt-mirrors.txt
           fi
           sudo apt-get -o Acquire::Retries=1 -o Acquire::http::Timeout=15 update
       - name: Install ca
         timeout-minutes: 5
+        continue-on-error: true
         run: sudo apt-get -o Acquire::Retries=1 -o Acquire::http::Timeout=15 install ca-certificates
       - name: Set up Python
         timeout-minutes: 10


### PR DESCRIPTION
## 發生什麼

#525 合併後推 `docs`，BuildDocs 兩格都停在 `Update libs` 逾時。重跑整個 workflow 之後結果一樣，所以不是偶發。

log 的形狀很清楚：

```
Ign:2 http://archive.ubuntu.com/ubuntu noble InRelease
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://archive.ubuntu.com/ubuntu noble-updates InRelease
Get:3 https://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
...
##[error]The action 'Update libs' has timed out after 5 minutes.
```

每一個 index 檔都先試 `http://`，等到逾時才 `Ign`，再退回 `https://` 抓成功。一來一回三十幾秒，八個檔案就把五分鐘用完。

2026-08-19 那次卡的是 mirrorlist 第一順位的 azure 連不上，當時的處理是把 azure 換成 archive.ubuntu.com。這次換成純 http 那一側不通，同一步已經是第二次擋住發布。

## 改了什麼

**mirrorlist 的通訊協定一起換成 https**，不要再走那條會逾時的路：

```bash
sudo sed -i \
  -e 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
  -e 's|http://|https://|g' \
  /etc/apt/apt-mirrors.txt
```

同一份 log 裡 `packages.microsoft.com` 與 `dl.google.com` 的 https 請求本來就成功，代表 runner 映像裡 `ca-certificates` 已經在，apt 走 https 不缺東西。這是從 log 讀到的，不是假設。

**兩步都加上 `continue-on-error: true`。** 它們存在的目的只是補一次 `ca-certificates`，而那個套件本來就在映像裡。後面用到的東西各自有自己的來源：Python 來自 `actions/setup-python`，uv 來自 `astral-sh/setup-uv`，都不靠 apt。

Ubuntu 的 mirror 出狀況不該讓一次發布停在這裡。內容是好的卻上不了線，代價比這兩步沒跑到高得多。真的缺套件的話後面會在用到的地方失敗，那時的錯誤訊息也比「apt 逾時」有用。

## 驗證

這一份改的是 workflow 自己，只有真的推 `docs` 才驗得到。YAML 語法本機用 `yaml.safe_load` 檢查過，sed 的行為也用三種形式的輸入模擬過：

```
http://azure.archive.ubuntu.com/ubuntu/   →  https://archive.ubuntu.com/ubuntu/
http://archive.ubuntu.com/ubuntu/         →  https://archive.ubuntu.com/ubuntu/
https://archive.ubuntu.com/ubuntu/        →  https://archive.ubuntu.com/ubuntu/
```

合併後推 `docs`，#525 的內容會跟著這次一起上線。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
