### PR TITLE
fix(en): 小紅書在 en 統一用官方品牌名 rednote

### DIFF
--- a/docs/en/basics/platform-tracking.md
+++ b/docs/en/basics/platform-tracking.md
@@ -70,7 +70,7 @@ The tracking mechanics are global. What differs across Sinophone Asia-Pacific is
 
 ### Mainland Chinese platforms add a further layer
 
-WeChat, Douyin, Xiaohongshu, and Weibo differ from the global platforms above in three ways, and this applies to diaspora users of those apps too.
+WeChat, Douyin, rednote (小紅書), and Weibo differ from the global platforms above in three ways, and this applies to diaspora users of those apps too.
 
 - **The account resolves to a legal person**: accounts bind to a phone number and the number to an identity document, with the national Cyberspace ID added on top since July 2025. An ad profile that is a pseudonymous blob elsewhere is a named individual here.
 

--- a/docs/en/scenarios/mainland-speech.md
+++ b/docs/en/scenarios/mainland-speech.md
@@ -18,7 +18,7 @@ It is a companion to [speaking online from Singapore and Malaysia](./singapore-m
 
 ### Accounts and identity
 
-Accounts on major mainland platforms bind to a phone number, and the phone number binds to a national ID. That chain has existed for years. Since 2025 there is another layer: the National Online Identity Authentication Public Service took effect on 15 July 2025, built jointly by the Cyberspace Administration and the Ministry of Public Security, issuing a "network number" and "network credential" that a user presents to platforms for real-name verification, nominally on a voluntary basis[^cyberid]. Taobao and Xiaohongshu were among the platforms integrated during the initial rollout.
+Accounts on major mainland platforms bind to a phone number, and the phone number binds to a national ID. That chain has existed for years. Since 2025 there is another layer: the National Online Identity Authentication Public Service took effect on 15 July 2025, built jointly by the Cyberspace Administration and the Ministry of Public Security, issuing a "network number" and "network credential" that a user presents to platforms for real-name verification, nominally on a voluntary basis[^cyberid]. Taobao and rednote (小紅書) were among the platforms integrated during the initial rollout.
 
 For anyone publishing, this changes the assumption that a new account is a new identity. As verification consolidates into one public service, the same natural person becomes easier to join across platforms.
 


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

en 版本裡小紅書寫成拼音 `Xiaohongshu`，英文讀者不容易對應到實際的 app。改成官方對外品牌名 `rednote`，第一次提及附上中文原名。

該 app 在兩個上架通路的名稱都是 rednote：[Google Play](https://play.google.com/store/apps/details?id=com.xingin.xhs)（`com.xingin.xhs`）與 [App Store](https://apps.apple.com/us/app/id741292507)（`id741292507`）。

相關 Issue / Related issue：無，審 https://github.com/anoni-net/docs/pull/523 的 en 內容時發現，該 PR 已先修掉自己那篇

## 改動範圍 / Scope

- 語系 / Language：en only
- 分類 / Category：basics、scenarios
- 對讀者的影響 / Reader impact：兩個句子裡的一個名詞，沒有連結或 URL 變動

| 檔案 | 改動 |
|---|---|
| `docs/en/scenarios/mainland-speech.md` | `Taobao and Xiaohongshu were among...` 改為 `Taobao and rednote (小紅書) were among...` |
| `docs/en/basics/platform-tracking.md` | `WeChat, Douyin, Xiaohongshu, and Weibo` 改為 `WeChat, Douyin, rednote (小紅書), and Weibo` |

zh-TW 與 zh-CN 的對應段落維持小紅書，中文版本來就正確，沒有跟著改。掃過 `docs/en/` 全樹的 `.md` 與 `.js`，這兩處是全部的出現位置。

## 自我檢查 / Self-check

- [x] 標點符合社群規範，`docs_style_lint.py` 兩份各 0 error、0 warn
- [x] 沒有新增或改動任何連結
- [x] en strict 建置（`run_en.sh`）exit 0，產物確認兩頁都已換名、`Xiaohongshu` 殘留為 0
- [ ] 其餘內容類檢查項目不適用，只換一個名詞，沒有新增段落或檔案

## 安全核心內容 / Security-core content

- [x] 改到 `scenarios` 與 `basics` 的頁面，我了解需要維護者審核。改動只有品牌名稱本身，沒有動到任何操作建議、風險描述或 OPSEC 判斷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
